### PR TITLE
fix(keyboard): 修复表情选择时调用错误的回调函数

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
@@ -555,7 +555,7 @@ fun KeyboardView(
                         if (emoji == "delete") {
                             onKeyPress("delete", false)
                         } else {
-                            onClipboardSelect?.invoke(emoji)
+                            onCommitText?.invoke(emoji)
                         }
                     },
                     onImageEmojiSelect = onCommitImage,


### PR DESCRIPTION
将表情选择的回调从 onClipboardSelect 改为 onCommitText，
确保表情能够正确提交到输入框中。

同时更新了 librime 子项目的提交版本。