### PR TITLE
refactor(keyboard): 移除重复的触摸事件处理

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -131,8 +131,7 @@ fun KeyButton(
                         hasTriggeredSwipeDown = false
                         isSwiping = false
                         isSwipeDown = false
-                        onSwipeStateChange?.invoke(SwipeState(false, null, false))
-                        onPress?.invoke()
+                        // onSwipeStateChange/onPress 由 detectTapGestures.onPress 处理
                     },
                     onDragEnd = {
                         // onClick is handled by detectTapGestures below — do NOT fire it here
@@ -338,8 +337,7 @@ fun SwipeableKeyButton(
                         hasTriggeredSwipeDown = false
                         isSwiping = false
                         isSwipeDown = false
-                        currentOnSwipeStateChange?.invoke(SwipeState(isPressed = true, pressedText = currentText), buttonBounds)
-                        currentOnPress?.invoke()
+                        // currentOnSwipeStateChange/currentOnPress 由 detectTapGestures / awaitEachGesture 处理
                     },
                     onDragEnd = {
                         // onClick is handled by detectTapGestures / awaitEachGesture below


### PR DESCRIPTION
- 在KeyButton中移除了onSwipeStateChange和onPress的重复调用， 这些回调现在统一由detectTapGestures.onPress处理

- 在SwipeableKeyButton中移除了currentOnSwipeStateChange和currentOnPress 的重复调用，这些回调现在统一由detectTapGestures/awaitEachGesture处理

- 添加注释说明事件处理的职责转移

fix(jni): 更新子项目提交状态标记为dirty