### PR TITLE
feat(XimeInputMethodService): 更新联想候选词处理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1528,10 +1528,11 @@ onVoiceModeChange = { enabled ->
                     } else if (candState.associationCandidates.isNotEmpty()) {
                         // 联想预测词模式：按空格选中第一个联想词
                         val text = candState.associationCandidates[0]
+                        val remaining = candState.associationCandidates.drop(1)
                         withContext(Dispatchers.Main) {
                             commitText(text)
                             candidateState.value = candidateState.value.copy(
-                                associationCandidates = emptyList()
+                                associationCandidates = remaining
                             )
                         }
                         updateUI()


### PR DESCRIPTION
当选择第一个联想词后，保留剩余的候选词而不是清空列表，
以便用户可以继续选择其他推荐词汇。

fix: 更新子项目依赖到最新版本

更新了librime、librime-lua和librime-lua-deps子项目的
提交版本以包含最新的修改。