### PR TITLE
feat(rime): 添加 Lua 翻译器支持并优化部署检测机制

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,8 @@
 1. 更新 PROGRESS.md
 2. 跑 `./gradlew assembleDebug --quiet` 确认一致状态
 3. 提交所有已完成的工作
+
+## Jetpack Compose
+For all Compose/Android UI tasks, follow the instructions in
+`.skills/compose-expert/SKILL.md` and consult the reference
+files in `.skills/compose-expert/references/` before answering.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 30
-        versionName = "2.4.0-beta2"
+        versionCode = 31
+        versionName = "2.4.0-beta3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -6,12 +6,7 @@
 # Keep Kotlin stdlib classes used by plugins via parent classloader
 # Plugins use compileOnly(plugin-core), so Kotlin stdlib resolves from host app.
 # R8 strips unused stdlib methods — these rules ensure plugins can call them.
--keep class kotlin.jvm.internal.** { *; }
--keep class kotlin.collections.** { *; }
--keep class kotlin.text.** { *; }
--keep class kotlin.comparisons.** { *; }
--keep class kotlin.ranges.** { *; }
--keep class kotlin.sequences.** { *; }
+-keep class kotlin.** { *; }
 
 -keep class com.kingzcheung.xime.plugin.** { *; }
 -keepclassmembers class com.kingzcheung.xime.plugin.** { *; }

--- a/app/src/main/assets/rime/lua/README.md
+++ b/app/src/main/assets/rime/lua/README.md
@@ -1,0 +1,3 @@
+see:
+https://github.com/iDvel/rime-ice/blob/82c0298031254299cf1265dad4ae7dd54013fdb7/lua/date_translator.lua
+https://github.com/iDvel/rime-ice/blob/82c0298031254299cf1265dad4ae7dd54013fdb7/lua/uuid.lua

--- a/app/src/main/assets/rime/lua/uuid.lua
+++ b/app/src/main/assets/rime/lua/uuid.lua
@@ -1,0 +1,46 @@
+local function yield_cand(seg, text)
+	local cand = Candidate("", seg.start, seg._end, text, "")
+	cand.quality = 100
+	yield(cand)
+end
+
+local fmt = string.format
+local rand = math.random
+local randomseed = math.randomseed
+
+local function generate_uuid_v4()
+	return fmt(
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		((rand(0, 255) % 16) + 64),
+		rand(0, 255),
+		((rand(0, 255) % 64) + 128),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255),
+		rand(0, 255)
+	)
+end
+
+local M = {}
+
+function M.init(env)
+	randomseed(math.floor(os.time() + os.clock() * 1000))
+	M.uuid = env.engine.schema.config:get_string(env.name_space:gsub("^*", "")) or "uuid"
+end
+
+function M.func(input, seg, _)
+	if input == M.uuid then
+		yield_cand(seg, generate_uuid_v4())
+	end
+end
+
+return M

--- a/app/src/main/assets/rime/pinyin_simp.schema.yaml
+++ b/app/src/main/assets/rime/pinyin_simp.schema.yaml
@@ -41,6 +41,8 @@ engine:
     - punct_translator
     - script_translator
     - reverse_lookup_translator
+    - lua_translator@*uuid
+    - lua_translator@*date_translator
 
 speller:
   alphabet: zyxwvutsrqponmlkjihgfedcba

--- a/app/src/main/assets/rime/wubi86.schema.yaml
+++ b/app/src/main/assets/rime/wubi86.schema.yaml
@@ -36,6 +36,7 @@ engine:
   translators:
     - punct_translator
     - table_translator
+    - lua_translator@*uuid
   filters:
     - uniquifier
 

--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -99,7 +99,16 @@ keyboard:
     key_text_color_dark: 0xE8EAED
     candidate_text_color: 0x202124
     candidate_text_color_dark: 0xE8EAED
- 
+  
+  # ── 按键阴影配置（可选，不设置则使用默认值）──
+  # enabled:            是否启用阴影（true/false）
+  # elevation:          阴影高度（dp，默认 1）
+  # shape_radius:       阴影圆角半径（dp，默认 8）
+  shadow:
+    enabled: true
+    elevation: 1
+    shape_radius: 8
+  
   keys:
     # ── 第一行 ──
     # long_press 顺序：小写 → 大写 → 带变音符号的相似字母

--- a/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
+++ b/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
@@ -79,6 +79,7 @@ class XimeApplication : Application() {
                     Log.d(TAG, "First launch: silently deploying schemas...")
                     engine.deploy()
                     SettingsPreferences.setDeploymentDone(this@XimeApplication, true)
+                    RimeConfigHelper.storeDeploymentHash(this@XimeApplication)
                     Log.d(TAG, "Silent deploy completed")
                 }
 

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
+import com.kingzcheung.xime.settings.SettingsPreferences
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import java.io.File
@@ -64,6 +65,14 @@ object RimeConfigHelper {
         return Pair(rimeDir.absolutePath, rimeDir.absolutePath)
     }
     
