### PR TITLE
feat(voice): 添加语音模式关闭回调处理

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/VoiceKeyboardContainer.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/VoiceKeyboardContainer.kt
@@ -22,7 +22,8 @@ class VoiceKeyboardContainer(
     private val onPerformSearch: () -> Unit,
     private val onStopRecognition: () -> Unit,
     private val isRecording: () -> Boolean,
-    private val setRecording: (Boolean) -> Unit
+    private val setRecording: (Boolean) -> Unit,
+    private val onVoiceDismiss: () -> Unit = {}
 ) : FrameLayout(context) {
 
     private var isTrackingVoiceButtons = false
@@ -215,6 +216,10 @@ class VoiceKeyboardContainer(
             if (isRecording()) {
                 onStopRecognition()
                 setRecording(false)
+            }
+
+            if (state.isVoiceMode) {
+                onVoiceDismiss()
             }
         }
 

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -607,7 +607,19 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             onPerformSearch = { pendingVoiceAction = { performSearch() } },
             onStopRecognition = { voiceRecognitionHandler.stopRecognition() },
             isRecording = { voiceRecordingStarted },
-            setRecording = { voiceRecordingStarted = it }
+            setRecording = { voiceRecordingStarted = it },
+            onVoiceDismiss = {
+                val action = pendingVoiceAction
+                pendingVoiceAction = null
+                action?.invoke()
+                uiState.value = uiState.value.copy(
+                    isVoiceMode = false,
+                    voiceButtonState = VoiceButtonState(),
+                    voiceRecognizedText = ""
+                )
+                keyboardViewModel.setRoute(KeyboardRoute.Keyboard)
+                isTrackingVoiceButtons = false
+            }
         )
         
         val composeView = ComposeView(this).apply {
@@ -1017,9 +1029,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     return true
                 }
                 KeyEvent.KEYCODE_SPACE, KeyEvent.KEYCODE_ENTER -> {
-                    selectCandidate(highlightIndex.intValue)
-                    highlightIndex.intValue = 0
-                    return true
+                    if (candidateState.value.candidates.isNotEmpty()) {
+                        selectCandidate(highlightIndex.intValue)
+                        highlightIndex.intValue = 0
+                        return true
+                    }
                 }
                 KeyEvent.KEYCODE_1 -> { selectCandidate(0); highlightIndex.intValue = 0; return true }
                 KeyEvent.KEYCODE_2 -> { selectCandidate(1); highlightIndex.intValue = 0; return true }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
@@ -76,16 +76,19 @@ fun SpaceKeyButton(
                         onVoiceModeChange?.invoke(true)
                     }
                     
-                    waitForUpOrCancellation()
-                    longPressJob.cancel()
-                    
-                    if (longPressTriggered) {
-                        onVoiceModeChange?.invoke(false)
-                    } else {
-                        onClick()
+                    try {
+                        waitForUpOrCancellation()
+                    } finally {
+                        longPressJob.cancel()
+                        
+                        if (longPressTriggered) {
+                            onVoiceModeChange?.invoke(false)
+                        } else {
+                            onClick()
+                        }
+                        
+                        isPressed = false
                     }
-                    
-                    isPressed = false
                 }
             },
         contentAlignment = Alignment.Center


### PR DESCRIPTION
添加 onVoiceDismiss 回调函数来处理语音模式关闭时的状态重置，
包括清除待执行动作、重置 UI 状态、切换键盘路由和重置跟踪状态。

修复候选词为空时按空格或回车键的崩溃问题，
在 SpaceKeyButton 中改进长按释放逻辑以确保正确重置按下状态。

fix(space-key): 修复长按后状态重置逻辑

在 SpaceKeyButton 的点击处理中使用 try-finally 块，
确保无论操作成功与否都能正确取消长按任务并重置按下状态。

fix(candidate): 防止空候选词列表时的选择错误

在处理空格键和回车键事件时添加检查，
仅当候选词列表不为空时才执行选择操作。

chore(submodule): 更新子模块版本标记为 dirty