### PR TITLE
fix(XimeInputMethodService): 修复键盘调整预览高度计算问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
@@ -553,6 +554,13 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 }
                 Log.d(TAG, "ComposeHeight: showResize=${state.showKeyboardResize} orientHeight=$orientationHeight displayHeight=$displayHeight keyboardHeight=$keyboardHeight")
                 
+                // 一次性计算导航栏高度，供后续布局复用
+                val density = LocalDensity.current
+                val navBarPx = WindowInsets.navigationBars.getBottom(density)
+                val navBarDp = with(density) { navBarPx.toDp() }
+                val hasNavBar = navBarDp > 0.dp
+                val actualNavBarDp = if (hasNavBar) navBarDp.value.toInt() else 0
+                
                 XimeTheme(darkTheme = isDarkTheme, themeId = state.themeId) {
                     Box(
                         modifier = Modifier
@@ -574,28 +582,15 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 if (state.isCompact) {
                                     if (cand.isComposing) 110.dp else 1.dp
                                 } else if (state.showKeyboardResize) ((screenHeightDp * 7) / 10 + 100).dp
-                                else {
-                                    val density = LocalDensity.current
-                                    val navBarPx = WindowInsets.navigationBars.getBottom(density)
-                                    val navBarDp = with(density) { navBarPx.toDp() }
-                                    (keyboardHeight + state.keyboardBottomPaddingDp).dp + (if (navBarDp > 0.dp) navBarDp else 0.dp)
-                                }
+                                else (keyboardHeight + state.keyboardBottomPaddingDp).dp + (if (hasNavBar) navBarDp else 0.dp)
                             )
                     ) {
                         // Sync FrameLayout height with Compose content height
-                        val density = LocalDensity.current
-                        val navBarPx = WindowInsets.navigationBars.getBottom(density)
-                        val navBarDp = with(density) { navBarPx.toDp() }
-                        val hasNavBar = navBarDp > 0.dp
-                        val actualNavBarDp = if (hasNavBar) navBarDp.value.toInt() else 0
-                        val height = if (state.showKeyboardResize) state.resizePreviewHeightDp else keyboardHeight
-                        val totalDp = height + state.keyboardBottomPaddingDp + actualNavBarDp
-                        Log.d(TAG, "HeightSync: mode=${if (state.showKeyboardResize) "resize" else "normal"} height=$height navBarDp=${navBarDp.value} padding=${state.keyboardBottomPaddingDp} hasNavBar=$hasNavBar totalDp=$totalDp")
+                        val contentHeight = if (state.showKeyboardResize) state.resizePreviewHeightDp else keyboardHeight
+                        val totalDp = contentHeight + state.keyboardBottomPaddingDp + actualNavBarDp
+                        Log.d(TAG, "HeightSync: mode=${if (state.showKeyboardResize) "resize" else "normal"} height=$contentHeight navBarDp=${navBarDp.value} padding=${state.keyboardBottomPaddingDp} hasNavBar=$hasNavBar totalDp=$totalDp")
                         SideEffect {
                             keyboardContainer.updateHeight(totalDp)
-                        }
-                        if (hasNavBar) {
-                            Spacer(modifier = Modifier.fillMaxWidth().height(navBarDp))
                         }
                         if (state.isCompact && cand.isComposing) {
                             FloatingCandidateBar(
@@ -804,61 +799,60 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 state = kbState,
                                 callbacks = callbacks,
                             )
+                           }
+                           if (state.showKeyboardResize) {
+                              KeyboardResizeOverlay(
+                                     initialHeightDp = state.resizePreviewHeightDp,
+                                     defaultHeightDp = SettingsPreferences.getDefaultKeyboardHeightDp(this@XimeInputMethodService, isLandscape),
+                                    maxContainerHeightDp = state.resizePreviewHeightDp,
+                                   currentBottomPaddingDp = state.keyboardBottomPaddingDp,
+                                  onHeightChange = { newHeight ->
+                                       uiState.value = uiState.value.copy(
+                                           resizePreviewHeightDp = newHeight
+                                       )
+                                   },
+                                  onBottomPaddingChange = { newPadding ->
+                                       uiState.value = uiState.value.copy(
+                                           keyboardBottomPaddingDp = newPadding
+                                       )
+                                   },
+                                  onReset = { defaultHeight ->
+                                       uiState.value = uiState.value.copy(
+                                           resizePreviewHeightDp = defaultHeight,
+                                           keyboardBottomPaddingDp = 0,
+                                           stretchFactor = 1f
+                                       )
+                                   },
+                                  onConfirm = { newHeight, newPadding ->
+                                       Log.d(TAG, "onConfirm: newHeight=$newHeight newPadding=$newPadding")
+                                       setKeyboardHeight(newHeight)
+                                       SettingsPreferences.setKeyboardBottomPaddingDp(this@XimeInputMethodService, newPadding)
+                                       uiState.value = uiState.value.copy(
+                                           showKeyboardResize = false,
+                                           keyboardHeightDp = newHeight,
+                                           keyboardBottomPaddingDp = newPadding,
+                                       )
+                                    },
+                                    onCancel = {
+                                        val restoreHeight = SettingsPreferences.getKeyboardHeightDp(this@XimeInputMethodService, isLandscape)
+                                        val restorePadding = SettingsPreferences.getKeyboardBottomPaddingDp(this@XimeInputMethodService)
+                                        uiState.value = uiState.value.copy(
+                                            showKeyboardResize = false,
+                                            keyboardHeightDp = restoreHeight,
+                                            keyboardBottomPaddingDp = restorePadding,
+                                        )
+                                    },
+                                    modifier = Modifier
+                                       .fillMaxSize()
+                              )
                           }
-                          }
-                          if (navBarDp > 0.dp) {
-                              Spacer(modifier = Modifier.fillMaxWidth().height(navBarDp))
-                          }
-                      }
-                      }
-                          if (state.showKeyboardResize) {
-                             KeyboardResizeOverlay(
-                                 initialHeightDp = state.resizePreviewHeightDp,
-                                 defaultHeightDp = SettingsPreferences.getDefaultKeyboardHeightDp(this@XimeInputMethodService, isLandscape),
-                                maxContainerHeightDp = keyboardHeight,
-                                currentBottomPaddingDp = state.keyboardBottomPaddingDp,
-                               onHeightChange = { newHeight ->
-                                   uiState.value = uiState.value.copy(
-                                       resizePreviewHeightDp = newHeight
-                                   )
-                               },
-                               onBottomPaddingChange = { newPadding ->
-                                   uiState.value = uiState.value.copy(
-                                       keyboardBottomPaddingDp = newPadding
-                                   )
-                               },
-                               onReset = { defaultHeight ->
-                                   uiState.value = uiState.value.copy(
-                                       resizePreviewHeightDp = defaultHeight,
-                                       keyboardBottomPaddingDp = 0,
-                                       stretchFactor = 1f
-                                   )
-                               },
-                               onConfirm = { newHeight, newPadding ->
-                                   Log.d(TAG, "onConfirm: newHeight=$newHeight newPadding=$newPadding")
-                                   setKeyboardHeight(newHeight)
-                                   SettingsPreferences.setKeyboardBottomPaddingDp(this@XimeInputMethodService, newPadding)
-                                   uiState.value = uiState.value.copy(
-                                       showKeyboardResize = false,
-                                       keyboardHeightDp = newHeight,
-                                       keyboardBottomPaddingDp = newPadding,
-                                   )
-                                },
-                                onCancel = {
-                                    val restoreHeight = SettingsPreferences.getKeyboardHeightDp(this@XimeInputMethodService, isLandscape)
-                                    val restorePadding = SettingsPreferences.getKeyboardBottomPaddingDp(this@XimeInputMethodService)
-                                    uiState.value = uiState.value.copy(
-                                        showKeyboardResize = false,
-                                        keyboardHeightDp = restoreHeight,
-                                        keyboardBottomPaddingDp = restorePadding,
-                                    )
-                                },
-                                modifier = Modifier
-                                   .align(androidx.compose.ui.Alignment.BottomCenter)
-                                   .fillMaxWidth()
-                          )
-                      }
-                    }
+                           }
+                           if (navBarDp > 0.dp) {
+                               Spacer(modifier = Modifier.fillMaxWidth().height(navBarDp))
+                           }
+                       }
+                       }
+                     }
                 }
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -804,7 +804,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                               KeyboardResizeOverlay(
                                      initialHeightDp = state.resizePreviewHeightDp,
                                      defaultHeightDp = SettingsPreferences.getDefaultKeyboardHeightDp(this@XimeInputMethodService, isLandscape),
-                                    maxContainerHeightDp = state.resizePreviewHeightDp,
+                                    maxContainerHeightDp = state.resizePreviewHeightDp + state.keyboardBottomPaddingDp,
                                    currentBottomPaddingDp = state.keyboardBottomPaddingDp,
                                   onHeightChange = { newHeight ->
                                        uiState.value = uiState.value.copy(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardResizeOverlay.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardResizeOverlay.kt
@@ -94,8 +94,8 @@ fun KeyboardResizeOverlay(
     ) {
         Box(
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .height(currentHeightDp.roundToInt().dp)
+                .align(Alignment.TopCenter)
+                .height((currentHeightDp + currentBottomPaddingDpState).roundToInt().dp)
                 .fillMaxWidth()
                 .background(Color.Black.copy(alpha = 0.5f))
                 .pointerInput(Unit) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardResizeOverlay.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardResizeOverlay.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -61,8 +62,8 @@ fun KeyboardResizeOverlay(
         maxKeyboardHeightDp = (screenHeightDp * 7) / 10
         maxBottomPaddingDp = 80
     } else {
-        minKeyboardHeightDp = (screenHeightDp * 20) / 100
-        maxKeyboardHeightDp = (screenHeightDp * 50) / 100
+        minKeyboardHeightDp = (screenHeightDp * 28) / 100
+        maxKeyboardHeightDp = (screenHeightDp * 45) / 100
         maxBottomPaddingDp = 80
     }
 
@@ -75,6 +76,10 @@ fun KeyboardResizeOverlay(
     val currentOnHeightChange by rememberUpdatedState(onHeightChange)
     val currentOnBottomPaddingChange by rememberUpdatedState(onBottomPaddingChange)
     val currentOnReset by rememberUpdatedState(onReset)
+
+    val dragThrottleMs = 50L
+    var lastHeightCallbackMs by remember { mutableLongStateOf(0L) }
+    var lastPaddingCallbackMs by remember { mutableLongStateOf(0L) }
 
     Box(
         modifier = modifier
@@ -90,7 +95,7 @@ fun KeyboardResizeOverlay(
         Box(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .height((currentHeightDp + currentBottomPaddingDpState).roundToInt().dp)
+                .height(currentHeightDp.roundToInt().dp)
                 .fillMaxWidth()
                 .background(Color.Black.copy(alpha = 0.5f))
                 .pointerInput(Unit) {
@@ -100,9 +105,15 @@ fun KeyboardResizeOverlay(
                             val paddingChangeDp = with(density) { -dragAmount.y.toDp().value }
                             currentBottomPaddingDpState = (currentBottomPaddingDpState + paddingChangeDp)
                                 .coerceIn(0f, maxBottomPaddingDp.toFloat())
-                            currentOnBottomPaddingChange(currentBottomPaddingDpState.roundToInt())
+                            val now = System.currentTimeMillis()
+                            if (now - lastPaddingCallbackMs >= dragThrottleMs) {
+                                currentOnBottomPaddingChange(currentBottomPaddingDpState.roundToInt())
+                                lastPaddingCallbackMs = now
+                            }
                         },
-                        onDragEnd = { }
+                        onDragEnd = {
+                            currentOnBottomPaddingChange(currentBottomPaddingDpState.roundToInt())
+                        }
                     )
                 }
         ) {
@@ -119,9 +130,15 @@ fun KeyboardResizeOverlay(
                                 val heightChangeDp = with(density) { -dragAmount.y.toDp().value }
                                 currentHeightDp = (currentHeightDp + heightChangeDp)
                                     .coerceIn(minKeyboardHeightDp.toFloat(), maxKeyboardHeightDp.toFloat())
-                                currentOnHeightChange(currentHeightDp.roundToInt())
+                                val now = System.currentTimeMillis()
+                                if (now - lastHeightCallbackMs >= dragThrottleMs) {
+                                    currentOnHeightChange(currentHeightDp.roundToInt())
+                                    lastHeightCallbackMs = now
+                                }
                             },
-                            onDragEnd = { }
+                            onDragEnd = {
+                                currentOnHeightChange(currentHeightDp.roundToInt())
+                            }
                         )
                     },
                 contentAlignment = Alignment.Center


### PR DESCRIPTION
- 修复resize预览容器的最大高度计算，将键盘底部填充考虑在内
- 修复KeyboardResizeOverlay的位置对齐，从底部居中改为顶部居中
- 修复KeyboardResizeOverlay的高度计算，正确包含底部填充