### PR TITLE
feat(theme): 添加深色模式跟随系统功能

### DIFF
--- a/app/src/androidTest/java/com/kingzcheung/xime/settings/SettingsPreferencesTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/settings/SettingsPreferencesTest.kt
@@ -32,11 +32,11 @@ class SettingsPreferencesTest {
 
     @Test
     fun `dark mode persists integer setting`() {
-        assertEquals(0, SettingsPreferences.getDarkMode(context))
-
-        SettingsPreferences.setDarkMode(context, 2)
-
         assertEquals(2, SettingsPreferences.getDarkMode(context))
+
+        SettingsPreferences.setDarkMode(context, 0)
+
+        assertEquals(0, SettingsPreferences.getDarkMode(context))
     }
 
     @Test

--- a/app/src/main/java/com/kingzcheung/xime/MainActivity.kt
+++ b/app/src/main/java/com/kingzcheung/xime/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -95,7 +96,13 @@ class MainActivity : ComponentActivity() {
             var darkMode by remember { mutableIntStateOf(SettingsPreferences.getDarkMode(context)) }
             var keyboardTheme by remember { mutableStateOf(SettingsPreferences.getKeyboardTheme(context)) }
             
-            XimeTheme(darkTheme = darkMode == 1, themeId = keyboardTheme) {
+            val isDarkTheme = when (darkMode) {
+                2 -> isSystemInDarkTheme() // 跟随系统
+                1 -> true                    // 强制深色
+                else -> false                // 强制浅色
+            }
+
+            XimeTheme(darkTheme = isDarkTheme, themeId = keyboardTheme) {
                 // 同步状态栏外观与应用主题，而非系统主题
                 val view = LocalView.current
                 if (!view.isInEditMode) {
@@ -103,7 +110,7 @@ class MainActivity : ComponentActivity() {
                         val window = (view.context as? ComponentActivity)?.window
                         if (window != null) {
                             val controller = WindowInsetsControllerCompat(window, view)
-                            controller.isAppearanceLightStatusBars = darkMode == 0
+                            controller.isAppearanceLightStatusBars = !isDarkTheme
                         }
                         onDispose { }
                     }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -66,6 +66,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         private const val TAG = "XimeInputMethodService"
         private const val DARK_MODE_LIGHT = 0
         private const val DARK_MODE_DARK = 1
+        private const val DARK_MODE_SYSTEM = 2
     }
 
     private val lifecycleRegistry = LifecycleRegistry(this)
@@ -147,12 +148,27 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
     
     fun toggleDarkMode() {
-        val newMode = if (uiState.value.darkMode == DARK_MODE_LIGHT) DARK_MODE_DARK else DARK_MODE_LIGHT
+        val currentMode = uiState.value.darkMode
+        val newMode = when (currentMode) {
+            DARK_MODE_LIGHT -> DARK_MODE_DARK
+            DARK_MODE_DARK -> DARK_MODE_LIGHT
+            else -> { // DARK_MODE_SYSTEM: 切换到当前系统主题的反面
+                if (isDarkTheme()) DARK_MODE_LIGHT else DARK_MODE_DARK
+            }
+        }
         saveDarkModePreference(newMode)
     }
     
     fun isDarkTheme(): Boolean {
-        return uiState.value.darkMode == DARK_MODE_DARK
+        return when (uiState.value.darkMode) {
+            DARK_MODE_DARK -> true
+            DARK_MODE_SYSTEM -> {
+                val nightModeFlags = resources.configuration.uiMode and
+                        android.content.res.Configuration.UI_MODE_NIGHT_MASK
+                nightModeFlags == android.content.res.Configuration.UI_MODE_NIGHT_YES
+            }
+            else -> false
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -81,7 +81,8 @@ object SettingsPreferences {
     }
     
     fun getDarkMode(context: Context): Int {
-        return getPrefs(context).getInt(KEY_DARK_MODE, 0)
+        // 0 = 浅色, 1 = 深色, 2 = 跟随系统（默认）
+        return getPrefs(context).getInt(KEY_DARK_MODE, 2)
     }
     
     fun setDarkMode(context: Context, mode: Int) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/SettingsComponents.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/SettingsComponents.kt
@@ -354,7 +354,8 @@ fun ThemeCard(
     isSelected: Boolean,
     isDark: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isSystem: Boolean = false
 ) {
     val backgroundColor = if (isDark) Color(0xFF202124) else Color(0xFFE8EAED)
     val keyColor = if (isDark) Color(0xFF35363A) else Color(0xFFFFFFFF)
@@ -390,56 +391,144 @@ fun ThemeCard(
                     .fillMaxSize()
                     .padding(8.dp)
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(backgroundColor)
-                        .padding(4.dp)
-                ) {
-                    Column(
-                        modifier = Modifier.fillMaxSize()
+                if (isSystem) {
+                    // 跟随系统: 左半浅色 + 右半深色
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .clip(RoundedCornerShape(6.dp))
                     ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(12.dp)
-                                .clip(RoundedCornerShape(3.dp))
-                                .background(candidateBarColor)
-                                .padding(horizontal = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
+                        Row(modifier = Modifier.fillMaxSize()) {
+                            // 左半浅色
                             Box(
                                 modifier = Modifier
-                                    .width(16.dp)
-                                    .height(6.dp)
-                                    .clip(RoundedCornerShape(2.dp))
-                                    .background(if (isDark) Color(0xFF8AB4F8) else Color(0xFF1A73E8))
-                            )
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .clip(RoundedCornerShape(topStart = 6.dp, bottomStart = 6.dp))
+                                    .background(Color(0xFFE8EAED))
+                                    .padding(3.dp)
+                            ) {
+                                Column(modifier = Modifier.fillMaxSize()) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(8.dp)
+                                            .clip(RoundedCornerShape(2.dp))
+                                            .background(Color(0xFFF8F9FA))
+                                            .padding(horizontal = 3.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Box(
+                                            modifier = Modifier
+                                                .width(12.dp)
+                                                .height(4.dp)
+                                                .clip(RoundedCornerShape(1.dp))
+                                                .background(Color(0xFF1A73E8))
+                                        )
+                                    }
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .weight(1f)
+                                            .clip(RoundedCornerShape(2.dp))
+                                            .background(Color.White)
+                                    )
+                                }
+                            }
+                            Spacer(modifier = Modifier.width(1.dp))
+                            // 右半深色
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .clip(RoundedCornerShape(topEnd = 6.dp, bottomEnd = 6.dp))
+                                    .background(Color(0xFF202124))
+                                    .padding(3.dp)
+                            ) {
+                                Column(modifier = Modifier.fillMaxSize()) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(8.dp)
+                                            .clip(RoundedCornerShape(2.dp))
+                                            .background(Color(0xFF2D2D2D))
+                                            .padding(horizontal = 3.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Box(
+                                            modifier = Modifier
+                                                .width(12.dp)
+                                                .height(4.dp)
+                                                .clip(RoundedCornerShape(1.dp))
+                                                .background(Color(0xFF8AB4F8))
+                                        )
+                                    }
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .weight(1f)
+                                            .clip(RoundedCornerShape(2.dp))
+                                            .background(Color(0xFF35363A))
+                                    )
+                                }
+                            }
                         }
-                        
-                        Spacer(modifier = Modifier.height(4.dp))
-                        
-                        repeat(3) { rowIndex ->
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(backgroundColor)
+                            .padding(4.dp)
+                    ) {
+                        Column(
+                            modifier = Modifier.fillMaxSize()
+                        ) {
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .weight(1f)
-                                    .padding(vertical = 1.dp),
-                                horizontalArrangement = Arrangement.spacedBy(2.dp)
+                                    .height(12.dp)
+                                    .clip(RoundedCornerShape(3.dp))
+                                    .background(candidateBarColor)
+                                    .padding(horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                val keysInRow = if (rowIndex == 2) 4 else 10
-                                repeat(keysInRow) { keyIndex ->
-                                    val isSpecialKey = (rowIndex == 0 && keyIndex == 0) ||
-                                            (rowIndex == 2 && (keyIndex == 0 || keyIndex == 3))
-                                    Box(
-                                        modifier = Modifier
-                                            .weight(if (isSpecialKey) 1.5f else 1f)
-                                            .fillMaxHeight()
-                                            .clip(RoundedCornerShape(3.dp))
-                                            .background(if (isSpecialKey) specialKeyColor else keyColor)
-                                    )
+                                Box(
+                                    modifier = Modifier
+                                        .width(16.dp)
+                                        .height(6.dp)
+                                        .clip(RoundedCornerShape(2.dp))
+                                        .background(if (isDark) Color(0xFF8AB4F8) else Color(0xFF1A73E8))
+                                )
+                            }
+                            
+                            Spacer(modifier = Modifier.height(4.dp))
+                            
+                            repeat(3) { rowIndex ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .weight(1f)
+                                        .padding(vertical = 1.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                                ) {
+                                    val keysInRow = if (rowIndex == 2) 4 else 10
+                                    repeat(keysInRow) { keyIndex ->
+                                        val isSpecialKey = (rowIndex == 0 && keyIndex == 0) ||
+                                                (rowIndex == 2 && (keyIndex == 0 || keyIndex == 3))
+                                        Box(
+                                            modifier = Modifier
+                                                .weight(if (isSpecialKey) 1.5f else 1f)
+                                                .fillMaxHeight()
+                                                .clip(RoundedCornerShape(3.dp))
+                                                .background(if (isSpecialKey) specialKeyColor else keyColor)
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -459,15 +548,6 @@ fun ThemeCard(
                         fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                         color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
                     )
-                    if (isSelected) {
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
                 }
             }
         }
@@ -581,26 +661,27 @@ fun KeyboardThemeCard(
                 ) {
                     Box(
                         modifier = Modifier
-                            .size(12.dp)
+                            .size(14.dp)
                             .clip(RoundedCornerShape(2.dp))
                             .background(specialKeyColor)
+                            .padding(end = 4.dp)
                     )
-                    Spacer(modifier = Modifier.width(6.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = theme.name,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                         color = if (isSelected) accentColor else MaterialTheme.colorScheme.onSurface
                     )
-                    if (isSelected) {
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            contentDescription = null,
-                            tint = accentColor,
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
+//                    if (isSelected) {
+//                        Spacer(modifier = Modifier.width(4.dp))
+//                        Icon(
+//                            imageVector = Icons.Default.Check,
+//                            contentDescription = null,
+//                            tint = accentColor,
+//                            modifier = Modifier.size(16.dp)
+//                        )
+//                    }
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ThemeSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ThemeSettingsScreen.kt
@@ -84,8 +84,19 @@ fun ThemeSettingsContent(
             item {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
+                    ThemeCard(
+                        title = "跟随系统",
+                        isSelected = uiState.darkMode == 2,
+                        isDark = false,
+                        isSystem = true,
+                        onClick = {
+                            viewModel.setDarkMode(2)
+                            onThemeChanged()
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
                     ThemeCard(
                         title = "浅色",
                         isSelected = uiState.darkMode == 0,


### PR DESCRIPTION
- 新增 DARK_MODE_SYSTEM 常量（值为2）用于表示跟随系统主题
- 实现根据系统主题自动切换深色/浅色模式的功能
- 在 MainActivity 中添加 isSystemInDarkTheme 导入并更新主题判断逻辑
- 修改状态栏外观控制逻辑以适配新的主题模式
- 更新测试用例中的预期值以匹配新的默认行为（从0改为2）
- 在设置界面中添加"跟随系统"主题卡片选项
- 优化 ThemeCard 组件以支持显示系统主题预览样式
- 移除选中状态的复选标记图标以简化UI