### PR TITLE
feat(settings): 添加显示模式枚举支持按键和气泡显示

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -23,11 +23,19 @@ import java.io.InputStreamReader
 
 // ── 键盘手势配置 ──
 
+enum class DisplayMode(val value: String) {
+    KEY("key"), BUBBLE("bubble"), BOTH("both");
+
+    companion object {
+        fun fromValue(value: String): DisplayMode = entries.firstOrNull { it.value == value } ?: BOTH
+    }
+}
+
 data class GestureDef(
     val label: String = "",
     val action: GestureAction? = GestureAction.COMMIT,
     val value: String = "",
-    val display: String = "key", // "key"（默认）显示在按键上, "bubble" 气泡显示
+    val display: DisplayMode = DisplayMode.BOTH,
 )
 
 data class LongPressConfig(
@@ -159,7 +167,7 @@ private fun parseGestureNode(node: com.charleskorn.kaml.YamlNode): GestureDef {
                 "display" -> display = vStr
             }
         }
-        return GestureDef(label = label, action = action, value = value, display = display)
+        return GestureDef(label = label, action = action, value = value, display = DisplayMode.fromValue(display))
     }
     return GestureDef()
 }
@@ -600,8 +608,8 @@ object KeysConfigHelper {
     }
 
     /** 获取下滑显示位置：key（按键上）或 bubble（气泡） */
