### PR TITLE
feat(keyboard): 添加编辑功能按钮到工具栏

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/keyboard/ToolbarButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/keyboard/ToolbarButton.kt
@@ -1,11 +1,15 @@
 package com.kingzcheung.xime.keyboard
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.ContentCopy
 import androidx.compose.material.icons.twotone.ContentPaste
 import androidx.compose.material.icons.twotone.EmojiEmotions
+import androidx.compose.material.icons.twotone.FirstPage
 import androidx.compose.material.icons.twotone.KeyboardAlt
+import androidx.compose.material.icons.twotone.LastPage
 import androidx.compose.material.icons.twotone.Paid
 import androidx.compose.material.icons.twotone.Quickreply
+import androidx.compose.material.icons.twotone.SelectAll
 import androidx.compose.ui.graphics.vector.ImageVector
 
 enum class ToolbarButton(
@@ -17,7 +21,12 @@ enum class ToolbarButton(
     CLIPBOARD("clipboard", "剪贴板", Icons.TwoTone.ContentPaste),
     SCHEMA("schema", "方案选择", Icons.TwoTone.KeyboardAlt),
     QUICK_PHRASE("quick_phrase", "快捷发送", Icons.TwoTone.Quickreply),
-    SYMBOL("symbol", "符号", Icons.TwoTone.Paid);
+    SYMBOL("symbol", "符号", Icons.TwoTone.Paid),
+    SELECT_ALL("select_all", "全选", Icons.TwoTone.SelectAll),
+    COPY("copy", "复制", Icons.TwoTone.ContentCopy),
+    PASTE("paste", "黏贴", Icons.TwoTone.ContentPaste),
+    HOME("home", "段首", Icons.TwoTone.FirstPage),
+    END("end", "段尾", Icons.TwoTone.LastPage);
 
     companion object {
         val DEFAULT_VISIBLE = emptySet<ToolbarButton>()

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -654,6 +654,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 @Suppress("DEPRECATION")
                                 imm.showInputMethodPicker()
                             },
+                            onToolbarEditingAction = { action ->
+                                handleToolbarEditingAction(action)
+                            },
                             associationCandidates = if (state.pendingEnglishText.isNotEmpty()) {
                                 arrayOf(state.pendingEnglishText) + state.associationCandidates
                             } else {
@@ -1772,6 +1775,23 @@ onVoiceModeChange = { enabled ->
         }
     }
     
+    private fun handleToolbarEditingAction(action: String) {
+        val ic = currentInputConnection ?: return
+        when (action) {
+            "select_all" -> ic.performContextMenuAction(android.R.id.selectAll)
+            "copy" -> ic.performContextMenuAction(android.R.id.copy)
+            "paste" -> ic.performContextMenuAction(android.R.id.paste)
+            "home" -> {
+                ic.setSelection(0, 0)
+            }
+            "end" -> {
+                val textBefore = ic.getTextBeforeCursor(Int.MAX_VALUE, 0) ?: ""
+                val textAfter = ic.getTextAfterCursor(Int.MAX_VALUE, 0) ?: ""
+                ic.setSelection(textBefore.length + textAfter.length, textBefore.length + textAfter.length)
+            }
+        }
+    }
+
     private fun applyPageSizeSetting(schemaId: String) {
         val userPageSize = SettingsPreferences.getPageSize(this)
         if (userPageSize > 0) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/KeyboardView.kt
@@ -106,6 +106,7 @@ fun KeyboardView(
     onSwitchSchema: ((String) -> Unit)? = null,
     onHideKeyboard: (() -> Unit)? = null,
     onSwitchKeyboard: (() -> Unit)? = null,
+    onToolbarEditingAction: ((String) -> Unit)? = null,
     onCommitImage: ((String) -> Unit)? = null,
     isVoiceMode: Boolean = false,
     voiceBottomActive: Boolean = false,
@@ -222,6 +223,11 @@ fun KeyboardView(
                         ToolbarButton.SCHEMA -> ({ currentRoute = KeyboardRoute.SchemaList })
                         ToolbarButton.QUICK_PHRASE -> ({ currentRoute = KeyboardRoute.Clipboard(1) })
                         ToolbarButton.SYMBOL -> ({ currentRoute = KeyboardRoute.Symbol })
+                        ToolbarButton.SELECT_ALL -> ({ onToolbarEditingAction?.invoke("select_all") })
+                        ToolbarButton.COPY -> ({ onToolbarEditingAction?.invoke("copy") })
+                        ToolbarButton.PASTE -> ({ onToolbarEditingAction?.invoke("paste") })
+                        ToolbarButton.HOME -> ({ onToolbarEditingAction?.invoke("home") })
+                        ToolbarButton.END -> ({ onToolbarEditingAction?.invoke("end") })
                     }
                     ToolbarAction(button, onClick)
                 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/ToolbarCustomizeView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/ToolbarCustomizeView.kt
@@ -134,30 +134,23 @@ fun ToolbarCustomizeView(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .weight(1f)
+                .padding(horizontal = 16.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .background(MaterialTheme.colorScheme.surface)
-                .padding(16.dp)
+                .padding(16.dp,10.dp)
         ) {
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxWidth()
             ) { page ->
                 FlowRow(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                     maxItemsInEachRow = 4
                 ) {
                     pages[page].forEach { button ->
@@ -189,13 +182,13 @@ fun ToolbarCustomizeView(
                                     Icon(
                                         imageVector = button.icon,
                                         contentDescription = button.label,
-                                        tint = if (isEnabled) accentColor else keyTextColor,
+                                        tint = if (isEnabled) accentColor else keyTextColor.copy(alpha = 0.8f),
                                         modifier = Modifier.size(22.dp)
                                     )
                                 }
                                 Text(
                                     text = button.label,
-                                    fontSize = 11.sp,
+                                    fontSize = 10.sp,
                                     color = keyTextColor.copy(alpha = 0.8f),
                                     maxLines = 1
                                 )
@@ -206,7 +199,7 @@ fun ToolbarCustomizeView(
                     }
                 }
             }
-        }        }
+        }
         if (pages.size > 1) {
             Spacer(modifier = Modifier.height(8.dp))
             Row(
@@ -232,3 +225,5 @@ fun ToolbarCustomizeView(
         Spacer(modifier = Modifier.height(if (isLandscape) 15.dp else maxOf(bottomPaddingDp, 40).dp))
     }
 }
+
+


### PR DESCRIPTION
添加了全选、复制、粘贴、段首、段尾等编辑操作按钮到工具栏，
并实现了相应的编辑功能处理逻辑，提升用户输入体验。

- 新增 SELECT_ALL, COPY, PASTE, HOME, END 按钮类型
- 实现编辑操作处理函数 handleToolbarEditingAction
- 在工具栏中集成编辑功能按钮
- 调整自定义工具栏界面布局和样式