### PR TITLE
feat(keyboard): 支持手势配置的多值和动作控制功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -172,11 +172,6 @@ private fun parseGestureNode(node: com.charleskorn.kaml.YamlNode): GestureDef {
     return GestureDef()
 }
 
-private fun parseGestureList(node: com.charleskorn.kaml.YamlNode): List<GestureDef>? {
-    val list = node as? YamlList ?: return null
-    return list.items.map { parseGestureNode(it) }
-}
-
 // ── 原有配置类 ──
 
 @Serializable
@@ -591,9 +586,16 @@ object KeysConfigHelper {
     fun getConfig(): KeysConfig = config
     
     fun getSwipeUpText(key: String): String? {
-        val fromYaml = keyGestureConfig[key.lowercase()]?.swipeUp?.value
-        if (fromYaml != null && fromYaml.isNotEmpty()) return fromYaml
+        val gesture = keyGestureConfig[key.lowercase()]?.swipeUp
+        if (gesture != null) {
+            if (gesture.value.isNotEmpty()) return gesture.value
+            if (gesture.label.isNotEmpty()) return gesture.label
+        }
         return config.swipeUp[key.lowercase()]
+    }
+
+    fun getSwipeUpAction(key: String): GestureAction? {
+        return keyGestureConfig[key.lowercase()]?.swipeUp?.action
     }
     
     fun getSwipeDownEnglishText(key: String): String? {
@@ -611,9 +613,13 @@ object KeysConfigHelper {
     fun getSwipeDownDisplay(key: String): DisplayMode {
         return keyGestureConfig[key.lowercase()]?.swipeDown?.display ?: DisplayMode.BOTH
     }
-    
 
-    
+    /** 获取上滑显示位置：key（按键上）或 bubble（气泡） */
+    fun getSwipeUpDisplay(key: String): DisplayMode {
+        return keyGestureConfig[key.lowercase()]?.swipeUp?.display ?: DisplayMode.BOTH
+    }
+
+
     private fun getDefaultSwipeUp(): Map<String, String> = mapOf(
         "q" to "1", "w" to "2", "e" to "3", "r" to "4", "t" to "5",
         "y" to "6", "u" to "7", "i" to "8", "o" to "9", "p" to "0",

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -272,6 +272,8 @@ fun SwipeableKeyButton(
     swipeDownText: String? = null,
     /** 下滑文本显示在按键上（气泡为空，用于 display:key�? */
     swipeDownKeyLabel: String? = null,
+    /** 上滑文本显示在按键上（气泡则为空，用于 display:bubble） */
+    swipeUpKeyLabel: String? = null,
     onSwipe: ((String) -> Unit)? = null,
     onSwipeDown: ((String) -> Unit)? = null,
     onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
@@ -522,8 +524,9 @@ fun SwipeableKeyButton(
             maxLines = 1
         )
         
-        if (!swipeText.isNullOrEmpty()) {
-            val displayText = if (swipeText.length <= 2) swipeText else swipeText.take(2)
+        if (!(swipeUpKeyLabel ?: swipeText).isNullOrEmpty()) {
+            val keyLabel = (swipeUpKeyLabel ?: swipeText)!!
+            val displayText = if (keyLabel.length <= 2) keyLabel else keyLabel.take(2)
             Text(
                 text = displayText,
                 color = textColor.copy(alpha = 0.6f),

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -335,6 +335,10 @@ fun KeyboardLayout(
                                     val rawSwipeUpText = KeysConfigHelper.getSwipeUpText(key)
                                     val swipeUpText =
                                         if (swipeUpHintsEnabled) rawSwipeUpText else null
+                                    val swipeUpAction = KeysConfigHelper.getSwipeUpAction(key)
+                                    val swipeUpDisplay = KeysConfigHelper.getSwipeUpDisplay(key)
+                                    val swipeUpKeyLabel =
+                                        if (swipeUpDisplay != DisplayMode.BUBBLE && swipeUpHintsEnabled) swipeUpText else null
                                     val swipeDownRaw =
                                         KeysConfigHelper.getKeyGesture(key)?.swipeDown
                                     val swipeDownLabel =
@@ -395,8 +399,9 @@ fun KeyboardLayout(
                                         modifier = Modifier.weight(1f),
                                         swipeText = swipeUpText,
                                         swipeDownText = swipeDownBubbleText,
+                                        swipeUpKeyLabel = swipeUpKeyLabel,
                                         swipeDownKeyLabel = if (swipeDownDisplay == DisplayMode.KEY || swipeDownDisplay == DisplayMode.BOTH) swipeDownLabel else null,
-                                        onSwipe = if (swipeUpText != null) onKeyPress else null,
+                                        onSwipe = if (swipeUpText != null && swipeUpAction != GestureAction.NONE) onKeyPress else null,
                                         onSwipeDown = onSwipeDown,
                                         onSwipeStateChange = onSwipeStateChange,
                                         onPress = onPress,
@@ -766,6 +771,10 @@ fun KeyboardRowWithConfig(
         keys.forEach { key ->
             val rawSwipeUpText = KeysConfigHelper.getSwipeUpText(key)
             val swipeUpText = if (swipeUpHintsEnabled) rawSwipeUpText else null
+            val swipeUpAction = KeysConfigHelper.getSwipeUpAction(key)
+            val swipeUpDisplay = KeysConfigHelper.getSwipeUpDisplay(key)
+            val swipeUpKeyLabel =
+                if (swipeUpDisplay != DisplayMode.BUBBLE && swipeUpHintsEnabled) swipeUpText else null
             val swipeDownRaw = KeysConfigHelper.getKeyGesture(key)?.swipeDown
             val swipeDownLabel = swipeDownRaw?.label?.takeIf { it.isNotEmpty() }
             val swipeDownAction = swipeDownRaw?.action
@@ -826,8 +835,9 @@ fun KeyboardRowWithConfig(
                 modifier = Modifier.weight(1f),
                 swipeText = swipeUpText,
                 swipeDownText = swipeDownBubbleText,
+                swipeUpKeyLabel = swipeUpKeyLabel,
                 swipeDownKeyLabel = if ((swipeDownDisplay == DisplayMode.KEY || swipeDownDisplay == DisplayMode.BOTH) && swipeDownHintsEnabled) swipeDownLabel else null,
-                onSwipe = if (swipeUpText != null) onKeyPress else null,
+                onSwipe = if (swipeUpText != null && swipeUpAction != GestureAction.NONE) onKeyPress else null,
                 onSwipeDown = onSwipeDown,
                 onSwipeStateChange = onSwipeStateChange,
                 onPress = onPress,
@@ -1222,6 +1232,8 @@ fun CompactSwipeableKeyButton(
     modifier: Modifier = Modifier,
     swipeText: String? = null,
     swipeDownText: String? = null,
+    swipeUpKeyLabel: String? = null,
+    swipeDownKeyLabel: String? = null,
     onSwipe: ((String) -> Unit)? = null,
     onSwipeDown: ((String) -> Unit)? = null,
     onPress: (() -> Unit)? = null,
@@ -1491,9 +1503,10 @@ fun CompactSwipeableKeyButton(
             )
         }
 
-        if (swipeText != null) {
+        val keyLabel = swipeUpKeyLabel ?: swipeText
+        if (keyLabel != null) {
             Text(
-                text = swipeText,
+                text = keyLabel,
                 color = textColor.copy(alpha = 0.5f),
                 fontSize = swipeFontSize,
                 fontWeight = FontWeight.Normal,
@@ -1556,6 +1569,10 @@ fun CompactKeyboardRowWithConfig(
         keys.forEach { key ->
             val rawSwipeUpText = KeysConfigHelper.getSwipeUpText(key)
             val swipeUpText = if (swipeUpHintsEnabled) rawSwipeUpText else null
+            val swipeUpAction = KeysConfigHelper.getSwipeUpAction(key)
+            val swipeUpDisplay = KeysConfigHelper.getSwipeUpDisplay(key)
+            val swipeUpKeyLabel =
+                if (swipeUpDisplay != DisplayMode.BUBBLE && swipeUpHintsEnabled) swipeUpText else null
             val swipeDownRaw = KeysConfigHelper.getKeyGesture(key)?.swipeDown
             val swipeDownLabel = swipeDownRaw?.label?.takeIf { it.isNotEmpty() }
             val swipeDownAction = swipeDownRaw?.action
@@ -1612,7 +1629,8 @@ fun CompactKeyboardRowWithConfig(
                 modifier = Modifier.weight(1f),
                 swipeText = swipeUpText,
                 swipeDownText = swipeDownBubbleText,
-                    onSwipe = if (swipeUpText != null) onKeyPress else null,
+                swipeUpKeyLabel = swipeUpKeyLabel,
+                onSwipe = if (swipeUpText != null && swipeUpAction != GestureAction.NONE) onKeyPress else null,
                     onSwipeDown = compactOnSwipeDown,
                     onSwipeStateChange = onSwipeStateChange,
                     onPress = compactOnPress,

--- a/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
@@ -193,6 +193,62 @@ class KeyboardGestureConfigTest {
         assertEquals("\\", keys["c"]!!.swipeUp!!.value)
     }
 
+    // ── action:none ──
+
+    @Test
+    fun `swipe_up 对象格式 action none 不产生任何值`() {
+        val keys = parseKeys("""
+            s: { tap: "s", swipe_up: { action: "none" } }
+        """.trimIndent())
+        val su = keys["s"]!!.swipeUp!!
+        assertEquals("", su.label)
+        assertEquals(GestureAction.NONE, su.action)
+        assertEquals("", su.value)
+    }
+
+    @Test
+    fun `swipe_up 对象格式 action none 有 label 仍无值`() {
+        val keys = parseKeys("""
+            s: { tap: "s", swipe_up: { label: "S", action: "none", display: "bubble" } }
+        """.trimIndent())
+        val su = keys["s"]!!.swipeUp!!
+        assertEquals("S", su.label)
+        assertEquals(GestureAction.NONE, su.action)
+        assertEquals("", su.value)
+    }
+
+    @Test
+    fun `swipe_up 对象格式 action commit 无 value 时 label 为回退值`() {
+        val keys = parseKeys("""
+            s: { tap: "s", swipe_up: { label: "S", action: "commit" } }
+        """.trimIndent())
+        val su = keys["s"]!!.swipeUp!!
+        assertEquals("S", su.label)
+        assertEquals(GestureAction.COMMIT, su.action)
+        assertEquals("", su.value)
+    }
+
+    @Test
+    fun `swipe_up 对象格式 action commit 有 value 优先`() {
+        val keys = parseKeys("""
+            s: { tap: "s", swipe_up: { label: "S", action: "commit", value: "s_swipe" } }
+        """.trimIndent())
+        val su = keys["s"]!!.swipeUp!!
+        assertEquals("S", su.label)
+        assertEquals("s_swipe", su.value)
+    }
+
+    @Test
+    fun `swipe_up 字符串简写解析为 COMMIT`() {
+        val keys = parseKeys("""
+            a: { tap: "a", swipe_up: "@" }
+        """.trimIndent())
+        val su = keys["a"]!!.swipeUp!!
+        assertEquals("@", su.label)
+        assertEquals(GestureAction.COMMIT, su.action)
+        assertEquals("@", su.value)
+    }
+
     // ── DisplayMode ──
 
     @Test


### PR DESCRIPTION
- 新增 GestureValuesConfig 数据类，支持配置多值手势（bubble 显示模式）
- 重构 KeyGestureConfig，添加 swipeUpValues、swipeDownValues 字段
- 实现 swipe_up 和 swipe_down 的 values 数组格式配置解析
- 添加 swipeUpAction、swipeUpDisplay 等获取方法
- 支持 action:none 配置以禁用特定手势操作
- 添加 swipeUpKeyLabel 参数控制按键上显示文本
- 更新 YAML 配置解析逻辑，支持新旧格式兼容
- 完善相关单元测试用例