### PR TITLE
feat(theme): 强制设置字体缩放为1.0倍

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/theme/Theme.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/theme/Theme.kt
@@ -5,8 +5,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import com.kingzcheung.xime.settings.SettingsPreferences
 
 // ========== 统一主题系统 ==========
@@ -59,8 +62,15 @@ fun XimeTheme(
         outlineVariant = Color(0xFF49454F)
     )
 
-    MaterialTheme(
-        colorScheme = if (darkTheme) darkScheme else lightScheme,
-        content = content
-    )
+    CompositionLocalProvider(
+        LocalDensity provides Density(
+            density = LocalDensity.current.density,
+            fontScale = 1.0f
+        )
+    ) {
+        MaterialTheme(
+            colorScheme = if (darkTheme) darkScheme else lightScheme,
+            content = content
+        )
+    }
 }


### PR DESCRIPTION
在主题系统中添加CompositionLocalProvider来统一管理密度配置，
强制将字体缩放(fontScale)设置为1.0倍，确保UI在不同设备上的一致性。

同时更新了librime子模块的引用状态。