### PR TITLE
feat(keyboard): 添加常用符号键盘布局支持

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
@@ -1,0 +1,272 @@
+package com.kingzcheung.xime.ui.keyboard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Backspace
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CommonSymbolKeyboardLayout(
+    onKeyPress: (String) -> Unit,
+    isAsciiMode: Boolean,
+    keyBackgroundColor: Color,
+    keyTextColor: Color,
+    specialKeyBackgroundColor: Color,
+    keyboardBackgroundColor: Color = Color.Transparent,
+    shadowEnabled: Boolean = true,
+    shadowElevation: Dp = 1.dp,
+    shadowShapeRadius: Dp = 8.dp,
+    modifier: Modifier = Modifier,
+    onKeyPressDown: ((String) -> Unit)? = null,
+) {
+    val row2Symbols = if (isAsciiMode) {
+        listOf("@", "#", "$", "&", "_", "-", "+", "(", ")", "/")
+    } else {
+        listOf("＠", "＃", "＄", "＆", "＿", "－", "＋", "（", "）", "／")
+    }
+
+    val row3Symbols = if (isAsciiMode) {
+        listOf("*", "\"", "'", ":", ";", "!", "?")
+    } else {
+        listOf("＊", "＂", "＇", "：", "；", "！", "？")
+    }
+
+    val commaChar = if (isAsciiMode) "," else "，"
+    val periodChar = if (isAsciiMode) "." else "。"
+
+    val isDarkTheme = keyTextColor == Color(0xFFE8EAED)
+    var swipeState by remember { mutableStateOf(SwipeState()) }
+    var keyboardBounds by remember { mutableStateOf(Rect(0f, 0f, 0f, 0f)) }
+    var lastKeyBounds by remember { mutableStateOf(Rect(0f, 0f, 0f, 0f)) }
+
+    val bubbleData = rememberSwipeBubbleDrawData(
+        swipeState = swipeState,
+        keyBounds = lastKeyBounds,
+        isDarkTheme = isDarkTheme,
+        keyWidth = if (swipeState.isSwiping || swipeState.isPressed) lastKeyBounds.width else 0f,
+        keyboardWidth = keyboardBounds.width,
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+            .background(keyboardBackgroundColor)
+            .onGloballyPositioned { coordinates ->
+                keyboardBounds = coordinates.boundsInRoot()
+            }
+            .drawWithContent {
+                drawContent()
+                bubbleData?.let { drawSwipeBubble(it) }
+            },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
+                (0..9).forEach { n ->
+                    val digit = n.toString()
+                    KeyButton(
+                        text = digit,
+                        onClick = { onKeyPress(digit) },
+                        backgroundColor = keyBackgroundColor,
+                        textColor = keyTextColor,
+                        modifier = Modifier.weight(1f),
+                        onPress = { onKeyPressDown?.invoke(digit) },
+                        shadowEnabled = shadowEnabled,
+                        shadowElevation = shadowElevation,
+                        shadowShapeRadius = shadowShapeRadius,
+                        fontSize = 20.sp,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
+                row2Symbols.forEach { sym ->
+                    KeyButton(
+                        text = sym,
+                        onClick = { onKeyPress(sym) },
+                        backgroundColor = keyBackgroundColor,
+                        textColor = keyTextColor,
+                        modifier = Modifier.weight(1f),
+                        onPress = { onKeyPressDown?.invoke(sym) },
+                        shadowEnabled = shadowEnabled,
+                        shadowElevation = shadowElevation,
+                        shadowShapeRadius = shadowShapeRadius,
+                        fontSize = 20.sp,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
+                KeyButton(
+                    text = "符号",
+                    onClick = { onKeyPress("symbol") },
+                    backgroundColor = specialKeyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(1.3f),
+                    onPress = { onKeyPressDown?.invoke("symbol") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 14.sp,
+                )
+                row3Symbols.forEach { sym ->
+                    KeyButton(
+                        text = sym,
+                        onClick = { onKeyPress(sym) },
+                        backgroundColor = keyBackgroundColor,
+                        textColor = keyTextColor,
+                        modifier = Modifier.weight(1f),
+                        onPress = { onKeyPressDown?.invoke(sym) },
+                        shadowEnabled = shadowEnabled,
+                        shadowElevation = shadowElevation,
+                        shadowShapeRadius = shadowShapeRadius,
+                        fontSize = 20.sp,
+                    )
+                }
+                SwipeableIconKeyButton(
+                    icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
+                    onClick = { onKeyPress("delete") },
+                    backgroundColor = specialKeyBackgroundColor,
+                    iconColor = keyTextColor,
+                    modifier = Modifier.weight(1.2f),
+                    swipeText = "清空",
+                    onSwipe = { onKeyPress("clear_composition") },
+                    onLongClick = { onKeyPress("delete") },
+                    onPress = { onKeyPressDown?.invoke("delete") },
+                    swipeUpLabel = "上滑清空",
+                    swipeDownLabel = "下滑撤回",
+                    onSwipeUp = { onKeyPress("clear_all") },
+                    onSwipeDown = { onKeyPress("undo_clear") },
+                    onSwipeStateChange = { state, bounds ->
+                        swipeState = state
+                        lastKeyBounds = Rect(
+                            left = bounds.left - keyboardBounds.left,
+                            top = bounds.top - keyboardBounds.top,
+                            right = bounds.right - keyboardBounds.left,
+                            bottom = bounds.bottom - keyboardBounds.top,
+                        )
+                    },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
+                KeyButton(
+                    text = "返回",
+                    onClick = { onKeyPress("abc") },
+                    backgroundColor = specialKeyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(1.2f),
+                    onPress = { onKeyPressDown?.invoke("abc") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 14.sp,
+                )
+                KeyButton(
+                    text = "数字",
+                    onClick = { onKeyPress("number") },
+                    backgroundColor = specialKeyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(1.2f),
+                    onPress = { onKeyPressDown?.invoke("number") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 14.sp,
+                )
+                KeyButton(
+                    text = commaChar,
+                    onClick = { onKeyPress(commaChar) },
+                    backgroundColor = keyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(1f),
+                    onPress = { onKeyPressDown?.invoke(commaChar) },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 20.sp,
+                )
+                KeyButton(
+                    text = "空格",
+                    onClick = { onKeyPress("space") },
+                    backgroundColor = keyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(2.5f),
+                    onPress = { onKeyPressDown?.invoke("space") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 14.sp,
+                )
+                KeyButton(
+                    text = periodChar,
+                    onClick = { onKeyPress(periodChar) },
+                    backgroundColor = keyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(1f),
+                    onPress = { onKeyPressDown?.invoke(periodChar) },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 20.sp,
+                )
+                KeyButton(
+                    text = "确定",
+                    onClick = { onKeyPress("enter") },
+                    backgroundColor = specialKeyBackgroundColor,
+                    textColor = keyTextColor,
+                    modifier = Modifier.weight(1.2f),
+                    onPress = { onKeyPressDown?.invoke("enter") },
+                    shadowEnabled = shadowEnabled,
+                    shadowElevation = shadowElevation,
+                    shadowShapeRadius = shadowShapeRadius,
+                    fontSize = 14.sp,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
@@ -103,6 +103,22 @@ fun KeyboardLayoutScreen(
             )
         }
 
+        is KeyboardLayoutState.CommonSymbol -> {
+            CommonSymbolKeyboardLayout(
+                onKeyPress = onKeyPress,
+                isAsciiMode = isAsciiMode,
+                keyBackgroundColor = keyBackgroundColor,
+                keyTextColor = keyTextColor,
+                specialKeyBackgroundColor = specialKeyBackgroundColor,
+                keyboardBackgroundColor = keyboardBackgroundColor,
+                shadowEnabled = shadowEnabled,
+                shadowElevation = shadowElevation,
+                shadowShapeRadius = shadowShapeRadius,
+                modifier = modifier,
+                onKeyPressDown = onKeyPressDown,
+            )
+        }
+
         is KeyboardLayoutState.Symbol -> {
             // 符号键盘已改为路由，此处不应到达
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutState.kt
@@ -8,7 +8,7 @@ package com.kingzcheung.xime.ui.keyboard
  * 状态转移由 [KeyboardLayoutAction] 驱动，参见 [KeyboardLayoutState.transition]。
  *
  * 横竖屏（分体/正常）是渲染层根据 [isLandscape] 自动选择的，
- * 不编码在状态机中，故仅有 4 种核心状态。
+ * 不编码在状态机中，故仅有 5 种核心状态。
  */
 sealed class KeyboardLayoutState {
 
@@ -23,6 +23,9 @@ sealed class KeyboardLayoutState {
 
     /** 符号键盘 */
     data object Symbol : KeyboardLayoutState()
+
+    /** 常用符号键盘（?123 进入的符号+数字混合键盘） */
+    data object CommonSymbol : KeyboardLayoutState()
 
     /** 是否为全键盘类（Chinese / English） */
     val isFullKeyboard: Boolean get() = this is Chinese || this is English
@@ -39,7 +42,10 @@ sealed class KeyboardLayoutAction {
     /** 切换到符号键盘 */
     data object SwitchToSymbol : KeyboardLayoutAction()
 
-    /** 从数字/符号切回全键盘（中文或英文，取决于 isAsciiMode） */
+    /** 切换到常用符号键盘 */
+    data object SwitchToCommonSymbol : KeyboardLayoutAction()
+
+    /** 从数字/符号/常用符号切回全键盘（中文或英文，取决于 isAsciiMode） */
     data object SwitchToFull : KeyboardLayoutAction()
 }
 
@@ -57,6 +63,7 @@ fun KeyboardLayoutState.transition(
     return when (action) {
         KeyboardLayoutAction.SwitchToNumber -> KeyboardLayoutState.Number
         KeyboardLayoutAction.SwitchToSymbol -> KeyboardLayoutState.Symbol
+        KeyboardLayoutAction.SwitchToCommonSymbol -> KeyboardLayoutState.CommonSymbol
         KeyboardLayoutAction.SwitchToFull -> when {
             isAsciiMode -> KeyboardLayoutState.English
             else -> KeyboardLayoutState.Chinese

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -329,7 +329,7 @@ fun KeyboardView(
                             "shift" -> isShifted = !isShifted
                             "mode_change" -> {
                                 keyboardState = keyboardState.transition(
-                                    KeyboardLayoutAction.SwitchToNumber, isAsciiMode
+                                    KeyboardLayoutAction.SwitchToCommonSymbol, isAsciiMode
                                 )
                                 onKeyPress("clear_composition", false)
                             }
@@ -362,10 +362,24 @@ fun KeyboardView(
                             else -> onKeyPress(key, false)
                         }
                     }
+                    val commonSymbolOnKeyPress: (String) -> Unit = { key ->
+                        when (key) {
+                            "abc" -> keyboardState = keyboardState.transition(
+                                KeyboardLayoutAction.SwitchToFull, isAsciiMode
+                            )
+                            "number" -> keyboardState = keyboardState.transition(
+                                KeyboardLayoutAction.SwitchToNumber, isAsciiMode
+                            )
+                            "symbol" -> currentRoute = KeyboardRoute.Symbol
+                            "emoji" -> currentRoute = KeyboardRoute.Emoji
+                            else -> onKeyPress(key, false)
+                        }
+                    }
                     val currentOnKeyPress = when (keyboardState) {
                         is KeyboardLayoutState.Chinese,
                         is KeyboardLayoutState.English -> fullScreenOnKeyPress
                         is KeyboardLayoutState.Number -> numberOnKeyPress
+                        is KeyboardLayoutState.CommonSymbol -> commonSymbolOnKeyPress
                         is KeyboardLayoutState.Symbol -> symbolOnKeyPress
                     }
                     KeyboardLayoutScreen(


### PR DESCRIPTION
新增 CommonSymbol 键盘布局状态，用于处理 ?123 进入的符号+数字混合键盘。
更新键盘状态机以支持在常用符号键盘与其他键盘类型之间的切换。
修改 KeyboardView 中的按键处理逻辑以适配新的键盘状态。

BREAKING CHANGE: 键盘状态数量从 4 种增加到 5 种。