### PR TITLE
feat(association): 添加ONNX关联引擎预热功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/association/AssociationManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/AssociationManager.kt
@@ -38,7 +38,11 @@ object AssociationManager {
                 FileLogger.i(TAG, "Starting OnnxAssociationEngine initialization...")
                 val modelInit = OnnxAssociationEngine.initialize(ctx)
                 FileLogger.i(TAG, "OnnxAssociationEngine init result: $modelInit")
-                
+
+                if (modelInit) {
+                    OnnxAssociationEngine.startWarmup()
+                }
+
                 val cacheInit = fusionEngine.initialize()
                 FileLogger.i(TAG, "NgramFusionEngine init result: $cacheInit")
                 

--- a/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
@@ -2,7 +2,10 @@ package com.kingzcheung.xime.association
 
 import android.content.Context
 import com.kingzcheung.xime.util.FileLogger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.io.File
@@ -13,6 +16,8 @@ object OnnxAssociationEngine {
     private var vocab: Map<String, Int> = emptyMap()
     private var id2word: Map<Int, String> = emptyMap()
     private var isInitialized = false
+    private var warmupStarted = false
+    private val warmupScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     fun initialize(context: Context): Boolean {
         if (isInitialized) {
@@ -126,6 +131,21 @@ object OnnxAssociationEngine {
             i++
         }
         return ids
+    }
+
+    fun startWarmup() {
+        if (!isInitialized || warmupStarted) return
+        warmupStarted = true
+        warmupScope.launch {
+            FileLogger.d(TAG, "Starting warmup prediction...")
+            val dummyIds = longArrayOf(1L, 9L)
+            try {
+                NativeOnnxEngine.predict(dummyIds, 5)
+                FileLogger.d(TAG, "Warmup prediction completed")
+            } catch (e: Exception) {
+                FileLogger.w(TAG, "Warmup prediction failed (non-fatal): ${e.message}")
+            }
+        }
     }
 
     fun release() {

--- a/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/PredictionManager.kt
@@ -77,36 +77,6 @@ class PredictionManager(
         }
     }
     
-    fun checkAndInitialize() {
-        if (!FileLogger.isInitialized()) {
-            FileLogger.init(context)
-        }
-        
-        serviceScope.launch(Dispatchers.IO) {
-            try {
-                if (!ExtensionManager.isInitialized()) {
-                    FileLogger.i(TAG, "ExtensionManager not initialized, initializing now...")
-                    ExtensionManager.initialize(context)
-                }
-                
-                if (SettingsPreferences.isSmartPredictionEnabled(context)) {
-                    try {
-                        val initialized = AssociationManager.initialize(context)
-                        if (initialized) {
-                            FileLogger.i(TAG, "Smart prediction initialized in checkAndInitialize")
-                        } else {
-                            FileLogger.w(TAG, "Smart prediction initialization failed in checkAndInitialize")
-                        }
-                    } catch (e: Exception) {
-                        FileLogger.e(TAG, "Failed to initialize smart prediction: ${e.message}")
-                    }
-                }
-            } catch (e: Exception) {
-                FileLogger.e(TAG, "Failed to initialize in checkAndInitialize: ${e.message}")
-            }
-        }
-    }
-    
     fun getPrediction(contextText: String) {
         if (contextText.isEmpty()) {
             onStateChanged(getState().copy(associationCandidates = emptyArray()))

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -282,9 +282,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         predictionManager.initialize()
     }
     
-    private fun checkAndInitializeAssociationEngine() {
-        predictionManager.checkAndInitialize()
-    }
     
     private fun getPredictionFromPlugin(contextText: String) {
         predictionManager.getPrediction(contextText)
@@ -938,8 +935,6 @@ onVoiceModeChange = { enabled ->
 
         predictionManager.clearCommittedText()
         Log.d(TAG, "onStartInput: cleared lastCommittedText")
-
-        checkAndInitializeAssociationEngine()
         
         if (RimeEngine.isInitialized()) {
             val savedSchema = SettingsPreferences.getCurrentSchema(this)


### PR DESCRIPTION
为OnnxAssociationEngine添加预热机制，在初始化完成后自动执行
预热预测以提升后续预测性能。同时移除不再使用的检查初始化方法，
简化代码结构并优化协程作用域管理。