### PR TITLE
style(ui): 统一语音转文字设置界面的颜色样式

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/speech/sherpa/SherpaAsrEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/sherpa/SherpaAsrEngine.kt
@@ -64,6 +64,9 @@ class SherpaAsrEngine(private val context: Context) {
     private val accumulatedText = StringBuilder()
     private var lastPartialText = ""
     
+    /** 当前已加载到 recognizer 中的模型 ID，用于检测模型切换 */
+    private var loadedModelId: String? = null
+    
     fun isAvailable(): Boolean {
         return try {
             System.loadLibrary("sherpa-onnx-jni")
@@ -83,14 +86,17 @@ class SherpaAsrEngine(private val context: Context) {
     }
     
     fun getSelectedModelDir(): File {
-        val sharedPrefs = context.getSharedPreferences("sherpa_asr", Context.MODE_PRIVATE)
-        val modelId = sharedPrefs.getString("selected_model", "zipformer-zh-int8") ?: "zipformer-zh-int8"
+        val modelId = getSelectedModelId()
         return File(context.filesDir, "asr_models/$modelId")
     }
 
-    fun getSelectedModelInfo(): AsrModelInfo? {
+    fun getSelectedModelId(): String {
         val sharedPrefs = context.getSharedPreferences("sherpa_asr", Context.MODE_PRIVATE)
-        val modelId = sharedPrefs.getString("selected_model", "zipformer-zh-int8") ?: "zipformer-zh-int8"
+        return sharedPrefs.getString("selected_model", "zipformer-zh-int8") ?: "zipformer-zh-int8"
+    }
+
+    fun getSelectedModelInfo(): AsrModelInfo? {
+        val modelId = getSelectedModelId()
         return AVAILABLE_MODELS.find { it.id == modelId }
     }
     
@@ -210,10 +216,22 @@ class SherpaAsrEngine(private val context: Context) {
     }
     
     fun startRecognition(): Boolean {
+        val currentModelId = getSelectedModelId()
+        
+        // 如果用户切换了模型，释放旧的 recognizer，重新加载新模型
+        if (recognizer != null && currentModelId != loadedModelId) {
+            Log.d(TAG, "Model changed from $loadedModelId to $currentModelId, reinitializing")
+            recognizer?.release()
+            recognizer = null
+            loadedModelId = null
+        }
+        
         if (recognizer == null) {
             if (!initialize()) {
+                loadedModelId = null
                 return false
             }
+            loadedModelId = currentModelId
         }
         
         stream = recognizer?.createStream()
@@ -311,6 +329,7 @@ class SherpaAsrEngine(private val context: Context) {
         cancelRecognition()
         recognizer?.release()
         recognizer = null
+        loadedModelId = null
         coroutineScope.cancel()
         Log.d(TAG, "SherpaAsrEngine released")
     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/SpeechToTextSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/SpeechToTextSettingsScreen.kt
@@ -202,7 +202,7 @@ fun EngineSelectorComposable() {
             .padding(horizontal = 16.dp),
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            containerColor = MaterialTheme.colorScheme.surface
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
@@ -382,7 +382,7 @@ fun LocalAsrTab() {
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(12.dp),
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    containerColor = MaterialTheme.colorScheme.surface
                 )
             ) {
                 Row(
@@ -438,7 +438,7 @@ fun KeepModelInRamToggle() {
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Row(
@@ -499,10 +499,7 @@ fun PunctuationModelSection() {
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(16.dp),
             colors = CardDefaults.cardColors(
-                containerColor = if (isDownloaded && isEnabled)
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f)
-                else
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                containerColor = MaterialTheme.colorScheme.surface
             )
         ) {
             Column(
@@ -761,7 +758,7 @@ fun PunctuationModelSection() {
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp),
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                containerColor = MaterialTheme.colorScheme.surface
             )
         ) {
             Row(
@@ -800,9 +797,9 @@ fun ModelCard(
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(
             containerColor = if (isSelected)
-                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f)
+                MaterialTheme.colorScheme.primaryContainer
             else
-                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                MaterialTheme.colorScheme.surface
         )
     ) {
         Column(
@@ -1055,7 +1052,7 @@ fun AsrProviderCardModern(
         shape = RoundedCornerShape(16.dp),
         onClick = { if (enabled) onClick() },
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            containerColor = MaterialTheme.colorScheme.surface
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {


### PR DESCRIPTION
- 新增 loadedModelId 变量用于跟踪当前加载的模型ID
- 重构 getSelectedModelId 方法提取公共逻辑
- 实现模型切换时自动重新初始化识别器功能
- 在适当时机清理 loadedModelId 状态
- 更新 librime 子模块状态

将多个卡片组件的背景色从半透明的 surfaceVariant
改为统一的 surface 颜色，提升界面视觉一致性。
同时为选中的模型卡片使用 primaryContainer 颜色以示区分。

- 统一 EngineSelectorComposable 卡片颜色
- 统一 LocalAsrTab 卡片颜色
- 统一 KeepModelInRamToggle 卡片颜色
- 简化 PunctuationModelSection 的条件颜色逻辑
- 调整 ModelCard 的选中状态颜色
- 统一 AsrProviderCardModern 卡片颜色