### PR TITLE
fix(emoji): 修复表情键盘页面滑动时的状态同步问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/EmojiKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/EmojiKeyboardLayout.kt
@@ -313,9 +313,9 @@ fun EmojiKeyboardLayout(
         }
 
         // Pager 滑动时同步到外部状态
-        LaunchedEffect(pagerState.currentPage) {
+        LaunchedEffect(pagerState.currentPage, pagerState.isScrollInProgress) {
             val page = pagerState.currentPage
-            if (page != currentPageIndex) {
+            if (!pagerState.isScrollInProgress && page != currentPageIndex) {
                 if (page < builtinCategories.size) {
                     selectedTopTabIndex = 0
                     selectedSubCategoryIndex = page


### PR DESCRIPTION
当用户正在滚动分页器时，避免更新当前页面索引以防止状态冲突，
确保只有在滚动完成且页面稳定时才进行状态同步。

更新了 LaunchedEffect 的依赖项以包含 isScrollInProgress 状态，
并在状态更新条件中检查滚动进度。