### PR TITLE
fix(deploy): 部署成功后存储配置哈希值

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1309,65 +1309,53 @@ onVoiceModeChange = { enabled ->
                     calculatorEngine.handleDelete()
                     updateCalculatorCandidates()
                     
-                    // 优先清空联想词：如果存在联想词，退格键先清空联想词，不执行实际删除
-                    if (candState.associationCandidates.isNotEmpty()) {
+                    // 优先清空候选栏：无论联想词、候选词还是复制内容，按删除键先清空候选栏
+                    val hasCandidateContent = candState.candidates.isNotEmpty() ||
+                        candState.associationCandidates.isNotEmpty() ||
+                        candState.isShowingRecentClipboard
+                    
+                    if (hasCandidateContent) {
+                        // 如果有待处理的英文输入，需同步删除已提交的字符并清空 pendingEnglishText
+                        // 否则候选栏清除后 pendingEnglishText 仍在，会重新拉取联想词
+                        val pendingLen = candState.pendingEnglishText.length
                         withContext(Dispatchers.Main) {
-                            candidateState.value = candidateState.value.copy(
-                                associationCandidates = emptyArray()
-                            )
-                        }
-                        needsUIUpdate = true
-                        Log.d(TAG, "Delete: cleared association candidates")
-                    } else if (candState.isShowingRecentClipboard) {
-                        // 清除候选栏的复制内容显示，不删除实际内容
-                        withContext(Dispatchers.Main) {
-                            candidateState.value = candidateState.value.copy(
-                                candidates = emptyArray(),
-                                candidateComments = emptyArray(),
-                                isShowingRecentClipboard = false
-                            )
-                        }
-                        needsUIUpdate = true
-                        Log.d(TAG, "Delete: cleared clipboard display")
-                    } else {
-                        val pendingEnglish = candState.pendingEnglishText
-                        
-                        if (pendingEnglish.isNotEmpty()) {
-                            val newPending = pendingEnglish.dropLast(1)
-                            withContext(Dispatchers.Main) {
-                                sendDownUpKeyEvents(KeyEvent.KEYCODE_DEL)
-                                candidateState.value = candidateState.value.copy(
-                                    pendingEnglishText = newPending,
-                                    associationCandidates = emptyArray()
-                                )
-                            }
-                            needsUIUpdate = true
-                            Log.d(TAG, "Delete English pending: '$newPending'")
-                        } else if (candState.isComposing || candState.inputText.isNotEmpty()) {
-                            rimeEngine.processKey(0xff08, 0)
-                            val result = rimeEngine.getProcessResult(true)
-                            if (result.inputText.isEmpty()) {
-                                rimeEngine.clearComposition()
-                            }
-                            uiEventChannel.trySend {
-                                updateUIWithResult(result)
-                                if (calculatorEngine.isActive()) updateCalculatorCandidates()
-                            }
-                        } else {
-                            predictionManager.deleteLastChar()
-                            Log.d(TAG, "Delete committed text, remaining: '${predictionManager.lastCommittedText}'")
-                            
-                            withContext(Dispatchers.Main) {
+                            repeat(pendingLen) {
                                 sendDownUpKeyEvents(KeyEvent.KEYCODE_DEL)
                             }
-                            
                             candidateState.value = candidateState.value.copy(
                                 candidates = emptyArray(),
                                 candidateComments = emptyArray(),
                                 associationCandidates = emptyArray(),
-                                isShowingRecentClipboard = false
+                                isShowingRecentClipboard = false,
+                                pendingEnglishText = ""
                             )
                         }
+                        needsUIUpdate = true
+                        Log.d(TAG, "Delete: cleared candidate bar (candidates=${candState.candidates.size}, assoc=${candState.associationCandidates.size}, clipboard=${candState.isShowingRecentClipboard})")
+                    } else if (candState.isComposing || candState.inputText.isNotEmpty()) {
+                        rimeEngine.processKey(0xff08, 0)
+                        val result = rimeEngine.getProcessResult(true)
+                        if (result.inputText.isEmpty()) {
+                            rimeEngine.clearComposition()
+                        }
+                        uiEventChannel.trySend {
+                            updateUIWithResult(result)
+                            if (calculatorEngine.isActive()) updateCalculatorCandidates()
+                        }
+                    } else {
+                        predictionManager.deleteLastChar()
+                        Log.d(TAG, "Delete committed text, remaining: '${predictionManager.lastCommittedText}'")
+                        
+                        withContext(Dispatchers.Main) {
+                            sendDownUpKeyEvents(KeyEvent.KEYCODE_DEL)
+                        }
+                        
+                        candidateState.value = candidateState.value.copy(
+                            candidates = emptyArray(),
+                            candidateComments = emptyArray(),
+                            associationCandidates = emptyArray(),
+                            isShowingRecentClipboard = false
+                        )
                     }
                 }
                 "clear_composition" -> {

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
@@ -147,7 +148,11 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
                 KeysConfigHelper.loadConfig(context)
                 KeyboardThemes.reload(context)
                 val engine = RimeEngine.getInstance()
-                engine.deploy()
+                val deployed = engine.deploy()
+                if (deployed) {
+                    RimeConfigHelper.storeDeploymentHash(context)
+                }
+                deployed
             }
             _uiState.update { it.copy(isDeploying = false) }
             showToast(if (success) "部署完成" else "部署失败")


### PR DESCRIPTION
在Rime引擎部署完成后，只有当部署成功时才存储
部署哈希值到配置中，确保部署状态的一致性。

perf(rime): 更新子项目依赖库版本

feat(input): 优化删除键逻辑优先清空候选栏

优先清空候选栏：无论联想词、候选词还是复制内容，
按删除键先清空候选栏。同时修复了英文输入时待处理
字符的同步删除问题。

当存在候选内容时，如果有待处理的英文输入，
需要同步删除已提交的字符并清空 pendingEnglishText，
避免候选栏清除后 pendingEnglishText 仍在导致重新
拉取联想词的问题。