### PR TITLE
fix(keyboard): 修复键盘布局高度填充问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -325,6 +325,7 @@ fun KeyboardLayout(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .weight(1f)
+                                .fillMaxHeight()
                                 .background(keyboardBackgroundColor),
                         ) {
                             Row3KeyButton(
@@ -335,19 +336,19 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 iconColor = keyTextColor,
                                 modifier = Modifier
-                                    .width(40.dp)
+                                    .weight(1.4f)
                                     .fillMaxHeight(),
                                 shadowEnabled = shadowEnabled,
                                 shadowElevation = shadowElevation,
                                 shadowShapeRadius = shadowShapeRadius,
                             )
 
-                            Row(
-                                modifier = Modifier
-                                    .weight(7f)
-                                    .fillMaxHeight()
-                                    .background(keyboardBackgroundColor),
-                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .weight(7f)
+                                        .fillMaxHeight()
+                                        .background(keyboardBackgroundColor),
+                                ) {
                                 val bottomKeys = listOf("z", "x", "c", "v", "b", "n", "m")
                                 bottomKeys.forEach { key ->
                                     val rawSwipeUpText = KeysConfigHelper.getSwipeUpText(key)
@@ -438,7 +439,7 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 iconColor = keyTextColor,
                                 modifier = Modifier
-                                    .width(48.dp)
+                                    .weight(1.4f)
                                     .fillMaxHeight(),
                                 swipeText = "清空",
                                 onSwipe = { onKeyPress("clear_composition") },


### PR DESCRIPTION
- 为键盘布局添加 fillMaxHeight() 修饰符以正确填充高度
- 将特殊键的宽度约束从固定 40dp 改为权重 1.4f，实现更好的自适应布局
- 将清空键的宽度约束从固定 48dp 改为权重 1.4f，保持一致的布局风格
- 修正了嵌套 Row 的缩进格式

fix(submodule): 更新子模块状态

- 标记 librime、librime-lua 和 librime-lua-deps 子模块为 dirty 状态