### PR TITLE
fix(XimeInputMethodService): 修复语音模式切换时UI更新问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1285,6 +1285,10 @@ onVoiceModeChange = { enabled ->
                         isShowingRecentClipboard = false
                     )
                 }
+            } else {
+                withContext(Dispatchers.Main) {
+                    updateUI()
+                }
             }
         }
     }


### PR DESCRIPTION
当语音模式切换后，在适当的时候更新UI界面，确保用户界面状态与实际状态保持一致。

同时更新了librime子模块到最新状态。