### PR TITLE
feat(keyboard): 添加长按功能支持数字键盘切换到符号模式

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -5,6 +5,8 @@
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime-lua" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime-lua-deps" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime-octagram" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime-predict" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/glog" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/googletest" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/leveldb" vcs="Git" />
@@ -13,6 +15,8 @@
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/marisa-trie" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/opencc" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/yaml-cpp" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/plugins/lua" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/plugins/lua/thirdparty" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy/third_party/benchmark" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy/third_party/googletest" vcs="Git" />

--- a/app/src/main/java/com/kingzcheung/xime/ui/EnglishKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/EnglishKeyboardLayout.kt
@@ -258,8 +258,9 @@ fun EnglishKeyboardLayout(
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         KeyButton(
-                            text = "123",
+                            text = "?123",
                             onClick = { onKeyPress("mode_change") },
+                            onLongClick = { onKeyPress("mode_change_symbol") },
                             backgroundColor = specialKeyBackgroundColor,
                             textColor = keyTextColor,
                             modifier = Modifier.weight(1.2f),
@@ -562,6 +563,7 @@ private fun LandscapeEnglishKeyboardContent(
                 KeyButton(
                     text = "123",
                     onClick = { onKeyPress("mode_change") },
+                    onLongClick = { onKeyPress("mode_change_symbol") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyButton.kt
@@ -79,6 +79,8 @@ fun KeyButton(
     onSwipeStateChange: ((SwipeState) -> Unit)? = null,
     fontSize: androidx.compose.ui.unit.TextUnit? = null,
     onPress: (() -> Unit)? = null,
+    /** 长按回调（含震动反馈），点按仍走 [onClick] */
+    onLongClick: (() -> Unit)? = null,
     shadowEnabled: Boolean = true,
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
@@ -90,8 +92,13 @@ fun KeyButton(
     var hasTriggeredSwipeDown by remember { mutableStateOf(false) }
     var isSwiping by remember { mutableStateOf(false) }
     var isSwipeDown by remember { mutableStateOf(false) }
+    /** 防止拖动手势和长按手势双重点击 */
+    var longPressActivated by remember { mutableStateOf(false) }
     
     val density = LocalDensity.current
+    val view = LocalView.current
+    val currentOnClick by rememberUpdatedState(onClick)
+    val currentOnLongClick by rememberUpdatedState(onLongClick)
     val swipeUpThreshold = with(density) { (-30).dp.toPx() }
     val swipeDownThreshold = with(density) { 30.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
@@ -136,8 +143,8 @@ fun KeyButton(
                         onPress?.invoke()
                     },
                     onDragEnd = {
-                        if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown && abs(dragOffsetX) < 5.dp.toPx() && dragOffsetY > swipeUpThreshold && dragOffsetY < swipeDownThreshold) {
-                            onClick()
+                        if (!longPressActivated && !hasTriggeredSwipeUp && !hasTriggeredSwipeDown && abs(dragOffsetX) < 5.dp.toPx() && dragOffsetY > swipeUpThreshold && dragOffsetY < swipeDownThreshold) {
+                            currentOnClick()
                         }
                         isPressed = false
                         dragOffsetX = 0f
@@ -146,6 +153,7 @@ fun KeyButton(
                         hasTriggeredSwipeDown = false
                         isSwiping = false
                         isSwipeDown = false
+                        longPressActivated = false
                         onSwipeStateChange?.invoke(SwipeState(false, null, false))
                     },
                     onDragCancel = {
@@ -196,18 +204,43 @@ fun KeyButton(
                     }
                 )
             }
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onPress = {
-                        isPressed = true
-                        onPress?.invoke()
-                        tryAwaitRelease()
-                        isPressed = false
-                    },
-                    onTap = {
-                        if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown) onClick()
-                    }
-                )
+            .pointerInput(currentOnLongClick) {
+                if (currentOnLongClick == null) {
+                    // 无长按时使用简单点击检测
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            onPress?.invoke()
+                            tryAwaitRelease()
+                            isPressed = false
+                        },
+                        onTap = {
+                            if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown) onClick()
+                        }
+                    )
+                } else {
+                    // 有长按回调：利用 detectTapGestures 的 onLongPress
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            longPressActivated = false
+                            onPress?.invoke()
+                            tryAwaitRelease()
+                            isPressed = false
+                        },
+                        onTap = {
+                            if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown && !longPressActivated) {
+                                currentOnClick()
+                            }
+                            longPressActivated = false
+                        },
+                        onLongPress = {
+                            longPressActivated = true
+                            view.performHapticFeedback(android.view.HapticFeedbackConstants.LONG_PRESS)
+                            currentOnLongClick?.invoke()
+                        }
+                    )
+                }
             },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardLayout.kt
@@ -442,8 +442,9 @@ fun KeyboardLayout(
                             )
                         } else {
                             KeyButton(
-                                text = "123",
+                                text = "?123",
                                 onClick = { onKeyPress("mode_change") },
+                                onLongClick = { onKeyPress("mode_change_symbol") },
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier.weight(1.2f),
@@ -1127,8 +1128,9 @@ private fun LandscapeKeyboardContent(
                     shadowShapeRadius = shadowShapeRadius,
                 )
                 KeyButton(
-                    text = "123",
+                    text = "?123",
                     onClick = { onKeyPress("mode_change") },
+                    onLongClick = { onKeyPress("mode_change_symbol") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
@@ -303,6 +303,7 @@ fun KeyboardView(
                             "mode_change" -> keyboardState = keyboardState.transition(
                                 KeyboardLayoutAction.SwitchToNumber, isAsciiMode
                             )
+                            "mode_change_symbol" -> currentRoute = KeyboardRoute.Symbol
                             "emoji" -> currentRoute = KeyboardRoute.Emoji
                             else -> onKeyPress(key, isShifted)
                         }
@@ -322,7 +323,7 @@ fun KeyboardView(
                             "abc" -> keyboardState = keyboardState.transition(
                                 KeyboardLayoutAction.SwitchToFull, isAsciiMode
                             )
-                            "123" -> keyboardState = keyboardState.transition(
+                            "?123" -> keyboardState = keyboardState.transition(
                                 KeyboardLayoutAction.SwitchToNumber, isAsciiMode
                             )
                             else -> onKeyPress(key, false)


### PR DESCRIPTION
- 在KeyButton组件中新增onLongClick参数，支持长按手势检测
- 实现长按震动反馈效果，防止拖动和长按手势冲突
- 英文键盘和普通键盘的"123"按键改为"?123"，长按可切换到符号模式
- 更新键盘状态管理逻辑，添加mode_change_symbol操作类型

chore(vcs): 配置IDEA VCS映射支持新的librime子模块

- 添加librime-octagram和librime-predict的Git映射
- 添加librime插件相关目录的Git映射
- 更新submodule状态标记为dirty