### PR TITLE
添加底部按钮显示选项

### DIFF
--- a/app/src/main/java/com/kingzcheung/kime/service/KimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/kime/service/KimeInputMethodService.kt
@@ -56,7 +56,8 @@ data class InputUIState(
     val schemaName: String = "",
     val enterKeyText: String = "发送",
     val darkMode: Int = 0,
-    val themeId: String = "ocean_blue"
+    val themeId: String = "ocean_blue",
+    val showBottomButtons: Boolean = false
 )
 
 /**
@@ -152,7 +153,8 @@ class KimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun loadDarkModePreference() {
         uiState.value = uiState.value.copy(
             darkMode = SettingsPreferences.getDarkMode(this),
-            themeId = SettingsPreferences.getKeyboardTheme(this)
+            themeId = SettingsPreferences.getKeyboardTheme(this),
+            showBottomButtons = SettingsPreferences.showBottomButtons(this)
         )
     }
     
@@ -251,7 +253,7 @@ class KimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     Surface(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(300.dp),
+                            .height(290.dp),
                         color = MaterialTheme.colorScheme.surface
                     ) {
                         KeyboardView(
@@ -263,6 +265,7 @@ class KimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             enterKeyText = state.enterKeyText,
                             isDarkTheme = isDarkTheme,
                             themeId = state.themeId,
+                            showBottomButtons = state.showBottomButtons,
                             clipboardItems = clipboardItemsState.value,
                             quickSendItems = quickSendItemsState.value,
                             candidateComments = state.candidateComments,

--- a/app/src/main/java/com/kingzcheung/kime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/kime/settings/SettingsPreferences.kt
@@ -13,6 +13,7 @@ object SettingsPreferences {
     private const val KEY_VIBRATION_ENABLED = "vibration_enabled"
     private const val KEY_VIBRATION_INTENSITY = "vibration_intensity"
     private const val KEY_KEYBOARD_THEME = "keyboard_theme"
+    private const val KEY_SHOW_BOTTOM_BUTTONS = "show_bottom_buttons"
     
     private fun getPrefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -72,5 +73,13 @@ object SettingsPreferences {
     
     fun setKeyboardTheme(context: Context, themeId: String) {
         getPrefs(context).edit().putString(KEY_KEYBOARD_THEME, themeId).apply()
+    }
+    
+    fun showBottomButtons(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_SHOW_BOTTOM_BUTTONS, false)
+    }
+    
+    fun setShowBottomButtons(context: Context, show: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_SHOW_BOTTOM_BUTTONS, show).apply()
     }
 }

--- a/app/src/main/java/com/kingzcheung/kime/ui/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/kime/ui/KeyboardLayout.kt
@@ -57,6 +57,7 @@ fun KeyboardLayout(
     keyBackgroundColor: Color,
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
+    showBottomButtons: Boolean = false,
     onHideKeyboard: (() -> Unit)? = null,
     onSwitchKeyboard: (() -> Unit)? = null,
     modifier: Modifier = Modifier
@@ -246,30 +247,32 @@ fun KeyboardLayout(
                 )
             }
             
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                IconButton(
-                    onClick = { onHideKeyboard?.invoke() }
+            if (showBottomButtons) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowDown,
-                        contentDescription = "收起键盘",
-                        tint = keyTextColor,
-                        modifier = Modifier.size(32.dp)
-                    )
-                }
-                
-                IconButton(
-                    onClick = { onSwitchKeyboard?.invoke() }
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Keyboard,
-                        contentDescription = "切换键盘",
-                        tint = keyTextColor,
-                        modifier = Modifier.size(24.dp)
-                    )
+                    IconButton(
+                        onClick = { onHideKeyboard?.invoke() }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = "收起键盘",
+                            tint = keyTextColor,
+                            modifier = Modifier.size(32.dp)
+                        )
+                    }
+                    
+                    IconButton(
+                        onClick = { onSwitchKeyboard?.invoke() }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Keyboard,
+                            contentDescription = "切换键盘",
+                            tint = keyTextColor,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/kime/ui/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/kime/ui/KeyboardView.kt
@@ -35,6 +35,7 @@ fun KeyboardView(
     enterKeyText: String = "发送",
     isDarkTheme: Boolean = false,
     themeId: String = "ocean_blue",
+    showBottomButtons: Boolean = false,
     clipboardItems: List<ClipboardItem> = emptyList(),
     quickSendItems: List<ClipboardItem> = emptyList(),
     onKeyPress: (String, Boolean) -> Unit,
@@ -210,6 +211,7 @@ CandidateBar(
                                 keyBackgroundColor = keyBgColor,
                                 keyTextColor = keyTextColor,
                                 specialKeyBackgroundColor = specialKeyBgColor,
+                                showBottomButtons = showBottomButtons,
                                 onHideKeyboard = onHideKeyboard,
                                 onSwitchKeyboard = onSwitchKeyboard
                             )

--- a/app/src/main/java/com/kingzcheung/kime/ui/SettingsComponents.kt
+++ b/app/src/main/java/com/kingzcheung/kime/ui/SettingsComponents.kt
@@ -95,6 +95,51 @@ fun SettingsItem(
 }
 
 @Composable
+fun SettingsToggleItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.primary,
+                checkedTrackColor = MaterialTheme.colorScheme.primaryContainer
+            )
+        )
+    }
+}
+
+@Composable
 fun SchemaItem(
     schema: SchemaInfo,
     isSelected: Boolean,

--- a/app/src/main/java/com/kingzcheung/kime/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/kime/ui/SettingsScreen.kt
@@ -160,8 +160,10 @@ fun SettingsMainContent(
                 })
             }
             
-            item {
+item {
                 SettingsSection(title = "功能设置", content = {
+                    var showBottomButtons by remember { mutableStateOf(SettingsPreferences.showBottomButtons(context)) }
+                    
                     SettingsItem(
                         icon = Icons.Outlined.KeyboardAlt,
                         title = "输入方案",
@@ -198,6 +200,21 @@ fun SettingsMainContent(
                         thickness = 0.5.dp,
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                     )
+                    SettingsToggleItem(
+                        icon = Icons.Outlined.Visibility,
+                        title = "显示底部按钮",
+                        subtitle = "显示收回键盘和切换输入法按钮（部分系统自带）",
+                        checked = showBottomButtons,
+                        onCheckedChange = { newValue ->
+                            showBottomButtons = newValue
+                            SettingsPreferences.setShowBottomButtons(context, newValue)
+                        }
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(start = 56.dp),
+                        thickness = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
                     SettingsItem(
                         icon = Icons.Outlined.Mic,
                         title = "语言转文字",
@@ -210,7 +227,7 @@ fun SettingsMainContent(
                         thickness = 0.5.dp,
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                     )
-SettingsItem(
+                    SettingsItem(
                         icon = Icons.Outlined.Book,
                         title = "词库管理",
                         subtitle = "管理用户词库",


### PR DESCRIPTION
feat(keyboard): 添加底部按钮显示选项

- 在InputUIState中添加showBottomButtons属性，默认值为false
- 在SettingsPreferences中添加KEY_SHOW_BOTTOM_BUTTONS常量及相关getter/setter方法
- 调整键盘高度从300dp改为290dp以适应新布局
- 修改KeyboardLayout和KeyboardView组件支持showBottomButtons参数
- 在候选栏区域条件渲染底部按钮（收起键盘和切换键盘按钮）
- 在设置界面添加"显示底部按钮"开关项，用户可控制是否显示底部按钮
- 底部按钮包括收起键盘箭头图标和切换输入法键盘图标
```