### PR TITLE
chore(app): 更新版本号并同步子项目依赖

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 41
-        versionName = "2.4.0"
+        versionCode = 42
+        versionName = "2.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
更新应用版本号从 2.4.0 (versionCode 41) 到 2.4.1 (versionCode 42)， 同时更新 librime、librime-lua 和 librime-lua-deps 子项目的
本地修改状态标记为 dirty，确保依赖项同步到最新状态。