### PR TITLE
chore(app): 升级版本号至2.5.0-beta2并更新子项目提交状态

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 44
-        versionName = "2.5.0-beta1"
+        versionCode = 45
+        versionName = "2.5.0-beta2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
- 将versionCode从44升级到45
- 将versionName从2.5.0-beta1更新为2.5.0-beta2
- 更新librime、librime-lua和librime-lua-deps子项目的提交状态为dirty标记