### PR TITLE
feat(schema-market): 实现方案市场下载安装功能并优化索引格式

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -10,8 +10,8 @@ xime_index:
   # 可替换为自建代理/镜像，下载器按顺序依次尝试，直到成功为止。
   # 末尾需要 /。
   base_urls:
-    - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index/"
-    - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index/"
+    - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index@master/"
     - "https://index.ximei.me/"
     - "https://raw.githubusercontent.com/ximeiorg/xime-index/refs/heads/main/"
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -16,6 +16,7 @@ import java.io.InputStream
 import java.io.InputStreamReader
 import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipFile
 
@@ -33,6 +34,89 @@ object SchemaManager {
 
     fun getRimeDir(context: Context): File =
         File(context.filesDir, "rime")
+
+    /** market 根目录。 */
+    fun getMarketDir(context: Context): File =
+        File(getRimeDir(context), "market")
+
+    /** 每个方案在 market 下的独立子目录：rime/market/{schemeId}/ */
+    fun getMarketDir(context: Context, schemeId: String): File =
+        File(getMarketDir(context), schemeId)
+
+    /** 检查方案的压缩包是否已下载。 */
+    fun isSchemeDownloaded(context: Context, schemeId: String): Boolean {
+        val dir = getMarketDir(context, schemeId)
+        return dir.exists() && (dir.listFiles()?.any { it.isFile } == true)
+    }
+
+    /** 删除 market 中指定方案的整个子目录（含压缩包）。 */
+    fun deleteSchemeArchive(context: Context, schemeId: String): Boolean {
+        val dir = getMarketDir(context, schemeId)
+        if (!dir.exists()) return false
+        return dir.deleteRecursively()
+    }
+
+    /** 在 market/{schemeId}/ 中查找已下载的文件。 */
+    fun findMarketFile(context: Context, schemeId: String): File? {
+        val dir = getMarketDir(context, schemeId)
+        if (!dir.exists()) return null
+        return dir.listFiles()?.firstOrNull { it.isFile }
+    }
+
+    /**
+     * 从 market 目录安装方案到 rime 目录：
+     * - .zip / .tar.gz / .tgz → 解压
+     * - 其他文件 → 直接复制
+     */
+    /**
+     * 从 market/{schemeId}/ 安装所有已下载文件到 rime 目录：
+     * - .zip / .tar.gz / .tgz → 解压
+     * - 其他文件 → 直接复制
+     */
+    fun installFromMarketToRime(context: Context, schemeId: String): Boolean {
+        val dir = getMarketDir(context, schemeId)
+        if (!dir.exists()) return false
+        val files = dir.listFiles()?.filter { it.isFile } ?: return false
+        if (files.isEmpty()) return false
+        val rimeDir = getRimeDir(context)
+        if (!rimeDir.exists()) rimeDir.mkdirs()
+        var allOk = true
+        for (file in files) {
+            try {
+                val name = file.name
+                // 解压前先校验压缩包完整性
+                val isArchive = name.endsWith(".zip", ignoreCase = true) ||
+                    name.endsWith(".tar.gz", ignoreCase = true) || name.endsWith(".tgz", ignoreCase = true)
+                if (isArchive && !validateArchive(file)) {
+                    Log.e(TAG, "installFromMarketToRime: ${file.name} is corrupted for $schemeId, deleting")
+                    file.delete()
+                    allOk = false
+                    continue
+                }
+                val ok = when {
+                    name.endsWith(".zip", ignoreCase = true) -> importZipFromFile(file, rimeDir)
+                    name.endsWith(".tar.gz", ignoreCase = true) || name.endsWith(".tgz", ignoreCase = true) ->
+                        importTarGzFromFile(file, rimeDir)
+                    else -> {
+                        val target = File(rimeDir, file.name)
+                        file.copyTo(target, overwrite = true)
+                        Log.i(TAG, "Copied ${file.name} to rime dir")
+                        true
+                    }
+                }
+                if (!ok) {
+                    Log.e(TAG, "installFromMarketToRime: failed to process ${file.name} for $schemeId, deleting")
+                    file.delete()
+                    allOk = false
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "installFromMarketToRime: error processing ${file.name} for $schemeId, deleting", e)
+                file.delete()
+                allOk = false
+            }
+        }
+        return allOk
+    }
 
     private fun getBuildDir(context: Context): File =
         File(getRimeDir(context), "build")
@@ -473,14 +557,123 @@ object SchemaManager {
     }
 
     /**
+     * 从 URL 下载文件到 market/{schemeId}/ 目录（仅下载，不解压）。
+     * 支持任意文件类型（zip、tar.gz、yaml 等）。
+     */
+    /** 下载结果：success + sha256 校验状态（null=未提供, true=通过, false=不通过）。 */
+    data class DownloadResult(val success: Boolean, val sha256Verified: Boolean? = null)
+
+    suspend fun downloadToMarket(
+        context: Context,
+        url: String,
+        schemeId: String,
+        fileName: String,
+        expectedSha256: String? = null,
+        onProgress: (Long, Long) -> Unit = { _, _ -> },
+    ): DownloadResult = withContext(Dispatchers.IO) {
+        try {
+            val schemeDir = getMarketDir(context, schemeId)
+            if (!schemeDir.exists()) schemeDir.mkdirs()
+            val targetFile = File(schemeDir, fileName)
+
+            val client = OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
+                .followRedirects(true)
+                .build()
+            client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Log.e(TAG, "Download failed: ${response.code} $url")
+                    return@withContext DownloadResult(false)
+                }
+                val body = response.body ?: return@withContext DownloadResult(false)
+                val totalBytes = body.contentLength()
+                var downloadedBytes = 0L
+                val md = if (!expectedSha256.isNullOrBlank()) MessageDigest.getInstance("SHA-256") else null
+                body.byteStream().use { input ->
+                    FileOutputStream(targetFile).use { output ->
+                        val buf = ByteArray(8192)
+                        var n = input.read(buf)
+                        while (n >= 0) {
+                            output.write(buf, 0, n)
+                            md?.update(buf, 0, n)
+                            downloadedBytes += n
+                            if (totalBytes > 0) onProgress(downloadedBytes, totalBytes)
+                            n = input.read(buf)
+                        }
+                    }
+                }
+                if (md != null && !expectedSha256.isNullOrBlank()) {
+                    val actual = md.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+                    if (!actual.equals(expectedSha256.trim(), ignoreCase = true)) {
+                        Log.e(TAG, "sha256 mismatch for $url: expected=${expectedSha256.trim()} actual=$actual")
+                        targetFile.delete()
+                        return@withContext DownloadResult(false, sha256Verified = false)
+                    }
+                    Log.i(TAG, "Downloaded (sha256 verified): ${targetFile.absolutePath}")
+                    DownloadResult(true, sha256Verified = true)
+                } else {
+                    // 无 sha256：校验压缩包完整性（zip/tar.gz），防止下载不完整
+                    val valid = validateArchive(targetFile)
+                    if (!valid) {
+                        Log.e(TAG, "Archive validation failed for $url, file is corrupted")
+                        targetFile.delete()
+                        return@withContext DownloadResult(false)
+                    }
+                    Log.i(TAG, "Downloaded (unverified, archive validated): ${targetFile.absolutePath}")
+                    DownloadResult(true, sha256Verified = null)
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "downloadToMarket failed: $url", e)
+            // 删除可能残留的损坏文件
+            val schemeDir = getMarketDir(context, schemeId)
+            val targetFile = File(schemeDir, fileName)
+            if (targetFile.exists()) targetFile.delete()
+            DownloadResult(false)
+        }
+    }
+
+    /**
+     * 验证压缩包完整性：zip 尝试列出条目，tar.gz 尝试读取首条。
+     * 非归档文件直接返回 true（无法校验）。
+     */
+    private fun validateArchive(file: File): Boolean {
+        val name = file.name
+        return try {
+            when {
+                name.endsWith(".zip", ignoreCase = true) -> {
+                    java.util.zip.ZipFile(file).use { zip -> zip.entries().hasMoreElements() }
+                }
+                name.endsWith(".tar.gz", ignoreCase = true) || name.endsWith(".tgz", ignoreCase = true) -> {
+                    org.apache.commons.compress.archivers.tar.TarArchiveInputStream(
+                        java.util.zip.GZIPInputStream(file.inputStream())
+                    ).use { tar -> tar.nextTarEntry != null }
+                }
+                else -> true // 非归档文件无法校验
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Archive validation failed for ${file.name}", e)
+            false
+        }
+    }
+
+    /**
      * 从 URL 下载压缩包并解压进 rime 目录。
      * @param expectedSha256 非空时，下载落临时文件并校验 SHA-256；不符则不落盘、返回 false。
      *                       为空/空白时保持原有行为（不校验）。
+     */
+    /**
+     * 从 URL 下载压缩包到 market 目录（保留压缩包），然后解压到 rime 目录。
+     * @param archiveName 压缩包在 market 目录中保存的文件名，如 "my_scheme.zip"。
+     *                    为空时从 URL 末段自动推断。
      */
     suspend fun importFromUrl(
         context: Context,
         url: String,
         expectedSha256: String? = null,
+        archiveName: String? = null,
+        onProgress: (Long, Long) -> Unit = { _, _ -> },
     ): Boolean = withContext(Dispatchers.IO) {
         try {
             val rimeDir = getRimeDir(context)
@@ -492,6 +685,16 @@ object SchemaManager {
                 Log.e(TAG, "Unsupported format: $url")
                 return@withContext false
             }
+
+            // 确定压缩包保存路径
+            val ext = when {
+                isZip -> ".zip"
+                url.endsWith(".tgz", ignoreCase = true) -> ".tgz"
+                else -> ".tar.gz"
+            }
+            val marketDir = getMarketDir(context)
+            if (!marketDir.exists()) marketDir.mkdirs()
+            val archiveFile = File(marketDir, archiveName ?: (url.substringAfterLast("/").takeIf { it.isNotBlank() } ?: "download$ext"))
 
             val client = OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
@@ -505,32 +708,35 @@ object SchemaManager {
                 }
                 val body = response.body ?: return@withContext false
 
-                // 下载到临时文件并边写边算 SHA-256（先校验，校验通过才解压落盘）
-                val tmp = File.createTempFile("rime_dl_", if (isZip) ".zip" else ".tar.gz", context.cacheDir)
-                try {
-                    val md = MessageDigest.getInstance("SHA-256")
-                    body.byteStream().use { input ->
-                        FileOutputStream(tmp).use { output ->
-                            val buf = ByteArray(8192)
-                            var n = input.read(buf)
-                            while (n >= 0) {
-                                output.write(buf, 0, n)
-                                md.update(buf, 0, n)
-                                n = input.read(buf)
+                // 下载到 market 目录的压缩包文件，边写边算 SHA-256
+                val totalBytes = body.contentLength()
+                var downloadedBytes = 0L
+                val md = MessageDigest.getInstance("SHA-256")
+                body.byteStream().use { input ->
+                    FileOutputStream(archiveFile).use { output ->
+                        val buf = ByteArray(8192)
+                        var n = input.read(buf)
+                        while (n >= 0) {
+                            output.write(buf, 0, n)
+                            md.update(buf, 0, n)
+                            downloadedBytes += n
+                            if (totalBytes > 0) {
+                                onProgress(downloadedBytes, totalBytes)
                             }
+                            n = input.read(buf)
                         }
                     }
-                    if (!expectedSha256.isNullOrBlank()) {
-                        val actual = md.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
-                        if (!actual.equals(expectedSha256.trim(), ignoreCase = true)) {
-                            Log.e(TAG, "sha256 mismatch for $url: expected=${expectedSha256.trim()} actual=$actual")
-                            return@withContext false
-                        }
-                    }
-                    if (isZip) importZipFromFile(tmp, rimeDir) else importTarGzFromFile(tmp, rimeDir)
-                } finally {
-                    tmp.delete()
                 }
+                if (!expectedSha256.isNullOrBlank()) {
+                    val actual = md.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+                    if (!actual.equals(expectedSha256.trim(), ignoreCase = true)) {
+                        Log.e(TAG, "sha256 mismatch for $url: expected=${expectedSha256.trim()} actual=$actual")
+                        archiveFile.delete()
+                        return@withContext false
+                    }
+                }
+                // 解压到 rime 目录
+                if (isZip) importZipFromFile(archiveFile, rimeDir) else importTarGzFromFile(archiveFile, rimeDir)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to import from URL: $url", e)

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexModels.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexModels.kt
@@ -28,6 +28,17 @@ data class IndexSource(
     val description: String = "",
 )
 
+/**
+ * 扁平索引格式：schemas 直接内联 MarketScheme 对象列表。
+ * 对应 rimes/index.yaml（由 scripts/generate_index.py 生成）。
+ */
+@Serializable
+data class SchemasDirectIndex(
+    @SerialName("index_version") val indexVersion: Int = 1,
+    @SerialName("updated_at") val updatedAt: String = "",
+    val schemas: List<MarketScheme> = emptyList(),
+)
+
 @Serializable
 data class SchemesSubIndex(
     @SerialName("index_version") val indexVersion: Int = 1,

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexParser.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexParser.kt
@@ -17,6 +17,10 @@ object XimeIndexParser {
     fun parseSubIndex(text: String): SchemesSubIndex =
         yaml.decodeFromString(SchemesSubIndex.serializer(), text)
 
+    /** 解析扁平索引（rimes/index.yaml），其中 schemas 直接内联 MarketScheme 列表。 */
+    fun parseDirectIndex(text: String): SchemasDirectIndex =
+        yaml.decodeFromString(SchemasDirectIndex.serializer(), text)
+
     fun parseScheme(text: String): MarketScheme =
         yaml.decodeFromString(MarketScheme.serializer(), migrateDownloadUrl(text))
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -10,11 +10,16 @@ import okhttp3.Request
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
-/** 安装结果（带失败原因 + 未解决依赖，供 ViewModel 映射文案）。 */
+/** 下载校验状态：null=未提供sha256, true=校验通过, false=校验不通过。 */
+typealias Sha256Status = Boolean?
+
+/** 安装结果（带失败原因 + 未解决依赖 + sha256 校验状态）。 */
 data class InstallResult(
     val success: Boolean,
     val unresolvedDeps: List<String> = emptyList(),
     val failureReason: String? = null,
+    /** null=未提供sha256, true=校验通过, false=校验不通过 */
+    val sha256Status: Sha256Status = null,
 )
 
 /** 方案列表拉取结果（含命中的来源主机名，供 UI 显示「从哪个端点拉的」）。 */
@@ -24,9 +29,9 @@ data class SchemesFetch(
 )
 
 /**
- * 方案市场数据源：读取 ximeiorg/xime-index 精选索引（根→子→逐方案，CDN 优先 + raw 回退），
- * 并按版本 sha256 安装；安装后用 [RimeDependencyResolver] 按索引声明的 dependencies 补齐编译依赖。
- * 网络/Android 依赖集中在此层；解析/版本/路径/兼容性逻辑都在 [XimeIndexParser] 纯函数里。
+ * 方案市场数据源：从镜像基址的 rimes/index.yaml（扁平索引，schemas 内联所有 MarketScheme）
+ * 获取方案列表，按版本 sha256 下载；安装后用 [RimeDependencyResolver] 补齐编译依赖。
+ * 网络/Android 依赖集中在此层；解析/版本/兼容性逻辑在 [XimeIndexParser] 纯函数里。
  *
  * 端点列表通过 [xime.yaml] 的 `xime_index.base_urls` 配置，用户可自定义镜像列表。
  */
@@ -81,36 +86,24 @@ object XimeIndexSource {
             }
         }
 
-    /** 尝试从一个镜像基址获取完整方案列表。获取到空方案不计为成功，返回 null 让外层试下一个镜像。 */
+    /**
+     * 尝试从一个镜像基址获取方案列表。
+     * 新索引格式：直接抓取 rimes/index.yaml，其中 schemas 已内联所有 MarketScheme。
+     */
     private fun tryFetchFromBase(base: String, appVersion: String): SchemesFetch? {
-        val repoPath = "index.yaml"
+        val repoPath = "rimes/index.yaml"
         val host = hostOf(base)
         try {
-            val rootText = fetchTextSingle(base, repoPath) ?: return null
-            val root = XimeIndexParser.parseIndex(rootText)
-            val subPath = XimeIndexParser.resolveRepoPath(
-                repoPath, root.schemas?.from ?: "./rimes/index.yaml",
-            )
-            val subText = fetchTextSingle(base, subPath) ?: return null
-            val sub = XimeIndexParser.parseSubIndex(subText)
-
-            // 方案文件从所有镜像获取（按顺序轮询），避免单个 CDN 频率限制
-            val schemeTexts = sub.schemas.mapNotNull { entry ->
-                val p = XimeIndexParser.resolveRepoPath(subPath, entry.file)
-                fetchTextAnyMirror(p)
-            }
-            Log.d(TAG, "tryFetchFromBase $host: 子索引共 ${sub.schemas.size} 条，获取到 ${schemeTexts.size} 个方案文件")
-            val schemes = schemeTexts.mapNotNull { text ->
-                runCatching { XimeIndexParser.parseScheme(text) }.getOrNull()
-            }.distinctBy { it.id }
+            val text = fetchTextSingle(base, repoPath) ?: return null
+            val direct = XimeIndexParser.parseDirectIndex(text)
+            val schemes = direct.schemas.distinctBy { it.id }
                 .map { XimeIndexParser.toItem(it, appVersion) }
-            Log.d(TAG, "tryFetchFromBase $host: 解析后 ${schemes.size} 个方案: ${schemes.map { it.scheme.id }}")
+            Log.i(TAG, "tryFetchFromBase $host: 获取到 ${schemes.size} 个方案（扁平索引）")
 
             if (schemes.isEmpty()) {
-                Log.w(TAG, "tryFetchFromBase $host: 获取到 0 个方案，尝试下一个镜像")
+                Log.w(TAG, "tryFetchFromBase $host: 0 个方案，尝试下一个镜像")
                 return null
             }
-            Log.i(TAG, "tryFetchFromBase $host: 获取到 ${schemes.size} 个方案")
             return SchemesFetch(schemes, host)
         } catch (e: Exception) {
             Log.w(TAG, "tryFetchFromBase $host failed: ${e.message}")
@@ -118,7 +111,7 @@ object XimeIndexSource {
         }
     }
 
-    /** 从单一镜像基址获取文件内容，失败返回 null（不抛异常）。 */
+    /** 从镜像基址获取文件内容，失败返回 null。 */
     private fun fetchTextSingle(base: String, repoPath: String): String? {
         return try {
             client.newCall(Request.Builder().url(base + repoPath).build()).execute().use { resp ->
@@ -132,40 +125,86 @@ object XimeIndexSource {
         }
     }
 
-    /** 在所有镜像中查找文件，返回第一个成功获取的内容。 */
-    private fun fetchTextAnyMirror(repoPath: String): String? {
-        for (base in mirrors) {
-            val result = fetchTextSingle(base, repoPath)
-            if (result != null) return result
+    /**
+     * 下载一个方案到 market 目录（仅下载，不解压）。
+     * 遍历所有 downloadUrl（如主包 + 语言模型等），逐一下载到 market/{schemeId}/。
+     */
+    suspend fun downloadScheme(
+        context: Context,
+        scheme: MarketScheme,
+        onDownloadProgress: (Long, Long) -> Unit = { _, _ -> },
+    ): InstallResult = withContext(Dispatchers.IO) {
+        val v = scheme.resolvedVersion()
+            ?: return@withContext InstallResult(false, failureReason = "无可用版本")
+        if (v.downloadUrls.isEmpty() || v.downloadUrls.all { it.url.isBlank() }) {
+            return@withContext InstallResult(false, failureReason = "缺少下载地址")
         }
-        return null
+
+        // 汇总所有文件的校验状态
+        var anyFailed = false
+        var anyMismatch = false
+        var anyVerified = false
+
+        data class DlItem(val item: DownloadItem, val fileName: String, val sizeBytes: Long)
+        val items = v.downloadUrls.filter { it.url.isNotBlank() }.map { dl ->
+            val fn = dl.url.substringAfterLast('/').takeIf { it.isNotBlank() }
+                ?: "file.${dl.url.substringAfterLast('.').takeIf { it.length in 1..6 } ?: "bin"}"
+            val bytes = dl.size.removeSuffix(" MB").trim().toDoubleOrNull()
+                ?.let { (it * 1024.0 * 1024.0).toLong() } ?: 0L
+            DlItem(dl, fn, bytes)
+        }
+        val totalBytesAll = items.sumOf { it.sizeBytes }
+        var accumulatedBytes = 0L
+
+        for ((dl, fn, sz) in items) {
+            val result = SchemaManager.downloadToMarket(
+                context, dl.url, scheme.id, fn, dl.sha256.takeIf { it.isNotBlank() },
+                onProgress = { read, _ ->
+                    // 跨文件合并进度：前序文件已下载完 + 当前文件进度
+                    val overall = accumulatedBytes + read
+                    if (totalBytesAll > 0) onDownloadProgress(overall, totalBytesAll)
+                },
+            )
+            accumulatedBytes += sz
+            if (!result.success) {
+                anyFailed = true
+                if (result.sha256Verified == false) anyMismatch = true
+            } else if (result.sha256Verified == true) {
+                anyVerified = true
+            }
+        }
+
+        if (anyFailed) {
+            val reason = when {
+                anyMismatch -> "文件校验失败（sha256 不匹配），部分文件可能不完整"
+                else -> "下载失败"
+            }
+            return@withContext InstallResult(false, failureReason = reason, sha256Status = if (anyMismatch) false else null)
+        }
+        InstallResult(success = true, sha256Status = if (anyVerified) true else null)
     }
 
     /**
-     * 安装一个方案：按版本 downloadUrl（+sha256）落盘，再按索引声明依赖补齐编译依赖。
-     * @param resolveDepUrl 依赖包 id → 下载 URL（由调用方从已取的方案列表构造）。
+     * 从 market 目录安装已下载的方案到 rime 目录（解压/复制 + 依赖补齐）。
+     * 返回安装结果，调用方据此更新已安装列表。
      */
-    suspend fun installScheme(
+    suspend fun installFromMarket(
         context: Context,
         scheme: MarketScheme,
         resolveDepUrl: (String) -> String? = { null },
     ): InstallResult = withContext(Dispatchers.IO) {
-        val v = scheme.resolvedVersion()
-            ?: return@withContext InstallResult(false, failureReason = "无可用版本")
-        val first = v.downloadUrls.firstOrNull()
-        if (first == null || first.url.isBlank()) {
-            return@withContext InstallResult(false, failureReason = "缺少下载地址")
+        if (!SchemaManager.isSchemeDownloaded(context, scheme.id)) {
+            return@withContext InstallResult(false, failureReason = "压缩包不存在，请先下载")
         }
-
         val before = SchemaManager.discoverSchemas(context).map { it.schemaId }.toSet()
-        val ok = SchemaManager.importFromUrl(context, first.url, first.sha256)
-        if (!ok) return@withContext InstallResult(false, failureReason = "安装失败或文件校验失败")
+        val ok = SchemaManager.installFromMarketToRime(context, scheme.id)
+        if (!ok) return@withContext InstallResult(false, failureReason = "安装失败")
 
-        // 找到新落盘的真实 rime schema id（索引 id 不保证等于 rime schema_id / 文件名）
+        // 找到新落盘的真实 rime schema id
         val after = SchemaManager.discoverSchemas(context).map { it.schemaId }.toSet()
         val newSchemaId = (after - before).firstOrNull() ?: scheme.id
 
-        // 依赖补齐（不剥离）：按索引声明的 dependencies 递归补齐，让方案带反查完整编译
+        // 依赖补齐
         val completion = RimeDependencyResolver.complete(
             context = context,
             schemaId = newSchemaId,
@@ -173,7 +212,7 @@ object XimeIndexSource {
             resolveUrl = resolveDepUrl,
         )
         val unresolved = (completion.unresolved + completion.stillMissingFiles).distinct()
-        if (unresolved.isNotEmpty()) Log.w(TAG, "install ${scheme.id}: unresolved=$unresolved")
+        if (unresolved.isNotEmpty()) Log.w(TAG, "installFromMarket ${scheme.id}: unresolved=$unresolved")
         InstallResult(success = true, unresolvedDeps = unresolved)
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/SettingsScreen.kt
@@ -11,6 +11,7 @@ import com.kingzcheung.xime.ui.settings.KeyEffectSettingsContent
 import com.kingzcheung.xime.ui.settings.LayoutDisplaySettingsContent
 import com.kingzcheung.xime.ui.settings.PluginSettingsContent
 import com.kingzcheung.xime.ui.settings.SchemaMarketContent
+import com.kingzcheung.xime.ui.settings.SchemaMarketDetailContent
 import com.kingzcheung.xime.ui.settings.SchemaSettingsContent
 import com.kingzcheung.xime.ui.settings.SettingsMainContent
 import com.kingzcheung.xime.ui.settings.SettingsRoutes
@@ -64,7 +65,20 @@ fun SettingsScreen(
         }
         composable(SettingsRoutes.SchemaMarket) {
             SchemaMarketContent(
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                onNavigateToDetail = { schemeId ->
+                    navController.navigate("schema_market_detail/$schemeId")
+                },
+            )
+        }
+        composable(
+            route = SettingsRoutes.SchemaMarketDetail,
+            arguments = listOf(navArgument("schemeId") { type = NavType.StringType }),
+        ) { backStackEntry ->
+            val schemeId = backStackEntry.arguments?.getString("schemeId") ?: return@composable
+            SchemaMarketDetailContent(
+                schemeId = schemeId,
+                onBack = { navController.popBackStack() },
             )
         }
         composable(SettingsRoutes.Theme) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
@@ -29,6 +30,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -49,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -62,6 +65,7 @@ import com.kingzcheung.xime.viewmodel.SchemaMarketViewModel
 @Composable
 fun SchemaMarketContent(
     onBack: () -> Unit,
+    onNavigateToDetail: (String) -> Unit = {},
 ) {
     val context = LocalContext.current
     val viewModel: SchemaMarketViewModel = viewModel()
@@ -188,11 +192,17 @@ fun SchemaMarketContent(
                     items(uiState.filteredSchemes, key = { it.scheme.id }) { item ->
                         SchemeCard(
                             item = item,
-                            installing = uiState.installingId == item.scheme.id,
+                            downloading = uiState.downloadingId == item.scheme.id,
+                            downloadProgress = uiState.downloadProgress,
+                            extracting = uiState.extractingId == item.scheme.id,
+                            downloaded = item.scheme.id in uiState.downloadedIds,
                             installed = item.scheme.id in uiState.installedIds,
+                            sha256Status = uiState.sha256Status[item.scheme.id],
                             deploying = uiState.isDeploying,
-                            onInstall = { viewModel.installScheme(item) },
+                            onDownload = { viewModel.downloadScheme(item) },
+                            onInstall = { viewModel.installFromMarket(item) },
                             onDeploy = { viewModel.deploy() },
+                            onDelete = { viewModel.deleteDownloadedScheme(item.scheme.id) },
                         )
                     }
                     item {
@@ -220,11 +230,17 @@ private fun CenterBox(content: @Composable () -> Unit) {
 @Composable
 private fun SchemeCard(
     item: MarketSchemeItem,
-    installing: Boolean,
+    downloading: Boolean,
+    downloadProgress: Float,
+    extracting: Boolean,
+    downloaded: Boolean,
     installed: Boolean,
+    sha256Status: Boolean?,
     deploying: Boolean,
+    onDownload: () -> Unit,
     onInstall: () -> Unit,
     onDeploy: () -> Unit,
+    onDelete: () -> Unit = {},
 ) {
     val scheme = item.scheme
     Card(
@@ -232,6 +248,7 @@ private fun SchemeCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
         Column(modifier = Modifier.padding(14.dp)) {
+            // 标题行：名称 + 版本号（无v前缀）
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     scheme.name.ifEmpty { scheme.id },
@@ -239,11 +256,19 @@ private fun SchemeCard(
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, fill = false),
                 )
+                if (scheme.currentVersion.isNotEmpty()) {
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        scheme.currentVersion,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
                 if (scheme.type == "built-in") {
-                    Tag("内置")
                     Spacer(Modifier.width(6.dp))
+                    Tag("内置")
                 }
             }
             if (scheme.description.isNotEmpty()) {
@@ -256,28 +281,74 @@ private fun SchemeCard(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Spacer(Modifier.height(6.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                if (scheme.author.isNotEmpty()) {
-                    Text(
-                        scheme.author,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                    Spacer(Modifier.width(12.dp))
+            // 作者
+            if (scheme.author.isNotEmpty()) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    "作者：${scheme.author}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            // 标签（逗号分隔）
+            if (scheme.tags.isNotEmpty()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    scheme.tags.joinToString("、"),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            // 依赖
+            if (scheme.dependencies.isNotEmpty()) {
+                Spacer(Modifier.height(6.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    scheme.dependencies.take(4).forEach { dep ->
+                        Tag(dep)
+                    }
                 }
-                if (scheme.currentVersion.isNotEmpty()) {
+            }
+            // APP 版本要求
+            if (scheme.appVersion.isNotEmpty()) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    "APP 版本要求 ：${scheme.appVersion}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            // 许可证
+            if (scheme.license.isNotEmpty()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    scheme.license,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            // 警告
+            if (scheme.warning.isNotEmpty()) {
+                Spacer(Modifier.height(6.dp))
+                Surface(
+                    shape = RoundedCornerShape(6.dp),
+                    color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f),
+                ) {
                     Text(
-                        "v${scheme.currentVersion}",
+                        scheme.warning,
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.outline,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
                     )
                 }
             }
-            if (scheme.tags.isNotEmpty()) {
+            if (downloaded) {
                 Spacer(Modifier.height(6.dp))
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    scheme.tags.take(4).forEach { Tag(it) }
+                    when (sha256Status) {
+                        true -> VerificationTag("已校验", MaterialTheme.colorScheme.primary)
+                        false -> VerificationTag("校验失败", MaterialTheme.colorScheme.error)
+                        null -> VerificationTag("未验证", MaterialTheme.colorScheme.outline)
+                    }
                 }
             }
             Spacer(Modifier.height(10.dp))
@@ -287,18 +358,66 @@ private fun SchemeCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 when {
-                    installing -> {
-                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                        Spacer(Modifier.width(8.dp))
-                        Text("安装中…", style = MaterialTheme.typography.labelMedium)
+                    downloading -> {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.End,
+                        ) {
+                            if (downloadProgress > 0f) {
+                                LinearProgressIndicator(
+                                    progress = { downloadProgress },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(bottom = 6.dp)
+                                        .height(4.dp)
+                                        .clip(RoundedCornerShape(2.dp)),
+                                )
+                            }
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    "下载中 ${(downloadProgress * 100).toInt()}%",
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            }
+                        }
+                    }
+
+                    extracting -> {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                            Spacer(Modifier.width(8.dp))
+                            Text("安装中…", style = MaterialTheme.typography.labelMedium)
+                        }
                     }
 
                     !item.compatible -> OutlinedButton(onClick = {}, enabled = false) {
                         Text("需 App ≥ ${item.minAppVersion}")
                     }
 
+                    downloaded && !installed -> Button(onClick = onInstall) {
+                        Text("安装")
+                    }
+
                     installed -> {
-                        OutlinedButton(onClick = onInstall) { Text("重新安装") }
+                        Row(
+                            modifier = Modifier.weight(1f),
+                            horizontalArrangement = Arrangement.Start,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            OutlinedButton(onClick = onDownload) { Text("重新下载") }
+                            Spacer(Modifier.width(4.dp))
+                            IconButton(
+                                onClick = onDelete,
+                                modifier = Modifier.size(36.dp),
+                            ) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = "删除压缩包",
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        }
                         Spacer(Modifier.width(8.dp))
                         if (deploying) {
                             CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
@@ -309,15 +428,24 @@ private fun SchemeCard(
                         }
                     }
 
-                    else -> Button(onClick = onInstall) {
+                    else -> Button(onClick = onDownload) {
                         Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(Modifier.width(6.dp))
-                        Text("安装")
+                        Text("下载")
                     }
                 }
             }
         }
     }
+}
+
+/** 方案详情占位页（待实现）。 */
+@Composable
+fun SchemaMarketDetailContent(
+    schemeId: String,
+    onBack: () -> Unit,
+) {
+    SchemaMarketContent(onBack = onBack)
 }
 
 @Composable
@@ -330,6 +458,21 @@ private fun Tag(text: String) {
             text,
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun VerificationTag(text: String, color: androidx.compose.ui.graphics.Color) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = color.copy(alpha = 0.12f),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
         )
     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -4,6 +4,7 @@ object SettingsRoutes {
     const val Main = "main"
     const val Schema = "schema"
     const val SchemaMarket = "schema_market"
+    const val SchemaMarketDetail = "schema_market_detail/{schemeId}"
     const val Theme = "theme"
     const val KeyEffect = "key_effect"
     const val LayoutDisplay = "layout_display"

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.kingzcheung.xime.BuildConfig
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.settings.MarketSchemeItem
-import com.kingzcheung.xime.settings.SettingsPreferences
+import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.XimeIndexSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,8 +19,18 @@ import kotlinx.coroutines.withContext
 data class SchemaMarketUiState(
     val schemes: List<MarketSchemeItem> = emptyList(),
     val isLoading: Boolean = false,
-    val installingId: String? = null,
+    /** 正在下载的方案 id */
+    val downloadingId: String? = null,
+    /** 下载进度 0f~1f */
+    val downloadProgress: Float = 0f,
+    /** 正在解压/安装的方案 id */
+    val extractingId: String? = null,
+    /** 已下载到 market 目录的方案 id（压缩包文件存在） */
+    val downloadedIds: Set<String> = emptySet(),
+    /** 已解压安装到 rime 目录的方案 id */
     val installedIds: Set<String> = emptySet(),
+    /** sha256 校验状态：null=未提供sha256, true=校验通过, false=校验不通过 */
+    val sha256Status: Map<String, Boolean?> = emptyMap(),
     val isDeploying: Boolean = false,
     val errorMessage: String? = null,
     val toastMessage: String? = null,
@@ -53,9 +63,15 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             val result = XimeIndexSource.fetchSchemes(context, BuildConfig.VERSION_NAME)
-            // 「已安装」用持久记录(市场主动安装过的 id)，不靠本地文件存在性
-            // —— 方案可能仅作为依赖落盘，文件存在 ≠ 用户装过它。
-            val installedRecord = SettingsPreferences.getInstalledMarketIds(context)
+            // 「已下载」靠 market/{schemeId}/ 子目录存在性判断
+            val downloadedIds = withContext(Dispatchers.IO) {
+                val marketDir = SchemaManager.getMarketDir(context)
+                if (!marketDir.exists()) emptySet()
+                else marketDir.listFiles()?.mapNotNull { sub ->
+                    if (sub.isDirectory && sub.listFiles()?.any { it.isFile } == true) sub.name
+                    else null
+                }?.toSet() ?: emptySet()
+            }
             result.onSuccess { fetch ->
                 if (fetch.schemes.isEmpty()) {
                     // 索引可达但没取到任何方案：当作软失败处理，不要用空列表覆盖已有数据
@@ -76,8 +92,7 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
                             isLoading = false,
                             source = fetch.source,
                             errorMessage = null,
-                            installedIds = fetch.schemes.map { item -> item.scheme.id }
-                                .filter { id -> id in installedRecord }.toSet(),
+                            downloadedIds = downloadedIds,
                             toastMessage = if (manual) "已刷新 · 来源：${fetch.source}" else it.toastMessage,
                         )
                     }
@@ -98,34 +113,94 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
 
     fun setSearchQuery(q: String) = _uiState.update { it.copy(searchQuery = q) }
 
-    fun installScheme(item: MarketSchemeItem) {
-        if (_uiState.value.installingId != null) return
+    /** 下载方案到 market 目录（仅下载，不解压）。 */
+    fun downloadScheme(item: MarketSchemeItem) {
+        if (_uiState.value.downloadingId != null) {
+            showToast("有其他方案正在下载，请稍候")
+            return
+        }
         if (!item.compatible) {
             showToast("需 App ≥ ${item.minAppVersion}")
             return
         }
         viewModelScope.launch {
-            _uiState.update { it.copy(installingId = item.scheme.id) }
-            // 依赖包 id → 下载 URL，取自已加载的方案列表（含登记为库包的条目）
+            _uiState.update { it.copy(downloadingId = item.scheme.id, downloadProgress = 0f) }
+            val result = withContext(Dispatchers.IO) {
+                XimeIndexSource.downloadScheme(
+                    context, item.scheme,
+                    onDownloadProgress = { downloaded, total ->
+                        val progress = if (total > 0) (downloaded.toFloat() / total) else 0f
+                        _uiState.update { it.copy(downloadProgress = progress) }
+                    },
+                )
+            }
+            val nowDownloaded = withContext(Dispatchers.IO) {
+                SchemaManager.isSchemeDownloaded(context, item.scheme.id)
+            }
+            _uiState.update { st ->
+                st.copy(
+                    downloadingId = null,
+                    downloadProgress = 0f,
+                    downloadedIds = if (nowDownloaded) st.downloadedIds + item.scheme.id else st.downloadedIds,
+                    sha256Status = if (result.success || result.sha256Status == false)
+                        st.sha256Status + (item.scheme.id to result.sha256Status)
+                    else st.sha256Status,
+                )
+            }
+            val toast = when {
+                !result.success && result.sha256Status == false ->
+                    "sha256 校验不通过，文件可能不完整，请重新下载"
+                !result.success -> result.failureReason ?: "下载失败"
+                result.sha256Status == true -> "已下载「${item.scheme.name}」（已校验）"
+                result.sha256Status == null -> "已下载「${item.scheme.name}」（未验证）"
+                else -> "已下载「${item.scheme.name}」"
+            }
+            showToast(toast)
+        }
+    }
+
+    /** 从 market 目录解压/复制已下载的方案到 rime 目录。 */
+    fun installFromMarket(item: MarketSchemeItem) {
+        if (_uiState.value.extractingId != null) {
+            showToast("正在安装其他方案，请稍候")
+            return
+        }
+        if (!item.compatible) {
+            showToast("需 App ≥ ${item.minAppVersion}")
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(extractingId = item.scheme.id) }
             val urlById = _uiState.value.schemes.associate { si ->
                 si.scheme.id to si.scheme.resolvedVersion()?.downloadUrls?.firstOrNull()?.url
             }
             val result = withContext(Dispatchers.IO) {
-                XimeIndexSource.installScheme(context, item.scheme) { id ->
-                    urlById[id]?.takeIf { it.isNotBlank() }
+                XimeIndexSource.installFromMarket(
+                    context, item.scheme,
+                    resolveDepUrl = { id: String -> urlById[id]?.takeIf { it.isNotBlank() } },
+                )
+            }
+            // 安装失败时确保目录清理干净，然后刷新状态让按钮恢复为"下载"
+            if (!result.success) {
+                withContext(Dispatchers.IO) {
+                    val dir = SchemaManager.getMarketDir(context, item.scheme.id)
+                    if (dir.exists()) dir.deleteRecursively()
                 }
             }
-            if (result.success) {
-                // 持久记录"通过市场主动安装"，跨重启保持，且与依赖/文件存在性解耦
-                SettingsPreferences.addInstalledMarketId(context, item.scheme.id)
+            val stillDownloaded = withContext(Dispatchers.IO) {
+                SchemaManager.isSchemeDownloaded(context, item.scheme.id)
             }
             _uiState.update { st ->
                 st.copy(
-                    installingId = null,
+                    extractingId = null,
+                    downloadedIds = if (stillDownloaded) st.downloadedIds else st.downloadedIds - item.scheme.id,
+                    sha256Status = if (stillDownloaded) st.sha256Status else st.sha256Status - item.scheme.id,
                     installedIds = if (result.success) st.installedIds + item.scheme.id else st.installedIds,
                 )
             }
             val msg = when {
+                !result.success && !stillDownloaded ->
+                    "文件不完整，已自动删除，请重新下载"
                 !result.success -> result.failureReason ?: "安装失败"
                 result.unresolvedDeps.isNotEmpty() ->
                     "已安装，部分依赖未获取：${result.unresolvedDeps.joinToString("、").take(60)}"
@@ -135,9 +210,32 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
+    /** 删除已下载到 market 目录的方案压缩包（不删除已解压到 rime 的文件）。 */
+    fun deleteDownloadedScheme(schemeId: String) {
+        viewModelScope.launch {
+            val ok = withContext(Dispatchers.IO) {
+                SchemaManager.deleteSchemeArchive(context, schemeId)
+            }
+            if (ok) {
+                _uiState.update {
+                    it.copy(
+                        downloadedIds = it.downloadedIds - schemeId,
+                        sha256Status = it.sha256Status - schemeId,
+                    )
+                }
+                showToast("已删除压缩包")
+            } else {
+                showToast("删除失败")
+            }
+        }
+    }
+
     /** 部署(全局编译已启用方案)。rime 部署是全局的,装好后点一次即可让方案生效。 */
     fun deploy() {
-        if (_uiState.value.isDeploying) return
+        if (_uiState.value.isDeploying) {
+            showToast("正在部署中，请稍候")
+            return
+        }
         viewModelScope.launch {
             _uiState.update { it.copy(isDeploying = true) }
             val success = withContext(Dispatchers.IO) {


### PR DESCRIPTION
- 修改 xime.yaml 中的 base_urls 配置，添加 @master 分支标识确保获取最新版本
- 新增 SchemaManager.kt 中的市场相关功能：下载、安装、验证、删除方案文件
- 实现压缩包完整性校验（zip/tar.gz）和 SHA-256 校验机制
- 更新 XimeIndexSource 使用扁平索引格式（rimes/index.yaml），简化方案获取流程
- 添加下载进度显示、文件验证状态标记和错误处理机制
- 实现 UI 界面支持方案详情页面跳转和下载安装操作
- 新增方案卡片显示版本号、作者、标签、依赖关系等详细信息
- 支持下载后先验证再安装的安全机制，提升方案安装可靠性