+    fun storeDeploymentHash(context: Context) {
+        val hash = computeDeploymentHash(context)
+        if (hash.isNotEmpty()) {
+            SettingsPreferences.setDeploymentHash(context, hash)
+            Log.d(TAG, "Deployment hash stored: $hash")
+        }
+    }
+
     fun isDeploymentComplete(context: Context): Boolean {
         val rimeDir = File(context.filesDir, "rime")
         val buildDir = File(rimeDir, "build")
@@ -72,37 +81,50 @@ object RimeConfigHelper {
         val enabledSchemas = SchemaManager.getEnabledSchemas(context)
         if (enabledSchemas.isEmpty()) return false
 
-        // 获取 build 目录中最早的编译产物时间戳
-        var buildTimestamp = Long.MAX_VALUE
         for (schemaId in enabledSchemas) {
-            val prismFile = File(buildDir, "$schemaId.prism.bin")
-            val schemaFile = File(buildDir, "$schemaId.schema.yaml")
-            if (prismFile.exists()) {
-                buildTimestamp = minOf(buildTimestamp, prismFile.lastModified())
-                continue
-            }
-            if (schemaFile.exists()) {
-                buildTimestamp = minOf(buildTimestamp, schemaFile.lastModified())
-                continue
-            }
-            return false  // 缺少编译产物，需要部署
-        }
-
-        // 检查源 schema 文件是否比编译产物更新（APK 升级后 schema 可能已变更）
-        for (schemaId in enabledSchemas) {
-            val sourceSchema = File(rimeDir, "$schemaId.schema.yaml")
-            if (sourceSchema.exists() && sourceSchema.lastModified() > buildTimestamp) {
-                Log.d(TAG, "Schema $schemaId has been updated since last deployment, re-deploy needed")
+            if (!File(buildDir, "$schemaId.prism.bin").exists() &&
+                !File(buildDir, "$schemaId.schema.yaml").exists()) {
                 return false
             }
         }
-        val defaultYaml = File(rimeDir, "default.yaml")
-        if (defaultYaml.exists() && defaultYaml.lastModified() > buildTimestamp) {
-            Log.d(TAG, "default.yaml has been updated since last deployment, re-deploy needed")
+
+        val currentHash = computeDeploymentHash(context)
+        if (currentHash.isEmpty()) return false
+
+        val storedHash = SettingsPreferences.getDeploymentHash(context)
+        if (storedHash.isEmpty()) {
+            SettingsPreferences.setDeploymentHash(context, currentHash)
+            return true
+        }
+
+        if (currentHash != storedHash) {
+            Log.d(TAG, "Schema files changed, re-deploy needed")
             return false
         }
 
         return true
+    }
+
+    private fun computeDeploymentHash(context: Context): String {
+        val rimeDir = File(context.filesDir, "rime")
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+
+        val enabledSchemas = SchemaManager.getEnabledSchemas(context)
+        for (schemaId in enabledSchemas.sorted()) {
+            val schemaFile = File(rimeDir, "$schemaId.schema.yaml")
+            if (schemaFile.exists()) {
+                digest.update(schemaId.toByteArray())
+                digest.update(schemaFile.readBytes())
+            }
+        }
+
+        val defaultYaml = File(rimeDir, "default.yaml")
+        if (defaultYaml.exists()) {
+            digest.update("default".toByteArray())
+            digest.update(defaultYaml.readBytes())
+        }
+
+        return digest.digest().joinToString("") { String.format("%02x", it) }
     }
 
     private fun checkAndCleanBuildDir(rimeDir: File) {
@@ -173,8 +195,20 @@ object RimeConfigHelper {
                         copiedAny = true
                     }
                 } else if (fileName.endsWith(".yaml") || fileName.endsWith(".lua")) {
-                    copyAssetFile(context, fullAssetPath, targetFile)
-                    copiedAny = true
+                    val needsCopy = try {
+                        if (targetFile.exists()) {
+                            val fd = context.assets.openFd(fullAssetPath)
+                            val sameSize = targetFile.length() == fd.length
+                            fd.close()
+                            !sameSize
+                        } else true
+                    } catch (_: Exception) {
+                        true
+                    }
+                    if (needsCopy) {
+                        copyAssetFile(context, fullAssetPath, targetFile)
+                        copiedAny = true
+                    }
                 }
             } catch (e: IOException) {
                 Log.e(TAG, "Failed to process: $fullAssetPath", e)

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -25,7 +25,6 @@ object RimeConfigHelper {
         }
         
         copyAssetsToRimeDir(context, rimeDir)
-        stripLuaTranslatorFromSchemas(rimeDir)
         // F1: assets 会用内置 default.yaml 覆盖，这里把启用方案重新写回 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
         
@@ -66,20 +65,43 @@ object RimeConfigHelper {
     }
     
     fun isDeploymentComplete(context: Context): Boolean {
-        val buildDir = File(File(context.filesDir, "rime"), "build")
+        val rimeDir = File(context.filesDir, "rime")
+        val buildDir = File(rimeDir, "build")
         if (!buildDir.exists()) return false
 
         val enabledSchemas = SchemaManager.getEnabledSchemas(context)
         if (enabledSchemas.isEmpty()) return false
 
+        // 获取 build 目录中最早的编译产物时间戳
+        var buildTimestamp = Long.MAX_VALUE
         for (schemaId in enabledSchemas) {
-            // 优先检查 prism.bin（每个独立方案都会生成）
-            if (File(buildDir, "$schemaId.prism.bin").exists()) continue
-            // 没有 prism.bin 可能是共享词典的多翻译器方案（如 wubi86_pinyin），
-            // 检查 schema.yaml 是否已部署到 build 目录即可
-            if (File(buildDir, "$schemaId.schema.yaml").exists()) continue
+            val prismFile = File(buildDir, "$schemaId.prism.bin")
+            val schemaFile = File(buildDir, "$schemaId.schema.yaml")
+            if (prismFile.exists()) {
+                buildTimestamp = minOf(buildTimestamp, prismFile.lastModified())
+                continue
+            }
+            if (schemaFile.exists()) {
+                buildTimestamp = minOf(buildTimestamp, schemaFile.lastModified())
+                continue
+            }
+            return false  // 缺少编译产物，需要部署
+        }
+
+        // 检查源 schema 文件是否比编译产物更新（APK 升级后 schema 可能已变更）
+        for (schemaId in enabledSchemas) {
+            val sourceSchema = File(rimeDir, "$schemaId.schema.yaml")
+            if (sourceSchema.exists() && sourceSchema.lastModified() > buildTimestamp) {
+                Log.d(TAG, "Schema $schemaId has been updated since last deployment, re-deploy needed")
+                return false
+            }
+        }
+        val defaultYaml = File(rimeDir, "default.yaml")
+        if (defaultYaml.exists() && defaultYaml.lastModified() > buildTimestamp) {
+            Log.d(TAG, "default.yaml has been updated since last deployment, re-deploy needed")
             return false
         }
+
         return true
     }
 
@@ -150,7 +172,7 @@ object RimeConfigHelper {
                     if (copyAssetsRecursively(context, fullAssetPath, targetFile)) {
                         copiedAny = true
                     }
-                } else if (fileName.endsWith(".yaml")) {
+                } else if (fileName.endsWith(".yaml") || fileName.endsWith(".lua")) {
                     copyAssetFile(context, fullAssetPath, targetFile)
                     copiedAny = true
                 }
@@ -170,33 +192,13 @@ object RimeConfigHelper {
 
             targetFile.parentFile?.mkdirs()
             context.assets.open(assetPath).use { input ->
-                val text = input.bufferedReader().readText()
-                val cleaned = if (targetFile.name.endsWith(".schema.yaml")) {
-                    text.lines().filter { !it.trimStart().startsWith("- lua_translator") }.joinToString("\n")
-                } else text
                 FileOutputStream(targetFile).use { output ->
-                    output.write(cleaned.toByteArray())
+                    input.copyTo(output)
                 }
             }
             Log.d(TAG, "Copied: $assetPath -> ${targetFile.absolutePath}")
         } catch (e: IOException) {
             Log.e(TAG, "Failed to copy: $assetPath", e)
-        }
-    }
-
-    private fun stripLuaTranslatorFromSchemas(rimeDir: File) {
-        val schemaFiles = rimeDir.listFiles { f -> f.name.endsWith(".schema.yaml") } ?: return
-        for (file in schemaFiles) {
-            try {
-                val lines = file.readLines()
-                val filtered = lines.filter { !it.trimStart().startsWith("- lua_translator") }
-                if (filtered.size != lines.size) {
-                    file.writeText(filtered.joinToString("\n"))
-                    Log.d(TAG, "Stripped lua_translator from ${file.name}")
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to process ${file.name}", e)
-            }
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -7,6 +7,39 @@ data class RimeCandidate(
     val comment: String
 )
 
+data class RimeProcessResult(
+    val processed: Boolean,
+    val committedText: String,
+    val inputText: String,
+    val candidates: Array<RimeCandidate>,
+    val isAsciiMode: Boolean,
+    val hasNextPage: Boolean,
+    val hasPrevPage: Boolean
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RimeProcessResult) return false
+        return processed == other.processed &&
+                committedText == other.committedText &&
+                inputText == other.inputText &&
+                candidates.contentEquals(other.candidates) &&
+                isAsciiMode == other.isAsciiMode &&
+                hasNextPage == other.hasNextPage &&
+                hasPrevPage == other.hasPrevPage
+    }
+
+    override fun hashCode(): Int {
+        var result = processed.hashCode()
+        result = 31 * result + committedText.hashCode()
+        result = 31 * result + inputText.hashCode()
+        result = 31 * result + candidates.contentHashCode()
+        result = 31 * result + isAsciiMode.hashCode()
+        result = 31 * result + hasNextPage.hashCode()
+        result = 31 * result + hasPrevPage.hashCode()
+        return result
+    }
+}
+
 class RimeEngine {
 
     companion object {
@@ -131,6 +164,13 @@ class RimeEngine {
         return nativeProcessKey(keycode, mask)
     }
 
+    fun processKeyAndGetResult(keycode: Int, mask: Int): RimeProcessResult {
+        if (!isInitialized) return RimeProcessResult(false, "", "", emptyArray(), false, false, false)
+        if (!nativeHasSession() && !nativeCreateSession())
+            return RimeProcessResult(false, "", "", emptyArray(), false, false, false)
+        return nativeProcessKeyAndGetResult(keycode, mask)
+    }
+
     fun getCandidates(): Array<String> {
         if (!nativeHasSession()) return emptyArray()
         return nativeGetCandidates() ?: emptyArray()
@@ -233,6 +273,7 @@ class RimeEngine {
     private external fun nativeIsMaintaining(): Boolean
     private external fun nativeGetCurrentSchema(): String?
     private external fun nativeProcessKey(keycode: Int, mask: Int): Boolean
+    private external fun nativeProcessKeyAndGetResult(keycode: Int, mask: Int): RimeProcessResult
     private external fun nativeGetCandidates(): Array<String>?
     private external fun nativeGetCandidatesWithComments(): Array<Array<String>>?
     private external fun nativeGetInput(): String?

--- a/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
@@ -134,7 +134,7 @@ class PredictionManager(
                     }
                 }
                 
-                val candidates = AssociationManager.predict(contextText, 20)
+                val candidates = AssociationManager.predict(contextText, MAX_ASSOCIATION_COUNT)
                 
                 Log.d(TAG, "Prediction candidates: ${candidates.map { it.text }}")
                 

--- a/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
@@ -21,6 +21,7 @@ class PredictionManager(
     companion object {
         private const val TAG = "PredictionManager"
         private const val MAX_CONTEXT_LENGTH = 25
+        const val MAX_ASSOCIATION_COUNT = 20
     }
     
     private var _lastCommittedText = ""
@@ -161,7 +162,7 @@ class PredictionManager(
         }
     }
     
-    suspend fun getEnglishAssociations(text: String, limit: Int = 5): Array<String> {
+    suspend fun getEnglishAssociations(text: String, limit: Int = MAX_ASSOCIATION_COUNT): Array<String> {
         return try {
             AssociationService.getAssociations(context, text, true, limit).toTypedArray()
         } catch (e: Exception) {
@@ -170,7 +171,7 @@ class PredictionManager(
         }
     }
     
-    suspend fun getChineseAssociations(text: String, limit: Int = 5): Array<String> {
+    suspend fun getChineseAssociations(text: String, limit: Int = MAX_ASSOCIATION_COUNT): Array<String> {
         return try {
             if (!AssociationManager.isInitialized()) {
                 Log.d(TAG, "AssociationManager not initialized, initializing...")

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1141,7 +1141,7 @@ onVoiceModeChange = { enabled ->
         
         if (pendingEnglish.isNotEmpty()) {
             serviceScope.launch {
-                val candidates = predictionManager.getEnglishAssociations(pendingEnglish, 5)
+                val candidates = predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                 Log.d(TAG, "English association for pending '$pendingEnglish': ${candidates.joinToString()}")
                 withContext(Dispatchers.Main) {
                     uiState.value = uiState.value.copy(associationCandidates = candidates)
@@ -1179,7 +1179,7 @@ onVoiceModeChange = { enabled ->
         
         if (pendingEnglish.isNotEmpty()) {
             serviceScope.launch {
-                val candidates = predictionManager.getEnglishAssociations(pendingEnglish, 5)
+                val candidates = predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)
                 Log.d(TAG, "English association for pending '$pendingEnglish': ${candidates.joinToString()}")
                 withContext(Dispatchers.Main) {
                     uiState.value = uiState.value.copy(associationCandidates = candidates)
@@ -1257,7 +1257,7 @@ onVoiceModeChange = { enabled ->
                         Log.d(TAG, "Delete committed text, remaining: '${predictionManager.lastCommittedText}'")
                         
                         if (!state.isAsciiMode && isChineseMode && SettingsPreferences.isSmartPredictionEnabled(this@XimeInputMethodService) && predictionManager.lastCommittedText.isNotEmpty()) {
-                            val candidates = predictionManager.getChineseAssociations(predictionManager.lastCommittedText, 20)
+                            val candidates = predictionManager.getChineseAssociations(predictionManager.lastCommittedText, PredictionManager.MAX_ASSOCIATION_COUNT)
                             uiState.value = uiState.value.copy(associationCandidates = candidates)
                         } else {
                             uiState.value = uiState.value.copy(

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -349,6 +349,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     // 确保部署成功后才标记完成，避免首次部署超时后误标记
                     if (needsDeployment) {
                         SettingsPreferences.setDeploymentDone(this@XimeInputMethodService, true)
+                        RimeConfigHelper.storeDeploymentHash(this@XimeInputMethodService)
                     }
                 } else {
                     Log.w(TAG, "initRimeEngine: Session not ready after 60s, continuing in background")

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1147,6 +1147,44 @@ onVoiceModeChange = { enabled ->
         }
     }
 
+    private fun updateUIWithResult(result: com.kingzcheung.xime.rime.RimeProcessResult) {
+        val isAsciiMode = result.isAsciiMode
+        val candidatesWithComments = result.candidates
+        
+        val pendingEnglish = uiState.value.pendingEnglishText
+        
+        val (filteredTexts, filteredComments) = if (isAsciiMode) {
+            val filtered = candidatesWithComments.filterNot { candidate ->
+                candidate.text.any { it.code in 0x4E00..0x9FFF }
+            }
+            filtered.map { it.text }.toTypedArray() to filtered.map { it.comment }.toTypedArray()
+        } else {
+            candidatesWithComments.map { it.text }.toTypedArray() to candidatesWithComments.map { it.comment }.toTypedArray()
+        }
+        
+        uiState.value = uiState.value.copy(
+            inputText = result.inputText,
+            candidates = filteredTexts,
+            candidateComments = filteredComments,
+            isComposing = result.inputText.isNotEmpty(),
+            isAsciiMode = isAsciiMode,
+            associationCandidates = if (isAsciiMode && pendingEnglish.isEmpty()) emptyArray() else uiState.value.associationCandidates,
+            isShowingRecentClipboard = false,
+            hasNextPage = result.hasNextPage,
+            hasPrevPage = result.hasPrevPage
+        )
+        
+        if (pendingEnglish.isNotEmpty()) {
+            serviceScope.launch {
+                val candidates = predictionManager.getEnglishAssociations(pendingEnglish, 5)
+                Log.d(TAG, "English association for pending '$pendingEnglish': ${candidates.joinToString()}")
+                withContext(Dispatchers.Main) {
+                    uiState.value = uiState.value.copy(associationCandidates = candidates)
+                }
+            }
+        }
+    }
+
     private fun updateSchemaName() {
         serviceScope.launch(Dispatchers.IO) {
             val context = this@XimeInputMethodService
@@ -1183,6 +1221,7 @@ onVoiceModeChange = { enabled ->
         serviceScope.launch(keyProcessingDispatcher) {
             val state = uiState.value
             var needsUIUpdate = false
+            var pendingResult: com.kingzcheung.xime.rime.RimeProcessResult? = null
             
             when (key) {
                 "delete" -> {
@@ -1204,14 +1243,11 @@ onVoiceModeChange = { enabled ->
                         needsUIUpdate = true
                         Log.d(TAG, "Delete English pending: '$newPending'")
                     } else if (state.isComposing || state.inputText.isNotEmpty()) {
-                        rimeEngine.processKey(0xff08, 0)
-                        
-                        val currentInput = rimeEngine.getInput()
-                        if (currentInput.isEmpty()) {
+                        val result = rimeEngine.processKeyAndGetResult(0xff08, 0)
+                        if (result.inputText.isEmpty()) {
                             rimeEngine.clearComposition()
-                            Log.d(TAG, "Delete: encoding cleared, cleared composition and candidates")
                         }
-                        
+                        pendingResult = result
                         needsUIUpdate = true
                     } else {
                         predictionManager.deleteLastChar()
@@ -1441,15 +1477,15 @@ onVoiceModeChange = { enabled ->
                         val keyCode = key.lowercase()[0].code
                         val mask = if (isShifted) KeyEvent.META_SHIFT_ON else 0
                         
-                        val processed = rimeEngine.processKey(keyCode, mask)
+                        val result = rimeEngine.processKeyAndGetResult(keyCode, mask)
                         
-                        if (processed) {
+                        if (result.processed) {
                             needsUIUpdate = true
+                            pendingResult = result
                             
-                            val committedText = rimeEngine.commit()
-                            if (committedText.isNotEmpty()) {
+                            if (result.committedText.isNotEmpty()) {
                                 withContext(Dispatchers.Main) {
-                                    commitText(committedText)
+                                    commitText(result.committedText)
                                 }
                                 needsUIUpdate = true
                             }
@@ -1483,8 +1519,13 @@ onVoiceModeChange = { enabled ->
             }
             
             if (needsUIUpdate) {
+                val result = pendingResult
                 withContext(Dispatchers.Main) {
-                    updateUI()
+                    if (result != null) {
+                        updateUIWithResult(result)
+                    } else {
+                        updateUI()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -728,9 +728,12 @@ onVoiceModeChange = { enabled ->
                                    SettingsPreferences.setToolbarButtons(this@XimeInputMethodService, buttons)
                                    uiState.value = uiState.value.copy(toolbarButtons = buttons)
                                },
-                               onKeyboardModeChange = { chineseMode ->
-                                   isChineseMode = chineseMode
-                               }
+                                onKeyboardModeChange = { chineseMode ->
+                                    isChineseMode = chineseMode
+                                    if (!chineseMode) {
+                                        uiState.value = uiState.value.copy(associationCandidates = emptyArray())
+                                    }
+                                }
                                 )
                          }
                      }
@@ -1128,7 +1131,7 @@ onVoiceModeChange = { enabled ->
             candidateComments = filteredComments,
             isComposing = inputText.isNotEmpty(),
             isAsciiMode = isAsciiMode,
-            associationCandidates = if (isAsciiMode && pendingEnglish.isEmpty()) emptyArray() else uiState.value.associationCandidates,
+            associationCandidates = if ((isAsciiMode || !isChineseMode) && pendingEnglish.isEmpty()) emptyArray() else uiState.value.associationCandidates,
             isShowingRecentClipboard = false,
             hasNextPage = hasNextPage,
             hasPrevPage = hasPrevPage
@@ -1168,7 +1171,7 @@ onVoiceModeChange = { enabled ->
             candidateComments = filteredComments,
             isComposing = result.inputText.isNotEmpty(),
             isAsciiMode = isAsciiMode,
-            associationCandidates = if (isAsciiMode && pendingEnglish.isEmpty()) emptyArray() else uiState.value.associationCandidates,
+            associationCandidates = if ((isAsciiMode || !isChineseMode) && pendingEnglish.isEmpty()) emptyArray() else uiState.value.associationCandidates,
             isShowingRecentClipboard = false,
             hasNextPage = result.hasNextPage,
             hasPrevPage = result.hasPrevPage

--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -44,6 +44,15 @@ data class KeyboardConfig(
 )
 
 /**
+ * 键盘阴影配置，从 xime.yaml keyboard.shadow 加载。
+ */
+data class KeyboardShadowConfig(
+    val enabled: Boolean = true,
+    val elevation: Int = 1,
+    val shapeRadius: Int = 8,
+)
+
+/**
  * 键盘颜色配置，从 xime.yaml keyboard.colors 加载。
  * 所有颜色值为 0xRRGGBB 格式（不含 alpha）。
  */
@@ -225,6 +234,9 @@ object KeysConfigHelper {
     // 键盘颜色配置缓存
     private var keyboardColorsConfig: KeyboardColorsConfig = KeyboardColorsConfig()
     
+    // 键盘阴影配置缓存
+    private var keyboardShadowConfig: KeyboardShadowConfig = KeyboardShadowConfig()
+    
     /** 配置版本号，每次 loadConfig 时递增，用于 Compose 感知配置变更。 */
     private val _configVersion = MutableStateFlow(0)
     val configVersion: StateFlow<Int> = _configVersion.asStateFlow()
@@ -247,6 +259,8 @@ object KeysConfigHelper {
             keyGestureConfig = parseKeyboardFromAssets(context) ?: emptyMap()
             // 键盘颜色（从原始 YAML 手动解析）
             keyboardColorsConfig = parseKeyboardColorsFromAssets(context)
+            // 键盘阴影（从原始 YAML 手动解析）
+            keyboardShadowConfig = parseKeyboardShadowFromAssets(context)
             _configVersion.value++
             Log.d(TAG, "Loaded config: ${keyGestureConfig.size} keys (v${_configVersion.value})")
         } catch (e: Exception) {
@@ -326,6 +340,36 @@ object KeysConfigHelper {
             candidateTextColor = candTxt,
             candidateTextColorDark = candTxtDark,
         )
+    }
+
+    /** 从 xime.yaml + xime.custom.yaml 合并解析键盘阴影配置。 */
+    private fun parseKeyboardShadowFromAssets(context: Context): KeyboardShadowConfig {
+        val defaultText = readAssetText(context, XIME_CONFIG_FILE) ?: return KeyboardShadowConfig()
+        val default = parseKeyboardShadowYamlText(defaultText) ?: return KeyboardShadowConfig()
+        val customText = readUserDataText(context, XIME_CUSTOM_CONFIG_FILE)
+            ?: readAssetText(context, XIME_CUSTOM_CONFIG_FILE) ?: return default
+        val custom = parseKeyboardShadowYamlText(customText)
+        return custom ?: default
+    }
+
+    /** 从 YAML 文本中提取 keyboard.shadow 段。 */
+    private fun parseKeyboardShadowYamlText(yamlText: String): KeyboardShadowConfig? {
+        val root = yaml.parseToYamlNode(yamlText) as? YamlMap ?: return null
+        val keyboardNode = root["keyboard"] as? YamlMap ?: return null
+        val shadowNode = keyboardNode["shadow"] as? YamlMap ?: return null
+        var enabled = true
+        var elevation = 1
+        var shapeRadius = 8
+        for ((kNode, vNode) in shadowNode.entries) {
+            val key = (kNode as? YamlScalar)?.content ?: continue
+            val value = (vNode as? YamlScalar)?.content ?: continue
+            when (key) {
+                "enabled" -> enabled = value.toBooleanStrictOrNull() ?: true
+                "elevation" -> elevation = value.toIntOrNull() ?: 1
+                "shape_radius" -> shapeRadius = value.toIntOrNull() ?: 8
+            }
+        }
+        return KeyboardShadowConfig(enabled = enabled, elevation = elevation, shapeRadius = shapeRadius)
     }
 
     /** 从 YAML 文本中提取 keyboard.keys 段。 */
@@ -428,6 +472,9 @@ object KeysConfigHelper {
 
     /** 获取键盘颜色配置（从 xime.yaml keyboard.colors 加载）。 */
     fun getKeyboardColors(): KeyboardColorsConfig = keyboardColorsConfig
+
+    /** 获取键盘阴影配置（从 xime.yaml keyboard.shadow 加载）。 */
+    fun getKeyboardShadow(): KeyboardShadowConfig = keyboardShadowConfig
 
     /** 获取某个按键的手势配置。 */
     fun getKeyGesture(key: String): KeyGestureConfig? = keyGestureConfig[key.lowercase()]

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -8,6 +8,7 @@ object SettingsPreferences {
     private const val PREFS_NAME = "kime_settings"
     private const val KEY_CURRENT_SCHEMA = "current_schema"
     private const val KEY_DEPLOYMENT_DONE = "deployment_done"
+    private const val KEY_DEPLOYMENT_HASH = "deployment_hash"
     private const val KEY_SETUP_COMPLETED = "setup_completed"
     private const val KEY_DARK_MODE = "dark_mode"
     
@@ -104,6 +105,14 @@ object SettingsPreferences {
     
     fun setDeploymentDone(context: Context, done: Boolean) {
         getPrefs(context).edit().putBoolean(KEY_DEPLOYMENT_DONE, done).apply()
+    }
+
+    fun getDeploymentHash(context: Context): String {
+        return getPrefs(context).getString(KEY_DEPLOYMENT_HASH, "") ?: ""
+    }
+
+    fun setDeploymentHash(context: Context, hash: String) {
+        getPrefs(context).edit().putString(KEY_DEPLOYMENT_HASH, hash).apply()
     }
 
     fun isSetupCompleted(context: Context): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/ui/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/CandidateBar.kt
@@ -1,5 +1,6 @@
 package com.kingzcheung.xime.ui
 
+import com.kingzcheung.xime.service.PredictionManager
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -87,7 +88,7 @@ fun CandidateBar(
     val horizontalPadding = if (isLandscape) 50.dp else 8.dp
     val context = LocalContext.current
     val showComments = SettingsPreferences.showCandidateComments(context)
-    val hasMoreAssociation = associationCandidates.size >= 5
+    val hasMoreAssociation = associationCandidates.size >= PredictionManager.MAX_ASSOCIATION_COUNT
     val hasAnyMore = hasMoreCandidates || hasMoreAssociation
 
     val density = LocalDensity.current
@@ -108,7 +109,7 @@ fun CandidateBar(
     val displayAssociation =
         remember(associationCandidates, displayCandidates, isComposing, inputText) {
             if (displayCandidates.isEmpty()) {
-                associationCandidates.take(5)
+                associationCandidates.take(PredictionManager.MAX_ASSOCIATION_COUNT)
             } else {
                 val leftSidePx = with(density) {
                     // inputText 已移到上方行，底部行只需留出 Logo 区域

--- a/app/src/main/java/com/kingzcheung/xime/ui/CandidatePage.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/CandidatePage.kt
@@ -155,57 +155,54 @@ fun CandidatePage(
             }
         }
 
-        Box(
+        HorizontalPager(
+            state = pagerState,
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f)
                 .padding(horizontal = 8.dp)
-        ) {
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                if (page == centerPage) {
-                    Column {
-                        if (candidates.isNotEmpty()) {
-                            FlowRow(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                verticalArrangement = Arrangement.spacedBy(6.dp)
-                            ) {
-                                candidates.forEachIndexed { index, candidate ->
-                                    CandidatePageItem(
-                                        text = candidate,
-                                        comment = candidateComments.getOrElse(index) { "" },
-                                        onClick = { onCandidateSelect(index) },
-                                        textColor = textColor
-                                    )
-                                }
+        ) { page ->
+            if (page == centerPage) {
+                Column {
+                    if (candidates.isNotEmpty()) {
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            candidates.forEachIndexed { index, candidate ->
+                                CandidatePageItem(
+                                    text = candidate,
+                                    comment = candidateComments.getOrElse(index) { "" },
+                                    onClick = { onCandidateSelect(index) },
+                                    textColor = textColor
+                                )
                             }
                         }
+                    }
 
-                        if (associationCandidates.isNotEmpty()) {
-                            Spacer(modifier = Modifier.height(8.dp))
+                    if (associationCandidates.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(8.dp))
 
-                            FlowRow(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                verticalArrangement = Arrangement.spacedBy(6.dp)
-                            ) {
-                                associationCandidates.forEachIndexed { index, candidate ->
-                                    CandidatePageItem(
-                                        text = candidate,
-                                        comment = "",
-                                        onClick = { onAssociationSelect?.invoke(index) },
-                                        textColor = textColor
-                                    )
-                                }
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            associationCandidates.forEachIndexed { index, candidate ->
+                                CandidatePageItem(
+                                    text = candidate,
+                                    comment = "",
+                                    onClick = { onAssociationSelect?.invoke(index) },
+                                    textColor = textColor
+                                )
                             }
                         }
                     }
                 }
             }
         }
+
+        Spacer(modifier = Modifier.weight(1f))
 
         // 底部留空
         Spacer(

--- a/app/src/main/java/com/kingzcheung/xime/ui/EnglishKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/EnglishKeyboardLayout.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.util.CharInfo
@@ -55,6 +56,9 @@ fun EnglishKeyboardLayout(
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
     keyboardBackgroundColor: Color = Color.Transparent,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
 ) {
@@ -105,6 +109,9 @@ fun EnglishKeyboardLayout(
                 keyTextColor = keyTextColor,
                 specialKeyBackgroundColor = specialKeyBackgroundColor,
                 keyboardBackgroundColor = keyboardBackgroundColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
                 onKeyPressDown = onKeyPressDown,
             )
         } else {
@@ -139,7 +146,10 @@ fun EnglishKeyboardLayout(
                                     onPress = { onKeyPressDown?.invoke(key) },
                                     onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
                                     longPressItems = longPressItems,
-                                    onLongPressSelect = { selected -> onKeyPress(selected) }
+                                    onLongPressSelect = { selected -> onKeyPress(selected) },
+                                    shadowEnabled = shadowEnabled,
+                                    shadowElevation = shadowElevation,
+                                    shadowShapeRadius = shadowShapeRadius,
                                 )
                             }
                         }
@@ -167,7 +177,10 @@ fun EnglishKeyboardLayout(
                                     onPress = { onKeyPressDown?.invoke(key) },
                                     onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
                                     longPressItems = longPressItems,
-                                    onLongPressSelect = { selected -> onKeyPress(selected) }
+                                    onLongPressSelect = { selected -> onKeyPress(selected) },
+                                    shadowEnabled = shadowEnabled,
+                                    shadowElevation = shadowElevation,
+                                    shadowShapeRadius = shadowShapeRadius,
                                 )
                             }
                         }
@@ -189,7 +202,10 @@ fun EnglishKeyboardLayout(
                             iconColor = keyTextColor,
                             modifier = Modifier.width(40.dp).fillMaxHeight(),
                             isHighlighted = isShifted,
-                            onPress = { onKeyPressDown?.invoke("shift") }
+                            onPress = { onKeyPressDown?.invoke("shift") },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
                         row3.forEach { key ->
                             val swipeText = swipeSymbols[key]
@@ -205,7 +221,10 @@ fun EnglishKeyboardLayout(
                                 onPress = { onKeyPressDown?.invoke(key) },
                                 onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
                                 longPressItems = longPressItems,
-                                onLongPressSelect = { selected -> onKeyPress(selected) }
+                                onLongPressSelect = { selected -> onKeyPress(selected) },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
                         // 退格键 — 对齐 KeyboardLayout 功能：长按连续删除、上滑清空等
@@ -223,7 +242,10 @@ fun EnglishKeyboardLayout(
                             swipeDownLabel = "下滑撤回",
                             onSwipeUp = { onKeyPress("clear_all") },
                             onSwipeDown = { onKeyPress("undo_clear") },
-                            onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) }
+                            onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
                     }
 
@@ -241,7 +263,10 @@ fun EnglishKeyboardLayout(
                             backgroundColor = specialKeyBackgroundColor,
                             textColor = keyTextColor,
                             modifier = Modifier.weight(1.2f),
-                            onPress = { onKeyPressDown?.invoke("mode_change") }
+                            onPress = { onKeyPressDown?.invoke("mode_change") },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
 
                         // 标点键 .
@@ -251,7 +276,10 @@ fun EnglishKeyboardLayout(
                             backgroundColor = keyBackgroundColor,
                             textColor = keyTextColor,
                             modifier = Modifier.weight(0.8f),
-                            onPress = { onKeyPressDown?.invoke(".") }
+                            onPress = { onKeyPressDown?.invoke(".") },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
 
                         // 空格键 — 使用 KeyButton 以获得震动/音效和按下效果
@@ -262,7 +290,10 @@ fun EnglishKeyboardLayout(
                             textColor = keyTextColor,
                             modifier = Modifier.weight(3f),
                             fontSize = 14.sp,
-                            onPress = { onKeyPressDown?.invoke("space") }
+                            onPress = { onKeyPressDown?.invoke("space") },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
 
                         KeyButton(
@@ -271,7 +302,10 @@ fun EnglishKeyboardLayout(
                             backgroundColor = specialKeyBackgroundColor,
                             textColor = keyTextColor,
                             modifier = Modifier.weight(0.8f),
-                            onPress = { onKeyPressDown?.invoke("ime_switch") }
+                            onPress = { onKeyPressDown?.invoke("ime_switch") },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
 
                         // 回车键
@@ -281,7 +315,10 @@ fun EnglishKeyboardLayout(
                             backgroundColor = specialKeyBackgroundColor,
                             textColor = keyTextColor,
                             modifier = Modifier.weight(1.2f),
-                            onPress = { onKeyPressDown?.invoke("enter") }
+                            onPress = { onKeyPressDown?.invoke("enter") },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
                     }
                 }
@@ -310,6 +347,9 @@ private fun LandscapeEnglishKeyboardContent(
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
     keyboardBackgroundColor: Color,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     onKeyPressDown: ((String) -> Unit)?,
 ) {
     val staggerStep = 10.dp
@@ -339,7 +379,10 @@ private fun LandscapeEnglishKeyboardContent(
                             backgroundColor = keyBackgroundColor,
                             textColor = keyTextColor,
                             modifier = Modifier.weight(1f),
-                            onPress = { onKeyPressDown?.invoke(key) }
+                            onPress = { onKeyPressDown?.invoke(key) },
+                            shadowEnabled = shadowEnabled,
+                            shadowElevation = shadowElevation,
+                            shadowShapeRadius = shadowShapeRadius,
                         )
                     }
                 }
@@ -388,7 +431,10 @@ private fun LandscapeEnglishKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     iconColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
-                    onPress = { onKeyPressDown?.invoke("emoji") }
+                    onPress = { onKeyPressDown?.invoke("emoji") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = ".",
@@ -396,7 +442,10 @@ private fun LandscapeEnglishKeyboardContent(
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(0.8f),
-                    onPress = { onKeyPressDown?.invoke(".") }
+                    onPress = { onKeyPressDown?.invoke(".") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 SplitSpaceKey(
                     onClick = { onKeyPress("space") },
@@ -404,7 +453,10 @@ private fun LandscapeEnglishKeyboardContent(
                     textColor = keyTextColor,
                     schemaName = "英文",
                     modifier = Modifier.weight(3f),
-                    onPress = { onKeyPressDown?.invoke("space") }
+                    onPress = { onKeyPressDown?.invoke("space") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
         }
@@ -472,7 +524,10 @@ private fun LandscapeEnglishKeyboardContent(
                                 backgroundColor = keyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier.weight(1f),
-                                onPress = { onKeyPressDown?.invoke(key) }
+                                onPress = { onKeyPressDown?.invoke(key) },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
                     }
@@ -483,7 +538,10 @@ private fun LandscapeEnglishKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     iconColor = keyTextColor,
                     modifier = Modifier.width(48.dp).fillMaxHeight(),
-                    onPress = { onKeyPressDown?.invoke("delete") }
+                    onPress = { onKeyPressDown?.invoke("delete") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Row(
@@ -496,7 +554,10 @@ private fun LandscapeEnglishKeyboardContent(
                     textColor = keyTextColor,
                     schemaName = "",
                     modifier = Modifier.weight(2f),
-                    onPress = { onKeyPressDown?.invoke("space") }
+                    onPress = { onKeyPressDown?.invoke("space") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = "123",
@@ -504,7 +565,10 @@ private fun LandscapeEnglishKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
-                    onPress = { onKeyPressDown?.invoke("mode_change") }
+                    onPress = { onKeyPressDown?.invoke("mode_change") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = "英",
@@ -512,7 +576,10 @@ private fun LandscapeEnglishKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(0.8f),
-                    onPress = { onKeyPressDown?.invoke("ime_switch") }
+                    onPress = { onKeyPressDown?.invoke("ime_switch") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = enterKeyText,
@@ -520,7 +587,10 @@ private fun LandscapeEnglishKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
-                    onPress = { onKeyPressDown?.invoke("enter") }
+                    onPress = { onKeyPressDown?.invoke("enter") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
         }
@@ -537,13 +607,19 @@ private fun SplitSpaceKey(
     textColor: Color,
     schemaName: String = "",
     modifier: Modifier = Modifier,
-    onPress: (() -> Unit)? = null
+    onPress: (() -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(1.dp, RoundedCornerShape(8.dp), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
+            )
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/EnglishKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/EnglishKeyboardLayout.kt
@@ -612,14 +612,16 @@ private fun SplitSpaceKey(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
 ) {
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
+
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .then(shadowModifier)
+            .clip(shadowShape)
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyButton.kt
@@ -78,7 +78,10 @@ fun KeyButton(
     onSwipeDown: ((String) -> Unit)? = null,
     onSwipeStateChange: ((SwipeState) -> Unit)? = null,
     fontSize: androidx.compose.ui.unit.TextUnit? = null,
-    onPress: (() -> Unit)? = null
+    onPress: (() -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     var dragOffsetX by remember { mutableStateOf(0f) }
@@ -107,8 +110,11 @@ fun KeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(1.dp, RoundedCornerShape(8.dp), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
+            )
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)
@@ -237,7 +243,7 @@ fun SwipeableKeyButton(
     isHighlighted: Boolean = false,
     swipeText: String? = null,
     swipeDownText: String? = null,
-    /** 下滑文本显示在按键上（气泡为空，用于 display:key�?*/
+    /** 下滑文本显示在按键上（气泡为空，用于 display:key�? */
     swipeDownKeyLabel: String? = null,
     onSwipe: ((String) -> Unit)? = null,
     onSwipeDown: ((String) -> Unit)? = null,
@@ -246,7 +252,10 @@ fun SwipeableKeyButton(
     onLongPressSelect: ((String) -> Unit)? = null,
     longPressItems: List<String>? = null,
     fontSize: androidx.compose.ui.unit.TextUnit = androidx.compose.ui.unit.TextUnit.Unspecified,
-    swipeFontSize: androidx.compose.ui.unit.TextUnit = 9.sp
+    swipeFontSize: androidx.compose.ui.unit.TextUnit = 9.sp,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     var dragOffsetY by remember { mutableStateOf(0f) }
@@ -279,11 +288,14 @@ fun SwipeableKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(1.dp, RoundedCornerShape(8.dp), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
+            )
             .onGloballyPositioned { coordinates ->
                 buttonBounds = coordinates.boundsInRoot()
             }
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(
                 if (isPressed) backgroundColor.copy(alpha = 0.7f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)
@@ -568,7 +580,10 @@ fun IconKeyButton(
     modifier: Modifier = Modifier,
     isHighlighted: Boolean = false,
     iconSize: androidx.compose.ui.unit.Dp = 20.dp,
-    onPress: (() -> Unit)? = null
+    onPress: (() -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     
@@ -585,8 +600,11 @@ fun IconKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(1.dp, RoundedCornerShape(8.dp), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
+            )
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.1f)
                 else if (isHighlighted) darkenColor(backgroundColor, 0.2f)
@@ -647,7 +665,10 @@ fun SwipeableIconKeyButton(
     onSwipeUp: (() -> Unit)? = null,
     onSwipeDown: (() -> Unit)? = null,
     onSwipeLeft: (() -> Unit)? = null,
-    onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null
+    onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     var dragOffsetY by remember { mutableStateOf(0f) }
@@ -698,11 +719,14 @@ fun SwipeableIconKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(1.dp, RoundedCornerShape(8.dp), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
+            )
             .onGloballyPositioned { coordinates ->
                 buttonBounds = coordinates.boundsInRoot()
             }
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyButton.kt
@@ -96,6 +96,11 @@ fun KeyButton(
     val swipeDownThreshold = with(density) { 30.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
     val bubbleShowThresholdDown = swipeDownThreshold * 0.3f
+
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     
     // 辅助函数：生成更深的颜色（混合黑色）
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -110,11 +115,8 @@ fun KeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .then(shadowModifier)
+            .clip(shadowShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)
@@ -284,18 +286,20 @@ fun SwipeableKeyButton(
     val swipeDownThreshold = with(density) { 30.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
     val bubbleShowThresholdDown = swipeDownThreshold * 0.3f
+
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
+            .then(shadowModifier)
             .onGloballyPositioned { coordinates ->
                 buttonBounds = coordinates.boundsInRoot()
             }
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .clip(shadowShape)
             .background(
                 if (isPressed) backgroundColor.copy(alpha = 0.7f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)
@@ -586,6 +590,11 @@ fun IconKeyButton(
     shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
+
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     
     // 辅助函数：生成更深的颜色（混合黑色）
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -600,11 +609,8 @@ fun IconKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .then(shadowModifier)
+            .clip(shadowShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.1f)
                 else if (isHighlighted) darkenColor(backgroundColor, 0.2f)
@@ -706,6 +712,11 @@ fun SwipeableIconKeyButton(
             }
         }
     }
+
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
         return Color(
@@ -719,14 +730,11 @@ fun SwipeableIconKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
+            .then(shadowModifier)
             .onGloballyPositioned { coordinates ->
                 buttonBounds = coordinates.boundsInRoot()
             }
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .clip(shadowShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayout.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.util.PermissionHelper
@@ -86,6 +87,9 @@ fun KeyboardLayout(
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
     keyboardBackgroundColor: Color = Color.Transparent,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     onVoiceModeChange: ((Boolean) -> Unit)? = null,
     onCommitText: ((String) -> Unit)? = null,
     isSttEnabled: Boolean = true,
@@ -179,6 +183,9 @@ fun KeyboardLayout(
                 swipeDownHintsEnabled = swipeDownHintsEnabled,
                 onCommitText = onCommitText,
                 onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         } else {
             Column(
@@ -223,7 +230,10 @@ fun KeyboardLayout(
                                 swipeDownHintsEnabled = swipeDownHintsEnabled,
                                 swipeUpHintsEnabled = swipeUpHintsEnabled,
                                 onCommitText = onCommitText,
-                                configVersion = cfgVer
+                                configVersion = cfgVer,
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
                     }
@@ -261,7 +271,10 @@ fun KeyboardLayout(
                                 swipeDownHintsEnabled = swipeDownHintsEnabled,
                                 swipeUpHintsEnabled = swipeUpHintsEnabled,
                                 onCommitText = onCommitText,
-                                configVersion = cfgVer
+                                configVersion = cfgVer,
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
                     }
@@ -291,7 +304,10 @@ fun KeyboardLayout(
                                 modifier = Modifier
                                     .width(40.dp)
                                     .fillMaxHeight(),
-                                onPress = { onKeyPressDown?.invoke("emoji") }
+                                onPress = { onKeyPressDown?.invoke("emoji") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
 
                             Row(
@@ -369,7 +385,10 @@ fun KeyboardLayout(
                                                 (onCommitText ?: onKeyPress)(selectedLabel)
                                             }
                                         },
-                                        longPressItems = longPressLabels
+                                        longPressItems = longPressLabels,
+                                        shadowEnabled = shadowEnabled,
+                                        shadowElevation = shadowElevation,
+                                        shadowShapeRadius = shadowShapeRadius,
                                     )
                                 }
                             }
@@ -395,7 +414,10 @@ fun KeyboardLayout(
                                         state,
                                         bounds
                                     )
-                                }
+                                },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
                     }
@@ -425,7 +447,10 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier.weight(1.2f),
-                                onPress = { onKeyPressDown?.invoke("mode_change") }
+                                onPress = { onKeyPressDown?.invoke("mode_change") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
 
                             SwipeableKeyButton(
@@ -442,7 +467,10 @@ fun KeyboardLayout(
                                         bounds
                                     )
                                 },
-                                onPress = { onKeyPressDown?.invoke("。") }
+                                onPress = { onKeyPressDown?.invoke("。") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
 
@@ -456,13 +484,11 @@ fun KeyboardLayout(
                             modifier = Modifier
                                 .weight(3f)
                                 .fillMaxHeight()
-                                .shadow(
-                                    1.dp,
-                                    RoundedCornerShape(8.dp),
-                                    ambientColor = Color(0x80000000),
-                                    spotColor = Color(0x80000000)
+                                .then(
+                                    if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                                    else Modifier
                                 )
-                                .clip(RoundedCornerShape(8.dp))
+                                .clip(RoundedCornerShape(shadowShapeRadius))
                                 .background(keyBackgroundColor)
                                 .pointerInput(isSttEnabled) {
                                     awaitEachGesture {
@@ -599,7 +625,10 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier.weight(0.8f),
-                                onPress = { onKeyPressDown?.invoke("ime_switch") }
+                                onPress = { onKeyPressDown?.invoke("ime_switch") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
 
                             KeyButton(
@@ -608,7 +637,10 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier.weight(1.2f),
-                                onPress = { onKeyPressDown?.invoke("enter") }
+                                onPress = { onKeyPressDown?.invoke("enter") },
+                                shadowEnabled = shadowEnabled,
+                                shadowElevation = shadowElevation,
+                                shadowShapeRadius = shadowShapeRadius,
                             )
                         }
                     }
@@ -731,6 +763,9 @@ fun KeyboardRowWithConfig(
     fontSize: androidx.compose.ui.unit.TextUnit = androidx.compose.ui.unit.TextUnit.Unspecified,
     swipeFontSize: androidx.compose.ui.unit.TextUnit = 9.sp,
     configVersion: Int = 0,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     Row(
         modifier = modifier
@@ -800,7 +835,10 @@ fun KeyboardRowWithConfig(
                 },
                 longPressItems = longPressLabels,
                 fontSize = fontSize,
-                swipeFontSize = swipeFontSize
+                swipeFontSize = swipeFontSize,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         }
     }
@@ -827,6 +865,9 @@ private fun LandscapeKeyboardContent(
     swipeDownHintsEnabled: Boolean,
     onCommitText: ((String) -> Unit)?,
     onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     val staggerStep = 10.dp
     val landscapeFontSize = 12.sp
@@ -861,6 +902,9 @@ private fun LandscapeKeyboardContent(
                     onCommitText = onCommitText,
                     onGestureAction = onGestureAction,
                     onSwipeStateChange = onSwipeStateChange,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Box(
@@ -883,6 +927,9 @@ private fun LandscapeKeyboardContent(
                     onCommitText = onCommitText,
                     onGestureAction = onGestureAction,
                     onSwipeStateChange = onSwipeStateChange,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Box(
@@ -905,6 +952,9 @@ private fun LandscapeKeyboardContent(
                     onCommitText = onCommitText,
                     onGestureAction = onGestureAction,
                     onSwipeStateChange = onSwipeStateChange,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Row(
@@ -919,7 +969,10 @@ private fun LandscapeKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     iconColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
-                    onPress = { onKeyPressDown?.invoke("emoji") }
+                    onPress = { onKeyPressDown?.invoke("emoji") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 CompactSwipeableKeyButton(
                     text = "，",
@@ -930,7 +983,10 @@ private fun LandscapeKeyboardContent(
                     swipeText = "。",
                     swipeFontSize = landscapeSwipeFontSize,
                     onSwipe = { onSwipeText -> onKeyPress(onSwipeText) },
-                    onPress = { onKeyPressDown?.invoke("。") }
+                    onPress = { onKeyPressDown?.invoke("。") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 SplitSpaceKey(
                     onClick = { onKeyPress("space") },
@@ -938,7 +994,10 @@ private fun LandscapeKeyboardContent(
                     textColor = keyTextColor,
                     schemaName = schemaName,
                     modifier = Modifier.weight(3f),
-                    onPress = { onKeyPressDown?.invoke("space") }
+                    onPress = { onKeyPressDown?.invoke("space") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
         }
@@ -970,6 +1029,9 @@ private fun LandscapeKeyboardContent(
                     onCommitText = onCommitText,
                     onGestureAction = onGestureAction,
                     onSwipeStateChange = onSwipeStateChange,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Box(
@@ -992,6 +1054,9 @@ private fun LandscapeKeyboardContent(
                     onCommitText = onCommitText,
                     onGestureAction = onGestureAction,
                     onSwipeStateChange = onSwipeStateChange,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Row(
@@ -1017,6 +1082,9 @@ private fun LandscapeKeyboardContent(
                         onCommitText = onCommitText,
                         onGestureAction = onGestureAction,
                         onSwipeStateChange = onSwipeStateChange,
+                        shadowEnabled = shadowEnabled,
+                        shadowElevation = shadowElevation,
+                        shadowShapeRadius = shadowShapeRadius,
                     )
                 }
                 SwipeableIconKeyButton(
@@ -1036,6 +1104,9 @@ private fun LandscapeKeyboardContent(
                     onSwipeUp = { onKeyPress("clear_all") },
                     onSwipeDown = { onKeyPress("undo_clear") },
                     onSwipeStateChange = onSwipeStateChange,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             Row(
@@ -1050,7 +1121,10 @@ private fun LandscapeKeyboardContent(
                     textColor = keyTextColor,
                     schemaName = "",
                     modifier = Modifier.weight(2f),
-                    onPress = { onKeyPressDown?.invoke("space") }
+                    onPress = { onKeyPressDown?.invoke("space") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = "123",
@@ -1058,7 +1132,10 @@ private fun LandscapeKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
-                    onPress = { onKeyPressDown?.invoke("mode_change") }
+                    onPress = { onKeyPressDown?.invoke("mode_change") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = "中",
@@ -1066,7 +1143,10 @@ private fun LandscapeKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(0.8f),
-                    onPress = { onKeyPressDown?.invoke("ime_switch") }
+                    onPress = { onKeyPressDown?.invoke("ime_switch") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
                     text = enterKeyText,
@@ -1074,7 +1154,10 @@ private fun LandscapeKeyboardContent(
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
-                    onPress = { onKeyPressDown?.invoke("enter") }
+                    onPress = { onKeyPressDown?.invoke("enter") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
         }
@@ -1100,7 +1183,10 @@ fun CompactSwipeableKeyButton(
     longPressItems: List<String>? = null,
     fontSize: androidx.compose.ui.unit.TextUnit = androidx.compose.ui.unit.TextUnit.Unspecified,
     swipeFontSize: androidx.compose.ui.unit.TextUnit = 8.sp,
-    onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null
+    onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     var dragOffsetY by remember { mutableStateOf(0f) }
@@ -1145,16 +1231,14 @@ fun CompactSwipeableKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(
-                1.dp,
-                RoundedCornerShape(8.dp),
-                ambientColor = Color(0x80000000),
-                spotColor = Color(0x80000000)
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
             )
             .onGloballyPositioned { coordinates ->
                 buttonBounds = coordinates.boundsInRoot()
             }
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(if (isPressed) darkenColor(backgroundColor) else backgroundColor)
             .pointerInput(currentLongPressItems, currentOnLongPressSelect) {
                 if (currentLongPressItems.isNullOrEmpty() || currentOnLongPressSelect == null) {
@@ -1410,6 +1494,9 @@ fun CompactKeyboardRowWithConfig(
     swipeFontSize: androidx.compose.ui.unit.TextUnit = 9.sp,
     onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
     configVersion: Int = 0,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     Row(
         modifier = modifier
@@ -1472,7 +1559,10 @@ fun CompactKeyboardRowWithConfig(
                 },
                 longPressItems = longPressLabels,
                 fontSize = fontSize,
-                swipeFontSize = swipeFontSize
+                swipeFontSize = swipeFontSize,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         }
     }
@@ -1488,18 +1578,19 @@ private fun SplitSpaceKey(
     textColor: Color,
     schemaName: String = "",
     modifier: Modifier = Modifier,
-    onPress: (() -> Unit)? = null
+    onPress: (() -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .shadow(
-                1.dp,
-                RoundedCornerShape(8.dp),
-                ambientColor = Color(0x80000000),
-                spotColor = Color(0x80000000)
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
             )
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayout.kt
@@ -1219,6 +1219,11 @@ fun CompactSwipeableKeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
     val bubbleShowThresholdDown = swipeDownThreshold * 0.3f
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
+
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
         return Color(
             red = (color.red * (1 - factor)).coerceIn(0f, 1f),
@@ -1231,14 +1236,11 @@ fun CompactSwipeableKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
+            .then(shadowModifier)
             .onGloballyPositioned { coordinates ->
                 buttonBounds = coordinates.boundsInRoot()
             }
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .clip(shadowShape)
             .background(if (isPressed) darkenColor(backgroundColor) else backgroundColor)
             .pointerInput(currentLongPressItems, currentOnLongPressSelect) {
                 if (currentLongPressItems.isNullOrEmpty() || currentOnLongPressSelect == null) {
@@ -1583,14 +1585,16 @@ private fun SplitSpaceKey(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
 ) {
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
+
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-                else Modifier
-            )
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .then(shadowModifier)
+            .clip(shadowShape)
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayoutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayoutScreen.kt
@@ -3,6 +3,8 @@ package com.kingzcheung.xime.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.kingzcheung.xime.keyboard.GestureAction
 
 /**
@@ -25,6 +27,9 @@ fun KeyboardLayoutScreen(
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
     keyboardBackgroundColor: Color,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     // Chinese-only 参数
@@ -50,6 +55,9 @@ fun KeyboardLayoutScreen(
                 keyTextColor = keyTextColor,
                 specialKeyBackgroundColor = specialKeyBackgroundColor,
                 keyboardBackgroundColor = keyboardBackgroundColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
                 modifier = modifier,
                 onVoiceModeChange = onVoiceModeChange,
                 onCommitText = onCommitText,
@@ -72,6 +80,9 @@ fun KeyboardLayoutScreen(
                 keyTextColor = keyTextColor,
                 specialKeyBackgroundColor = specialKeyBackgroundColor,
                 keyboardBackgroundColor = keyboardBackgroundColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
                 modifier = modifier,
                 onKeyPressDown = onKeyPressDown,
             )
@@ -84,6 +95,9 @@ fun KeyboardLayoutScreen(
                 keyTextColor = keyTextColor,
                 specialKeyBackgroundColor = specialKeyBackgroundColor,
                 keyboardBackgroundColor = keyboardBackgroundColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
                 modifier = modifier,
                 onKeyPressDown = onKeyPressDown,
             )

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
@@ -138,6 +138,7 @@ fun KeyboardView(
     }
 
     val kbColors = KeysConfigHelper.getKeyboardColors()
+    val kbShadow = KeysConfigHelper.getKeyboardShadow()
     val longToColor: (Long) -> Color = { Color(0xFF000000 or it) }
     val keyboardBgColor = if (isDarkTheme) longToColor(kbColors.keyboardBgColorDark)
         else longToColor(kbColors.keyboardBgColor)
@@ -346,6 +347,9 @@ fun KeyboardView(
                         keyTextColor = keyTextColor,
                         specialKeyBackgroundColor = specialKeyBgColor,
                         keyboardBackgroundColor = keyboardBgColor,
+                        shadowEnabled = kbShadow.enabled,
+                        shadowElevation = kbShadow.elevation.dp,
+                        shadowShapeRadius = kbShadow.shapeRadius.dp,
                         modifier = Modifier.weight(1f).then(cursorMod),
                         onKeyPressDown = onKeyPressDown,
                         onVoiceModeChange = onVoiceModeChange,

--- a/app/src/main/java/com/kingzcheung/xime/ui/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/NumberKeyboardLayout.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
@@ -34,6 +35,9 @@ fun NumberKeyboardLayout(
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
     keyboardBackgroundColor: Color = Color.Transparent,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null
 ) {
@@ -77,7 +81,10 @@ fun NumberKeyboardLayout(
                                     backgroundColor = keyBackgroundColor,
                                     textColor = keyTextColor,
                                     modifier = Modifier.weight(1f),
-                                    onPress = { onKeyPressDown?.invoke(sym) }
+                                    onPress = { onKeyPressDown?.invoke(sym) },
+                                    shadowEnabled = shadowEnabled,
+                                    shadowElevation = shadowElevation,
+                                    shadowShapeRadius = shadowShapeRadius,
                                 )
                             }
                             repeat(6 - rowSymbols.size) {
@@ -99,38 +106,38 @@ fun NumberKeyboardLayout(
                         modifier = Modifier.fillMaxWidth().weight(1f),
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
-                        KeyButton(text = "+", onClick = { onKeyPress("+") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("+") })
-                        listOf("1","2","3").forEach { k -> KeyButton(text = k, onClick = { onKeyPress(k) }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(k) }) }
-                        SwipeableIconKeyButton(icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace), onClick = { onKeyPress("delete") }, backgroundColor = specialKeyBackgroundColor, iconColor = keyTextColor, modifier = Modifier.weight(1f), onSwipe = { onKeyPress("clear_composition") }, onLongClick = { onKeyPress("delete") }, onPress = { onKeyPressDown?.invoke("delete") })
+                        KeyButton(text = "+", onClick = { onKeyPress("+") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("+") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        listOf("1","2","3").forEach { k -> KeyButton(text = k, onClick = { onKeyPress(k) }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(k) }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius) }
+                        SwipeableIconKeyButton(icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace), onClick = { onKeyPress("delete") }, backgroundColor = specialKeyBackgroundColor, iconColor = keyTextColor, modifier = Modifier.weight(1f), onSwipe = { onKeyPress("clear_composition") }, onLongClick = { onKeyPress("delete") }, onPress = { onKeyPressDown?.invoke("delete") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
                     }
                     // 第二行：符号 | 4 | 5 | 6 | 空格
                     Row(
                         modifier = Modifier.fillMaxWidth().weight(1f),
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
-                        KeyButton(text = "-", onClick = { onKeyPress("-") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("-") })
-                        listOf("4","5","6").forEach { k -> KeyButton(text = k, onClick = { onKeyPress(k) }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(k) }) }
-                        KeyButton(text = "符号", onClick = { onKeyPress("symbol") }, backgroundColor = specialKeyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("symbol") })
+                        KeyButton(text = "-", onClick = { onKeyPress("-") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("-") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        listOf("4","5","6").forEach { k -> KeyButton(text = k, onClick = { onKeyPress(k) }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(k) }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius) }
+                        KeyButton(text = "符号", onClick = { onKeyPress("symbol") }, backgroundColor = specialKeyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("symbol") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
                     }
                     // 第三行：符号 | 7 | 8 | 9 | 表情
                     Row(
                         modifier = Modifier.fillMaxWidth().weight(1f),
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
-                        KeyButton(text = "*", onClick = { onKeyPress("*") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("*") })
-                        listOf("7","8","9").forEach { k -> KeyButton(text = k, onClick = { onKeyPress(k) }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(k) }) }
-                        IconKeyButton(icon = rememberVectorPainter(Icons.Default.EmojiEmotions), onClick = { onKeyPress("emoji") }, backgroundColor = specialKeyBackgroundColor, iconColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("emoji") })
+                        KeyButton(text = "*", onClick = { onKeyPress("*") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("*") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        listOf("7","8","9").forEach { k -> KeyButton(text = k, onClick = { onKeyPress(k) }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(k) }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius) }
+                        IconKeyButton(icon = rememberVectorPainter(Icons.Default.EmojiEmotions), onClick = { onKeyPress("emoji") }, backgroundColor = specialKeyBackgroundColor, iconColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("emoji") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
                     }
                     // 第四行：返回 | 符号切换 | 0 | . | 确定
                     Row(
                         modifier = Modifier.fillMaxWidth().weight(1f),
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
-                        IconKeyButton(icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack), onClick = { onKeyPress("abc") }, backgroundColor = specialKeyBackgroundColor, iconColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("abc") })
-                        KeyButton(text = "/", onClick = { onKeyPress("/") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("/") })
-                        KeyButton(text = "0", onClick = { onKeyPress("0") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1.5f), onPress = { onKeyPressDown?.invoke("0") })
-                        KeyButton(text = ".", onClick = { onKeyPress(".") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(".") })
-                        KeyButton(text = "确定", onClick = { onKeyPress("enter") }, backgroundColor = specialKeyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1.2f), onPress = { onKeyPressDown?.invoke("enter") })
+                        IconKeyButton(icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack), onClick = { onKeyPress("abc") }, backgroundColor = specialKeyBackgroundColor, iconColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("abc") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        KeyButton(text = "/", onClick = { onKeyPress("/") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke("/") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        KeyButton(text = "0", onClick = { onKeyPress("0") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1.5f), onPress = { onKeyPressDown?.invoke("0") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        KeyButton(text = ".", onClick = { onKeyPress(".") }, backgroundColor = keyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1f), onPress = { onKeyPressDown?.invoke(".") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
+                        KeyButton(text = "确定", onClick = { onKeyPress("enter") }, backgroundColor = specialKeyBackgroundColor, textColor = keyTextColor, modifier = Modifier.weight(1.2f), onPress = { onKeyPressDown?.invoke("enter") }, shadowEnabled = shadowEnabled, shadowElevation = shadowElevation, shadowShapeRadius = shadowShapeRadius)
                     }
                 }
             }
@@ -149,6 +156,9 @@ fun NumberKeyboardLayout(
                     keyBackgroundColor = keyBackgroundColor,
                     keyTextColor = keyTextColor,
                     specialKeyBackgroundColor = specialKeyBackgroundColor,
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                     onKeyPressDown = onKeyPressDown
                 )
             }
@@ -162,6 +172,9 @@ private fun NumberRows(
     keyBackgroundColor: Color,
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
     onKeyPressDown: ((String) -> Unit)? = null
 ) {
     val symbols = listOf("+", "-", "*")
@@ -184,7 +197,10 @@ private fun NumberRows(
                 backgroundColor = keyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke(symbols[0]) }
+                onPress = { onKeyPressDown?.invoke(symbols[0]) },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             listOf("1", "2", "3").forEach { key ->
                 KeyButton(
@@ -193,7 +209,10 @@ private fun NumberRows(
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1f),
-                    onPress = { onKeyPressDown?.invoke(key) }
+                    onPress = { onKeyPressDown?.invoke(key) },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             SwipeableIconKeyButton(
@@ -205,7 +224,10 @@ private fun NumberRows(
                 swipeText = "清空",
                 onSwipe = { onKeyPress("clear_composition") },
                 onLongClick = { onKeyPress("delete") },
-                onPress = { onKeyPressDown?.invoke("delete") }
+                onPress = { onKeyPressDown?.invoke("delete") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         }
 
@@ -222,7 +244,10 @@ private fun NumberRows(
                 backgroundColor = keyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke(symbols[1]) }
+                onPress = { onKeyPressDown?.invoke(symbols[1]) },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             listOf("4", "5", "6").forEach { key ->
                 KeyButton(
@@ -231,7 +256,10 @@ private fun NumberRows(
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1f),
-                    onPress = { onKeyPressDown?.invoke(key) }
+                    onPress = { onKeyPressDown?.invoke(key) },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             KeyButton(
@@ -240,7 +268,10 @@ private fun NumberRows(
                 backgroundColor = specialKeyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke("symbol") }
+                onPress = { onKeyPressDown?.invoke("symbol") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         }
 
@@ -257,7 +288,10 @@ private fun NumberRows(
                 backgroundColor = keyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke(symbols[2]) }
+                onPress = { onKeyPressDown?.invoke(symbols[2]) },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             listOf("7", "8", "9").forEach { key ->
                 KeyButton(
@@ -266,7 +300,10 @@ private fun NumberRows(
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1f),
-                    onPress = { onKeyPressDown?.invoke(key) }
+                    onPress = { onKeyPressDown?.invoke(key) },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
                 )
             }
             IconKeyButton(
@@ -275,7 +312,10 @@ private fun NumberRows(
                 backgroundColor = specialKeyBackgroundColor,
                 iconColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke("emoji") }
+                onPress = { onKeyPressDown?.invoke("emoji") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         }
 
@@ -292,7 +332,10 @@ private fun NumberRows(
                 backgroundColor = specialKeyBackgroundColor,
                 iconColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke("abc") }
+                onPress = { onKeyPressDown?.invoke("abc") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             KeyButton(
                 text = "/",
@@ -300,7 +343,10 @@ private fun NumberRows(
                 backgroundColor = keyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke("/") }
+                onPress = { onKeyPressDown?.invoke("/") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             KeyButton(
                 text = "0",
@@ -308,7 +354,10 @@ private fun NumberRows(
                 backgroundColor = keyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1.5f),
-                onPress = { onKeyPressDown?.invoke("0") }
+                onPress = { onKeyPressDown?.invoke("0") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             KeyButton(
                 text = ".",
@@ -316,7 +365,10 @@ private fun NumberRows(
                 backgroundColor = keyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1f),
-                onPress = { onKeyPressDown?.invoke(".") }
+                onPress = { onKeyPressDown?.invoke(".") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
             KeyButton(
                 text = "确定",
@@ -324,7 +376,10 @@ private fun NumberRows(
                 backgroundColor = specialKeyBackgroundColor,
                 textColor = keyTextColor,
                 modifier = Modifier.weight(1.2f),
-                onPress = { onKeyPressDown?.invoke("enter") }
+                onPress = { onKeyPressDown?.invoke("enter") },
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
             )
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/SpaceKeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/SpaceKeyButton.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
@@ -44,7 +45,10 @@ fun SpaceKeyButton(
     onSwipeRight: (() -> Unit)? = null,
     onPress: (() -> Unit)? = null,
     isVoiceMode: Boolean = false,
-    onVoiceModeChange: ((Boolean) -> Unit)? = null
+    onVoiceModeChange: ((Boolean) -> Unit)? = null,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
 ) {
     // 使用 remember 保存手势相关状态
     var isPressed by remember { mutableStateOf(false) }
@@ -59,8 +63,11 @@ fun SpaceKeyButton(
     Box(
         modifier = modifier
             .height((44 * LocalStretchFactor.current).dp)
-            .shadow(1.dp, RoundedCornerShape(8.dp), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
-            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                else Modifier
+            )
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(
                 if (isPressed) backgroundColor.copy(alpha = 0.7f)
                 else backgroundColor

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SetupWizardScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SetupWizardScreen.kt
@@ -126,6 +126,7 @@ fun SetupWizardScreen(
                             }
                             SettingsPreferences.setSetupCompleted(context, true)
                             SettingsPreferences.setDeploymentDone(context, true)
+                            RimeConfigHelper.storeDeploymentHash(context)
                             onCompleted()
                         }
                     )

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -124,15 +124,7 @@ include_directories(
     "${CMAKE_SOURCE_DIR}/boost/libs/concept_check/include"
 )
 
-option(BUILD_TEST "" OFF)
-option(BUILD_STATIC "" ON)
-add_subdirectory(librime)
-
-target_compile_options(
-    rime-static PRIVATE 
-    "-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=." 
-    "-Wno-error=deprecated-declarations"
-)
+include(Rime)
 
 # 编译 JNI 库
 add_subdirectory(librime_jni)

--- a/app/src/main/jni/cmake/Rime.cmake
+++ b/app/src/main/jni/cmake/Rime.cmake
@@ -2,7 +2,42 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# 已集成的插件（需先在 plugins/ 下创建对应目录或配置好复制逻辑）
+# 应用 Lua 5.4 Android 兼容性补丁（修复 32 位设备上 fseeko/ftello 不可用的问题）
+# 对 liolib.c 中 l_fseek 配置块做条件增强，使 32 位 Android < API 24 能编译
+# 使用 CMake 原生方式修补，无需依赖 git/patch
+string(ASCII 10 LUA_NL)
+set(LUA_LIOLIB_SRC "${CMAKE_SOURCE_DIR}/librime-lua-deps/lua5.4/liolib.c")
+if(EXISTS "${LUA_LIOLIB_SRC}")
+  file(READ "${LUA_LIOLIB_SRC}" LUA_LIOLIB_CONTENT)
+  # 检查补丁是否已应用
+  string(FIND "${LUA_LIOLIB_CONTENT}" "ANDROID" LUA_ALREADY_PATCHED)
+  if(LUA_ALREADY_PATCHED EQUAL -1)
+    string(FIND "${LUA_LIOLIB_CONTENT}" "#if !defined(l_fseek)" LUA_ANCHOR_POS)
+    if(LUA_ANCHOR_POS GREATER -1)
+      string(SUBSTRING "${LUA_LIOLIB_CONTENT}" ${LUA_ANCHOR_POS} -1 LUA_SUB_CONTENT)
+      string(FIND "${LUA_SUB_CONTENT}" "#if defined(LUA_USE_POSIX)" LUA_REL_POS)
+      if(LUA_REL_POS GREATER -1)
+        math(EXPR LUA_TARGET_POS "${LUA_ANCHOR_POS} + ${LUA_REL_POS}")
+        string(SUBSTRING "${LUA_LIOLIB_CONTENT}" ${LUA_TARGET_POS} -1 LUA_TARGET_CONTENT)
+        string(FIND "${LUA_TARGET_CONTENT}" "${LUA_NL}" LUA_REL_NL_POS)
+        if(LUA_REL_NL_POS GREATER -1)
+          math(EXPR LUA_NL_POS "${LUA_TARGET_POS} + ${LUA_REL_NL_POS}")
+          string(SUBSTRING "${LUA_LIOLIB_CONTENT}" 0 ${LUA_TARGET_POS} LUA_HEAD)
+          string(SUBSTRING "${LUA_LIOLIB_CONTENT}" ${LUA_NL_POS} -1 LUA_TAIL)
+          math(EXPR LUA_SUFFIX_START "${LUA_TARGET_POS} + 26")
+          math(EXPR LUA_SUFFIX_LEN "${LUA_NL_POS} - ${LUA_SUFFIX_START}")
+          string(SUBSTRING "${LUA_LIOLIB_CONTENT}" ${LUA_SUFFIX_START} ${LUA_SUFFIX_LEN} LUA_SUFFIX)
+          set(LUA_PATCHED_LINE
+            "#if defined(LUA_USE_POSIX) && \\${LUA_NL}   (!defined(ANDROID) || (defined(__LP64__) || ANDROID_PLATFORM >= 24))${LUA_SUFFIX}")
+          set(LUA_LIOLIB_CONTENT "${LUA_HEAD}${LUA_PATCHED_LINE}${LUA_TAIL}")
+          file(WRITE "${LUA_LIOLIB_SRC}" "${LUA_LIOLIB_CONTENT}")
+        endif()
+      endif()
+    endif()
+  endif()
+endif()
+
+# 已集成的插件
 # 注意：librime-lua 官方文档要求插件目录名为 lua
 set(RIME_PLUGINS librime-lua)
 
@@ -24,7 +59,7 @@ option(BUILD_TEST "" OFF)
 option(BUILD_STATIC "" ON)
 add_subdirectory(librime)
 target_compile_options(
-  rime-static PRIVATE "-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=." "-Wno-error=deprecated-declarations")
+  rime-static PRIVATE "-ffile-prefix-map=${CMAKE_SOURCE_DIR}=." "-Wno-error=deprecated-declarations")
 
 target_compile_options(
-  rime-lua-objs PRIVATE "-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
+  rime-lua-objs PRIVATE "-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.")

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -18,6 +18,16 @@
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 
+struct ProcessResult {
+    bool processed;
+    std::string committedText;
+    std::string inputText;
+    std::vector<std::pair<std::string, std::string>> candidates;
+    bool isAsciiMode;
+    bool hasNextPage;
+    bool hasPrevPage;
+};
+
 // Rime 单例类
 class Rime {
 public:
@@ -118,6 +128,55 @@ public:
         LOGD("processKey: keycode=%d, mask=%d", keycode, mask);
         bool result = rime->process_key(session_id_, keycode, mask);
         LOGD("processKey result: %d", result);
+        return result;
+    }
+
+    ProcessResult processKeyAndGetResult(int keycode, int mask) {
+        ProcessResult result;
+        result.processed = false;
+        result.isAsciiMode = false;
+        result.hasNextPage = false;
+        result.hasPrevPage = false;
+
+        if (!rime || !session_id_) {
+            LOGE("processKeyAndGetResult: rime or session not available");
+            return result;
+        }
+
+        result.processed = rime->process_key(session_id_, keycode, mask);
+
+        RIME_STRUCT(RimeCommit, commit);
+        if (rime->get_commit(session_id_, &commit)) {
+            result.committedText = commit.text ? commit.text : "";
+            rime->free_commit(&commit);
+        }
+
+        const char* input = rime->get_input(session_id_);
+        result.inputText = input ? input : "";
+
+        RIME_STRUCT(RimeContext, context);
+        if (rime->get_context(session_id_, &context)) {
+            if (context.menu.num_candidates > 0) {
+                for (int i = 0; i < context.menu.num_candidates; ++i) {
+                    const char* text = context.menu.candidates[i].text;
+                    const char* comment = context.menu.candidates[i].comment;
+                    result.candidates.push_back(std::make_pair(
+                        text ? text : "",
+                        comment ? comment : ""
+                    ));
+                }
+            }
+            result.hasNextPage = !context.menu.is_last_page;
+            result.hasPrevPage = context.menu.page_no > 0;
+            rime->free_context(&context);
+        }
+
+        RIME_STRUCT(RimeStatus, status);
+        if (rime->get_status(session_id_, &status)) {
+            result.isAsciiMode = status.is_ascii_mode;
+            rime->free_status(&status);
+        }
+
         return result;
     }
 
@@ -509,6 +568,28 @@ private:
 
 extern "C" {
 
+static jclass gRimeProcessResultClass = nullptr;
+static jmethodID gRimeProcessResultCtor = nullptr;
+static jclass gRimeCandidateClass = nullptr;
+static jmethodID gRimeCandidateCtor = nullptr;
+
+static void ensureJniCache(JNIEnv* env) {
+    if (!gRimeCandidateClass) {
+        jclass cls = env->FindClass("com/kingzcheung/xime/rime/RimeCandidate");
+        gRimeCandidateClass = (jclass)env->NewGlobalRef(cls);
+        gRimeCandidateCtor = env->GetMethodID(gRimeCandidateClass, "<init>",
+            "(Ljava/lang/String;Ljava/lang/String;)V");
+        env->DeleteLocalRef(cls);
+    }
+    if (!gRimeProcessResultClass) {
+        jclass cls = env->FindClass("com/kingzcheung/xime/rime/RimeProcessResult");
+        gRimeProcessResultClass = (jclass)env->NewGlobalRef(cls);
+        gRimeProcessResultCtor = env->GetMethodID(gRimeProcessResultClass, "<init>",
+            "(ZLjava/lang/String;Ljava/lang/String;[Lcom/kingzcheung/xime/rime/RimeCandidate;ZZZ)V");
+        env->DeleteLocalRef(cls);
+    }
+}
+
 // 初始化 Rime 引擎
 JNIEXPORT void JNICALL
 Java_com_kingzcheung_xime_rime_RimeEngine_nativeInitialize(
@@ -573,6 +654,49 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeProcessKey(
     jint mask
 ) {
     return Rime::Instance().processKey(keycode, mask) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jobject JNICALL
+Java_com_kingzcheung_xime_rime_RimeEngine_nativeProcessKeyAndGetResult(
+    JNIEnv* env,
+    jobject thiz,
+    jint keycode,
+    jint mask
+) {
+    ensureJniCache(env);
+
+    ProcessResult result = Rime::Instance().processKeyAndGetResult(keycode, mask);
+
+    jobjectArray candidateArray = env->NewObjectArray(
+        result.candidates.size(), gRimeCandidateClass, nullptr);
+
+    for (size_t i = 0; i < result.candidates.size(); ++i) {
+        jstring text = env->NewStringUTF(result.candidates[i].first.c_str());
+        jstring comment = env->NewStringUTF(result.candidates[i].second.c_str());
+        jobject candidate = env->NewObject(gRimeCandidateClass, gRimeCandidateCtor, text, comment);
+        env->SetObjectArrayElement(candidateArray, i, candidate);
+        env->DeleteLocalRef(text);
+        env->DeleteLocalRef(comment);
+        env->DeleteLocalRef(candidate);
+    }
+
+    jstring jCommitted = env->NewStringUTF(result.committedText.c_str());
+    jstring jInput = env->NewStringUTF(result.inputText.c_str());
+
+    jobject jResult = env->NewObject(gRimeProcessResultClass, gRimeProcessResultCtor,
+        result.processed ? JNI_TRUE : JNI_FALSE,
+        jCommitted,
+        jInput,
+        candidateArray,
+        result.isAsciiMode ? JNI_TRUE : JNI_FALSE,
+        result.hasNextPage ? JNI_TRUE : JNI_FALSE,
+        result.hasPrevPage ? JNI_TRUE : JNI_FALSE);
+
+    env->DeleteLocalRef(jCommitted);
+    env->DeleteLocalRef(jInput);
+    env->DeleteLocalRef(candidateArray);
+
+    return jResult;
 }
 
 // 获取候选词列表

--- a/patches/lua.patch
+++ b/patches/lua.patch
@@ -1,0 +1,13 @@
+diff --git a/lua5.4/liolib.c b/lua5.4/liolib.c
+index b08397d..2815fa5 100644
+--- a/lua5.4/liolib.c
++++ b/lua5.4/liolib.c
+@@ -115,7 +115,8 @@ static int l_checkmode (const char *mode) {
+
+ #if !defined(l_fseek)		/* { */
+
+-#if defined(LUA_USE_POSIX)	/* { */
++#if defined(LUA_USE_POSIX) && \
++   (!defined(ANDROID) || (defined(__LP64__) || ANDROID_PLATFORM >= 24))	/* { */
+
+ #include <sys/types.h>


### PR DESCRIPTION
- 在 pinyin_simp 和 wubi86 方案中添加 lua_translator 支持
- 移除对 assets 中 schema 文件的 Lua 翻译器过滤逻辑
- 改进部署完整性检测，增加对源文件时间戳的比较
- 支持 .lua 文件的资源复制
- 应用 Android 32 位设备的 Lua 5.4 兼容性补丁
- 重构 CMake 配置以使用模块化方式引入 Rime