### PR TITLE
feat(keyboard): 添加清空关联候选词功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -724,6 +724,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     }
                                 }
                             },
+                            onClearAssociation = {
+                                candidateState.value = candidateState.value.copy(associationCandidates = emptyList())
+                            },
                             onPageDown = { pageDown() },
                             onPageUp = { pageUp() },
                             onCommitImage = { imagePath ->

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
@@ -69,6 +69,7 @@ data class CandidateBarCallbacks(
     val onBack: (() -> Unit)? = null,
     val onHideKeyboard: (() -> Unit)? = null,
     val onShowMoreCandidates: (() -> Unit)? = null,
+    val onClearAssociation: (() -> Unit)? = null,
     val onInputTextClick: (() -> Unit)? = null,
     val onAssociationSelect: ((Int) -> Unit)? = null
 )
@@ -97,8 +98,9 @@ fun CandidateBar(
     val rowPaddingPx = with(density) { 16.dp.toPx() }
     val rightSidePx = with(density) {
         val moreBtn = if (callbacks.onShowMoreCandidates != null) 38.dp.toPx() else 0f
+        val clearBtn = if (callbacks.onClearAssociation != null) 38.dp.toPx() else 0f
         val hideBtn = if (callbacks.onHideKeyboard != null) 28.dp.toPx() else 0f
-        rowPaddingPx + moreBtn + hideBtn + 8.dp.toPx()
+        rowPaddingPx + maxOf(moreBtn, clearBtn) + hideBtn + 8.dp.toPx()
     }
 
     val displayCandidates: List<String>
@@ -425,6 +427,42 @@ fun CandidateBar(
                                 modifier = Modifier.size(24.dp)
                             )
                         }
+                    }
+                }
+                displayAssociation.isNotEmpty() && callbacks.onClearAssociation != null -> {
+                    val clearInteractionSource = remember { MutableInteractionSource() }
+                    val isClearPressed by clearInteractionSource.collectIsPressedAsState()
+
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Box(
+                        modifier = Modifier
+                            .width(1.dp)
+                            .height(28.dp)
+                            .background(visuals.dividerColor).padding(end = 1.dp)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .width(30.dp)
+                            .height(24.dp)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(
+                                if (isClearPressed) (if (visuals.isDarkTheme) Color.White.copy(alpha = 0.15f) else Color.Black.copy(
+                                    alpha = 0.1f
+                                ))
+                                else Color.Transparent
+                            )
+                            .clickable(
+                                interactionSource = clearInteractionSource,
+                                indication = null,
+                                onClick = { callbacks.onClearAssociation() }
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "清空",
+                            color = if (isClearPressed) visuals.textColor.copy(alpha = 0.6f) else visuals.textColor,
+                            fontSize = 11.sp
+                        )
                     }
                 }
                 hasAnyMore && callbacks.onShowMoreCandidates != null -> {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -90,6 +90,7 @@ fun KeyboardView(
     onKeyPressDown: ((String) -> Unit)? = null,
     onCandidateSelect: (Int) -> Unit,
     onAssociationSelect: ((Int) -> Unit)? = null,
+    onClearAssociation: (() -> Unit)? = null,
     onToggleDarkMode: (() -> Unit)? = null,
     onClipboard: (() -> Unit)? = null,
     onClipboardSelect: ((String) -> Unit)? = null,
@@ -249,7 +250,8 @@ fun KeyboardView(
                             onClipboardSelect?.invoke(inputText)
                         }
                     },
-                    onAssociationSelect = onAssociationSelect
+                    onAssociationSelect = onAssociationSelect,
+                    onClearAssociation = onClearAssociation
                 )
             )
 


### PR DESCRIPTION
在候选词栏中添加了清空关联候选词按钮，允许用户清除当前显示的关联候选词列表。
更新了相关回调接口以支持此新功能，并调整了UI布局计算以适应新增的按钮。

主要变更包括：
- 在XimeInputMethodService中添加了clearAssociation回调处理
- 在CandidateBar中添加了onClearAssociation回调参数
- 实现了清空按钮的UI组件和交互逻辑
- 调整了候选词栏右侧按钮区域的宽度计算
- 更新了KeyboardView以传递clearAssociation回调