### PR TITLE
fix(XimeInputMethodService): 修复带有 IME_FLAG_NO_ENTER_ACTION 的输入框中回车键行为

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1097,12 +1097,19 @@ onVoiceModeChange = { enabled ->
                         withContext(Dispatchers.Main) {
                             val imeOptions = currentInputEditorInfo?.imeOptions ?: 0
                             val action = imeOptions and EditorInfo.IME_MASK_ACTION
-                            when (action) {
-                                EditorInfo.IME_ACTION_GO,
-                                EditorInfo.IME_ACTION_SEARCH,
-                                EditorInfo.IME_ACTION_SEND,
-                                EditorInfo.IME_ACTION_NEXT,
-                                EditorInfo.IME_ACTION_DONE -> {
+                            val noEnterAction = imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION != 0
+                            when {
+                                // 如果设置了 IME_FLAG_NO_ENTER_ACTION，必须插入换行符
+                                // 不能走 performEditorAction，否则某些应用收到 Done/Send 等
+                                // 动作后会收起键盘，但按键标签显示的是"换行"
+                                noEnterAction -> {
+                                    sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
+                                }
+                                action == EditorInfo.IME_ACTION_GO ||
+                                action == EditorInfo.IME_ACTION_SEARCH ||
+                                action == EditorInfo.IME_ACTION_SEND ||
+                                action == EditorInfo.IME_ACTION_NEXT ||
+                                action == EditorInfo.IME_ACTION_DONE -> {
                                     currentInputConnection?.performEditorAction(action)
                                 }
                                 else -> {


### PR DESCRIPTION
当输入框设置了 IME_FLAG_NO_ENTER_ACTION 标志时，必须插入换行符而不是执行编辑器动作， 避免某些应用在接收到 Done/Send 等动作后收起键盘但按键标签显示为"换行"的问题

- 添加对 IME_FLAG_NO_ENTER_ACTION 标志的检测
- 当存在该标志时，直接发送 KEYCODE_ENTER 事件插入换行符
- 修改条件判断逻辑以正确处理各种输入法动作