### PR TITLE
refactor(settings): 移除无用的导入并简化颜色配置

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -60,7 +59,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
@@ -102,7 +100,7 @@ fun SchemaSettingsContent(
             onDismissRequest = {
                 showImportWarning = false
             },
-            containerColor = if (isSystemInDarkTheme()) MaterialTheme.colorScheme.surface else Color.White,
+            containerColor = MaterialTheme.colorScheme.surface,
             title = {
                 Text("导入方案须知", fontWeight = FontWeight.SemiBold)
             },
@@ -170,7 +168,7 @@ fun SchemaSettingsContent(
             onDismissRequest = {
                 if (!uiState.isDownloading) { showUrlDialog = false; urlInput = "" }
             },
-            containerColor = if (isSystemInDarkTheme()) MaterialTheme.colorScheme.surface else Color.White,
+            containerColor = MaterialTheme.colorScheme.surface,
             title = {
                 Text("网络导入", fontWeight = FontWeight.SemiBold)
             },


### PR DESCRIPTION
移除了未使用的 isSystemInDarkTheme 和 Color 导入，
统一使用 MaterialTheme.colorScheme.surface 颜色，
避免手动判断深色主题模式

fix(librime): 更新子项目提交哈希值