### PR TITLE
chore(app): 更新版本号至2.5.0-beta4并同步子项目提交

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 46
-        versionName = "2.5.0-beta3"
+        versionCode = 47
+        versionName = "2.5.0-beta4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
更新应用版本号从2.5.0-beta3到2.5.0-beta4，versionCode从46递增到47， 同时更新了librime、librime-lua和librime-lua-deps子项目的本地修改状态标记