### PR TITLE
docs(plugins): 移除恶搞兔表情包截图

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -22,8 +22,6 @@
 
 **说明：** 恶搞兔表情包，从 APK assets 加载表情图片
 
-![Meme Bunny](/Screenshot/MemeBunny.jpg)
-
 **下载：** [APK](https://github.com/ximeiorg/Xime/releases) | **源码：** [GitHub](https://github.com/ximeiorg/Xime/tree/main/plugins/meme-bunny)
 
 ---


### PR DESCRIPTION
移除 docs/plugins/index.md 中的恶搞兔表情包预览图片，
保持文档简洁性并减少不必要的资源引用。