-    fun getSwipeDownDisplay(key: String): String {
-        return keyGestureConfig[key.lowercase()]?.swipeDown?.display ?: "key"
+    fun getSwipeDownDisplay(key: String): DisplayMode {
+        return keyGestureConfig[key.lowercase()]?.swipeDown?.display ?: DisplayMode.BOTH
     }
     
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import com.kingzcheung.xime.settings.SettingsPreferences
+import com.kingzcheung.xime.settings.DisplayMode
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.keyboard.GestureAction
 import androidx.compose.ui.Modifier
@@ -337,10 +338,8 @@ fun KeyboardLayout(
                                         swipeDownRaw?.label?.takeIf { it.isNotEmpty() }
                                     val swipeDownAction = swipeDownRaw?.action
                                     val swipeDownValue = swipeDownRaw?.value
-                                    val swipeDownDisplay = swipeDownRaw?.display ?: "key"
-                                    val swipeDownBubbleText =
-                                        if (swipeDownDisplay != "key") swipeDownLabel else null
-
+                                    val swipeDownDisplay = swipeDownRaw?.display ?: DisplayMode.BOTH
+                                    val swipeDownBubbleText = if (swipeDownDisplay != DisplayMode.KEY) swipeDownLabel else null
                                     val longPressConfig =
                                         KeysConfigHelper.getKeyGesture(key)?.longPress
                                     val longPressDisplay = longPressConfig?.display ?: "key"
@@ -358,11 +357,11 @@ fun KeyboardLayout(
                                     val onClick = remember(key, commitValue, onKeyPress) { { onKeyPress(commitValue) } }
                                     val onPress: (() -> Unit)? = remember(key, onKeyPressDown) { { onKeyPressDown?.invoke(key); Unit } }
                                     val onSwipeDown = if (swipeDownAction != null && swipeDownLabel != null) {
-                                        remember(key, onKeyPress, onGestureAction, swipeDownAction, swipeDownValue, swipeDownLabel) {
+                                        remember(key, onKeyPress, onGestureAction, onCommitText, swipeDownAction, swipeDownValue, swipeDownLabel) {
                                             val label = swipeDownLabel
                                             { _: String ->
                                                 if (swipeDownAction == GestureAction.COMMIT) {
-                                                    onKeyPress(key)
+                                                    (onCommitText ?: onKeyPress)(swipeDownValue?.ifEmpty { label } ?: label)
                                                 } else {
                                                     onGestureAction?.invoke(
                                                         swipeDownAction,
@@ -393,7 +392,7 @@ fun KeyboardLayout(
                                         modifier = Modifier.weight(1f),
                                         swipeText = swipeUpText,
                                         swipeDownText = swipeDownBubbleText,
-                                        swipeDownKeyLabel = if (swipeDownDisplay == "key") swipeDownLabel else null,
+                                        swipeDownKeyLabel = if (swipeDownDisplay == DisplayMode.KEY || swipeDownDisplay == DisplayMode.BOTH) swipeDownLabel else null,
                                         onSwipe = if (swipeUpText != null) onKeyPress else null,
                                         onSwipeDown = onSwipeDown,
                                         onSwipeStateChange = onSwipeStateChange,
@@ -787,9 +786,9 @@ fun KeyboardRowWithConfig(
             val swipeDownLabel = swipeDownRaw?.label?.takeIf { it.isNotEmpty() }
             val swipeDownAction = swipeDownRaw?.action
             val swipeDownValue = swipeDownRaw?.value
-            val swipeDownDisplay = swipeDownRaw?.display ?: "key"
+            val swipeDownDisplay = swipeDownRaw?.display ?: DisplayMode.BOTH
             val swipeDownBubbleText =
-                if (swipeDownDisplay != "key" && swipeDownHintsEnabled) swipeDownLabel else null
+                if (swipeDownDisplay != DisplayMode.KEY && swipeDownHintsEnabled) swipeDownLabel else null
 
             // 长按选项
             val longPressConfig = KeysConfigHelper.getKeyGesture(key)?.longPress
@@ -809,11 +808,11 @@ fun KeyboardRowWithConfig(
             val onClick = remember(key, commitValue, onKeyPress) { { onKeyPress(commitValue) } }
             val onPress: (() -> Unit)? = remember(key, onKeyPressDown) { { onKeyPressDown?.invoke(key); Unit } }
             val onSwipeDown: ((String) -> Unit)? = if (swipeDownAction != null && swipeDownHintsEnabled && swipeDownLabel != null) {
-                remember(key, onKeyPress, onGestureAction, swipeDownAction, swipeDownValue, swipeDownLabel) {
+                remember(key, onKeyPress, onGestureAction, onCommitText, swipeDownAction, swipeDownValue, swipeDownLabel) {
                     val label = swipeDownLabel
                     { _: String ->
                         if (swipeDownAction == GestureAction.COMMIT) {
-                            onKeyPress(key)
+                            (onCommitText ?: onKeyPress)(swipeDownValue?.ifEmpty { label } ?: label)
                         } else {
                             onGestureAction?.invoke(
                                 swipeDownAction,
@@ -843,7 +842,7 @@ fun KeyboardRowWithConfig(
                 modifier = Modifier.weight(1f),
                 swipeText = swipeUpText,
                 swipeDownText = swipeDownBubbleText,
-                swipeDownKeyLabel = if (swipeDownDisplay == "key" && swipeDownHintsEnabled) swipeDownLabel else null,
+                swipeDownKeyLabel = if ((swipeDownDisplay == DisplayMode.KEY || swipeDownDisplay == DisplayMode.BOTH) && swipeDownHintsEnabled) swipeDownLabel else null,
                 onSwipe = if (swipeUpText != null) onKeyPress else null,
                 onSwipeDown = onSwipeDown,
                 onSwipeStateChange = onSwipeStateChange,
@@ -1526,9 +1525,9 @@ fun CompactKeyboardRowWithConfig(
             val swipeDownLabel = swipeDownRaw?.label?.takeIf { it.isNotEmpty() }
             val swipeDownAction = swipeDownRaw?.action
             val swipeDownValue = swipeDownRaw?.value
-            val swipeDownDisplay = swipeDownRaw?.display ?: "key"
+            val swipeDownDisplay = swipeDownRaw?.display ?: DisplayMode.BOTH
             val swipeDownBubbleText =
-                if (swipeDownDisplay != "key" && swipeDownHintsEnabled) swipeDownLabel else null
+                if (swipeDownDisplay != DisplayMode.KEY && swipeDownHintsEnabled) swipeDownLabel else null
 
             val longPressConfig = KeysConfigHelper.getKeyGesture(key)?.longPress
             val longPressDisplay = longPressConfig?.display ?: "key"
@@ -1544,14 +1543,15 @@ fun CompactKeyboardRowWithConfig(
             val compactOnClick = remember(key, commitValue, onKeyPress) { { onKeyPress(commitValue) } }
             val compactOnPress: (() -> Unit)? = remember(key, onKeyPressDown) { { onKeyPressDown?.invoke(key); Unit } }
             val compactOnSwipeDown: ((String) -> Unit)? = if (swipeDownAction != null && swipeDownHintsEnabled && swipeDownLabel != null) {
-                remember(key, onKeyPress, onGestureAction, swipeDownAction, swipeDownValue, swipeDownLabel) {
+                remember(key, onKeyPress, onGestureAction, onCommitText, swipeDownAction, swipeDownValue, swipeDownLabel) {
+                    val label = swipeDownLabel
                     { _: String ->
                         if (swipeDownAction == GestureAction.COMMIT) {
-                            onKeyPress(key)
+                            (onCommitText ?: onKeyPress)(swipeDownValue?.ifEmpty { label } ?: label)
                         } else {
                             onGestureAction?.invoke(
                                 swipeDownAction,
-                                swipeDownValue?.ifEmpty { swipeDownLabel } ?: swipeDownLabel!!)
+                                swipeDownValue?.ifEmpty { label } ?: label!!)
                         }
                         Unit
                     }

--- a/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
@@ -193,6 +193,58 @@ class KeyboardGestureConfigTest {
         assertEquals("\\", keys["c"]!!.swipeUp!!.value)
     }
 
+    // ── DisplayMode ──
+
+    @Test
+    fun `字符串简写默认 display 为 both`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_down: "@" }
+        """.trimIndent())
+        assertEquals(DisplayMode.BOTH, keys["a"]!!.swipeDown!!.display)
+    }
+
+    @Test
+    fun `对象格式无 display 字段默认为 both`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_down: { label: "@", action: "commit" } }
+        """.trimIndent())
+        assertEquals(DisplayMode.BOTH, keys["a"]!!.swipeDown!!.display)
+    }
+
+    @Test
+    fun `对象格式 display_key 解析为 KEY`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_down: { label: "@", action: "commit", display: "key" } }
+        """.trimIndent())
+        assertEquals(DisplayMode.KEY, keys["a"]!!.swipeDown!!.display)
+    }
+
+    @Test
+    fun `对象格式 display_bubble 解析为 BUBBLE`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_down: { label: "@", action: "commit", display: "bubble" } }
+        """.trimIndent())
+        assertEquals(DisplayMode.BUBBLE, keys["a"]!!.swipeDown!!.display)
+    }
+
+    @Test
+    fun `对象格式 display_both 解析为 BOTH`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_down: { label: "@", action: "commit", display: "both" } }
+        """.trimIndent())
+        assertEquals(DisplayMode.BOTH, keys["a"]!!.swipeDown!!.display)
+    }
+
+    @Test
+    fun `对象指定 value 和 label 不同时 value 优先`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_down: { label: "@", action: "commit", value: "at" } }
+        """.trimIndent())
+        val sd = keys["a"]!!.swipeDown!!
+        assertEquals("@", sd.label)
+        assertEquals("at", sd.value)
+    }
+
     // ── 完整 26 键配置 ──
 
     @Test
@@ -367,7 +419,7 @@ class KeyboardGestureConfigTest {
             var label = ""
             var action: GestureAction? = GestureAction.COMMIT
             var value = ""
-            var display = "bubble"
+            var display = "both"
             for ((k, v) in node.entries) {
                 val key = (k as com.charleskorn.kaml.YamlScalar).content
                 val vStr = (v as? com.charleskorn.kaml.YamlScalar)?.content
@@ -378,7 +430,7 @@ class KeyboardGestureConfigTest {
                     "display" -> if (vStr != null) display = vStr
                 }
             }
-            return GestureDef(label = label, action = action, value = value, display = display)
+            return GestureDef(label = label, action = action, value = value, display = DisplayMode.fromValue(display))
         }
         return GestureDef()
     }


### PR DESCRIPTION
添加 DisplayMode 枚举类，支持三种显示方式：
- KEY：仅在按键上显示
- BUBBLE：仅以气泡形式显示
- BOTH：按键和气泡同时显示

更新 GestureDef 数据类将 display 字段从 String 类型改为
DisplayMode 类型，并修改解析逻辑以支持新的显示模式配置。

fix(keyboard): 修复下滑手势显示判断逻辑

修改键盘布局中下滑手势的显示逻辑，使用新引入的
DisplayMode 枚举类型进行判断，确保在不同显示模式下
正确显示按键标签或气泡提示。

feat(gesture): 支持下滑手势自定义值和标签分离

当下滑手势执行提交操作时，优先使用配置的 value 值，
如果未配置则回退到使用 label 值，实现值和显示标签的分离。

test(config): 添加显示模式配置解析测试用例

为键盘手势配置添加完整的显示模式测试用例，覆盖
默认值、KEY、BUBBLE、BOTH 模式的解析验证。