### PR TITLE
fix(keyboard): 修复候选词与联想词同时高亮的问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
@@ -299,7 +299,8 @@ fun CandidateBar(
                                 onClick = { callbacks.onAssociationSelect?.invoke(index) },
                                 textColor = visuals.textColor,
                                 comment = "",
-                                isSelected = index == 0,
+                                // 候选词存在时联想词不高亮，避免双重选中
+                                isSelected = index == 0 && displayCandidates.isEmpty(),
                                 accentColor = visuals.accentColor
                             )
                         }


### PR DESCRIPTION
当存在候选词时，联想词不再高亮显示，避免出现双重选中的视觉效果，
提升用户界面的清晰度和用户体验。

当前的实现会导致在有候选词的情况下，联想词的第一个项目也会被高亮，
这可能会让用户感到困惑。通过添加条件判断候选词列表是否为空，
确保只有在没有候选词时联想词才会高亮。