### PR TITLE
feat(keyboard): 添加长按图标支持和模式切换功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -37,6 +37,16 @@ object SettingsPreferences {
     const val KEY_SWIPE_UP_HINTS_ENABLED = "swipe_up_hints_enabled"
     const val KEY_SWIPE_DOWN_HINTS_ENABLED = "swipe_down_hints_enabled"
     const val KEY_SHOW_PRESS_BUBBLE = "show_press_bubble"
+
+    private const val KEY_MODE_CHANGE_TARGET = "mode_change_target"
+
+    fun getModeChangeTargetIsNumber(context: Context): Boolean {
+        return getPrefs(context).getBoolean(KEY_MODE_CHANGE_TARGET, false)
+    }
+
+    fun setModeChangeTargetIsNumber(context: Context, isNumber: Boolean) {
+        getPrefs(context).edit().putBoolean(KEY_MODE_CHANGE_TARGET, isNumber).apply()
+    }
     
     private const val KEY_KEYBOARD_HEIGHT_DP = "keyboard_height_dp"
     private const val KEY_KEYBOARD_HEIGHT_DP_LANDSCAPE = "keyboard_height_dp_landscape"

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -60,7 +60,8 @@ data class SwipeState(
     // 长按弹出选择
     val isLongPress: Boolean = false,
     val longPressItems: List<String> = emptyList(),
-    val selectedLongPressIndex: Int = 0
+    val selectedLongPressIndex: Int = 0,
+    val longPressDrawableIds: List<Int> = emptyList(),
 )
 
 @Composable
@@ -289,6 +290,7 @@ fun SwipeableKeyButton(
     onPress: (() -> Unit)? = null,
     onLongPressSelect: ((String) -> Unit)? = null,
     longPressItems: List<String>? = null,
+    longPressDrawableIds: List<Int>? = null,
     fontSize: androidx.compose.ui.unit.TextUnit = androidx.compose.ui.unit.TextUnit.Unspecified,
     swipeFontSize: androidx.compose.ui.unit.TextUnit = 9.sp,
     shadowEnabled: Boolean = true,
@@ -315,6 +317,7 @@ fun SwipeableKeyButton(
     val currentOnClick by rememberUpdatedState(onClick)
     val currentOnLongPressSelect by rememberUpdatedState(onLongPressSelect)
     val currentLongPressItems by rememberUpdatedState(longPressItems)
+    val currentLongPressDrawableIds by rememberUpdatedState(longPressDrawableIds)
     val scope = rememberCoroutineScope()
     val view = LocalView.current
     
@@ -453,7 +456,8 @@ fun SwipeableKeyButton(
                                 isPressed = true,
                                 isLongPress = true,
                                 longPressItems = items,
-                                selectedLongPressIndex = 0
+                                selectedLongPressIndex = 0,
+                                longPressDrawableIds = currentLongPressDrawableIds ?: emptyList()
                             ),
                             buttonBounds
                         )
@@ -494,7 +498,8 @@ fun SwipeableKeyButton(
                                             isPressed = true,
                                             isLongPress = true,
                                             longPressItems = items,
-                                            selectedLongPressIndex = selectedIdx
+                                            selectedLongPressIndex = selectedIdx,
+                                            longPressDrawableIds = currentLongPressDrawableIds ?: emptyList()
                                         ),
                                         buttonBounds
                                     )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -519,15 +519,21 @@ fun KeyboardLayout(
                                 modifier = Modifier.weight(0.8f)
                             )
                         } else {
-                            // ?123 — 硬编码
-                            KeyButton(
+                            // ?123 — 硬编码（长按弹出 t9/t26 图标）
+                            SwipeableKeyButton(
                                 text = "?123",
                                 onClick = { onKeyPress("mode_change") },
-                                onLongClick = { onKeyPress("mode_change_symbol") },
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier.weight(1.2f),
                                 onPress = { onKeyPressDown?.invoke("mode_change") },
+                                onLongPressSelect = { label -> onKeyPress("mode_change_$label") },
+                                longPressItems = listOf("t9", "t26"),
+                                longPressDrawableIds = listOf(
+                                    com.kingzcheung.xime.R.drawable.t9,
+                                    com.kingzcheung.xime.R.drawable.t26
+                                ),
+                                onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
                                 shadowEnabled = shadowEnabled,
                                 shadowElevation = shadowElevation,
                                 shadowShapeRadius = shadowShapeRadius,
@@ -1503,14 +1509,20 @@ private fun LandscapeKeyboardContent(
                     shadowElevation = shadowElevation,
                     shadowShapeRadius = shadowShapeRadius,
                 )
-                KeyButton(
+                SwipeableKeyButton(
                     text = "?123",
                     onClick = { onKeyPress("mode_change") },
-                    onLongClick = { onKeyPress("mode_change_symbol") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("mode_change") },
+                    onLongPressSelect = { label -> onKeyPress("mode_change_$label") },
+                    longPressItems = listOf("t9", "t26"),
+                    longPressDrawableIds = listOf(
+                        com.kingzcheung.xime.R.drawable.t9,
+                        com.kingzcheung.xime.R.drawable.t26
+                    ),
+                    onSwipeStateChange = onSwipeStateChange,
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
                     shadowShapeRadius = shadowShapeRadius,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -34,6 +35,7 @@ import com.kingzcheung.xime.keyboard.KeyboardRoute
 import com.kingzcheung.xime.keyboard.ToolbarAction
 import com.kingzcheung.xime.keyboard.ToolbarButton
 import com.kingzcheung.xime.settings.KeysConfigHelper
+import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.ui.settings.SchemaListView
 import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import com.kingzcheung.xime.viewmodel.KeyboardUiState
@@ -277,6 +279,17 @@ fun KeyboardView(
                         Modifier
                     }
 
+                    val context = LocalContext.current
+
+                    var modeChangeTarget: KeyboardLayoutAction by remember {
+                        mutableStateOf(
+                            if (SettingsPreferences.getModeChangeTargetIsNumber(context))
+                                KeyboardLayoutAction.SwitchToNumber
+                            else
+                                KeyboardLayoutAction.SwitchToCommonSymbol
+                        )
+                    }
+
                     val fullScreenOnKeyPress: (String) -> Unit = { key ->
                         when (key) {
                             "shift" -> viewModel.toggleShift()
@@ -284,11 +297,25 @@ fun KeyboardView(
                             "shift_caps" -> viewModel.doubleTapShift()
                             "mode_change" -> {
                                 viewModel.setKeyboardState(keyboardState.transition(
-                                    KeyboardLayoutAction.SwitchToCommonSymbol, state.isAsciiMode
+                                    modeChangeTarget, state.isAsciiMode
                                 ))
                                 callbacks.onKeyPress("clear_composition", false)
                             }
                             "mode_change_symbol" -> viewModel.setRoute(KeyboardRoute.Symbol)
+                            "mode_change_t9" -> {
+                                modeChangeTarget = KeyboardLayoutAction.SwitchToNumber
+                                SettingsPreferences.setModeChangeTargetIsNumber(context, true)
+                                viewModel.setKeyboardState(keyboardState.transition(
+                                    KeyboardLayoutAction.SwitchToNumber, state.isAsciiMode
+                                ))
+                            }
+                            "mode_change_t26" -> {
+                                modeChangeTarget = KeyboardLayoutAction.SwitchToCommonSymbol
+                                SettingsPreferences.setModeChangeTargetIsNumber(context, false)
+                                viewModel.setKeyboardState(keyboardState.transition(
+                                    KeyboardLayoutAction.SwitchToCommonSymbol, state.isAsciiMode
+                                ))
+                            }
                             "emoji" -> viewModel.setRoute(KeyboardRoute.Emoji)
                             else -> {
                                 callbacks.onKeyPress(key, isShifted)

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SwipeBubble.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SwipeBubble.kt
@@ -1,5 +1,6 @@
 package com.kingzcheung.xime.ui.keyboard
 
+import android.graphics.Bitmap
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.Typeface
@@ -56,6 +57,7 @@ data class BubbleDrawData(
     val selectedFontSizePx: Float,
     val normalFontSizePx: Float,
     val selectedBgRadiusPx: Float,
+    val longPressIconBitmaps: List<Bitmap> = emptyList(),
 )
 
 @Composable
@@ -105,7 +107,11 @@ fun rememberSwipeBubbleDrawData(
     }
 
     val bodyWidth = if (isLongPressMode) {
-        maxOf(swipeState.longPressItems.size, 3) * keyWidthPx
+        val cellMin = if (swipeState.longPressDrawableIds.isNotEmpty())
+            swipeState.longPressItems.size
+        else
+            maxOf(swipeState.longPressItems.size, 3)
+        cellMin * keyWidthPx
     } else {
         maxOf(textPaint.measureText(displayText!!) + with(density) { 20.dp.toPx() }, minBodyWidthPx)
     }
@@ -140,6 +146,20 @@ fun rememberSwipeBubbleDrawData(
 
     val paddingPx = with(density) { 10.dp.toPx() }
 
+    val longPressIconBitmaps = remember(swipeState.longPressDrawableIds, textColor) {
+        swipeState.longPressDrawableIds.mapNotNull { id ->
+            val drawable = context.resources.getDrawable(id, context.theme)?.mutate() ?: return@mapNotNull null
+            drawable.setTint(textColor)
+            val w = drawable.intrinsicWidth.coerceAtLeast(1)
+            val h = drawable.intrinsicHeight.coerceAtLeast(1)
+            val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            val bmpCanvas = android.graphics.Canvas(bitmap)
+            drawable.setBounds(0, 0, w, h)
+            drawable.draw(bmpCanvas)
+            bitmap
+        }
+    }
+
     return BubbleDrawData(
         boxLeft = boxLeft,
         boxTop = boxTop,
@@ -166,6 +186,7 @@ fun rememberSwipeBubbleDrawData(
         selectedFontSizePx = selectedFontSizePx,
         normalFontSizePx = normalFontSizePx,
         selectedBgRadiusPx = selectedBgRadiusPx,
+        longPressIconBitmaps = longPressIconBitmaps,
     )
 }
 
@@ -254,12 +275,24 @@ fun DrawScope.drawSwipeBubble(data: BubbleDrawData) {
                         itemLeft, 0f, itemLeft + cellWidth, data.bodyHeightPx, r, r, bubbleBgPaint
                     )
                 }
-                val fontSize = if (index == data.selectedLongPressIndex) data.selectedFontSizePx else data.normalFontSizePx
-                bubbleLabelPaint.color = if (index == data.selectedLongPressIndex) accentColor else data.textColor
-                bubbleLabelPaint.textSize = fontSize
-                bubbleLabelPaint.textAlign = Paint.Align.CENTER
-                val textY = data.bodyHeightPx / 2f - (bubbleLabelPaint.fontMetrics.ascent + bubbleLabelPaint.fontMetrics.descent) / 2f
-                canvas.drawText(item, itemLeft + cellWidth / 2f, textY, bubbleLabelPaint)
+                if (data.longPressIconBitmaps.isNotEmpty() && index < data.longPressIconBitmaps.size) {
+                    val icon = data.longPressIconBitmaps[index]
+                    val iconSize = data.bodyHeightPx * 0.45f
+                    val iconLeft = itemLeft + (cellWidth - iconSize) / 2f
+                    val iconTop = (data.bodyHeightPx - iconSize) / 2f
+                    canvas.drawBitmap(
+                        icon, null,
+                        android.graphics.RectF(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize),
+                        null
+                    )
+                } else {
+                    val fontSize = if (index == data.selectedLongPressIndex) data.selectedFontSizePx else data.normalFontSizePx
+                    bubbleLabelPaint.color = if (index == data.selectedLongPressIndex) accentColor else data.textColor
+                    bubbleLabelPaint.textSize = fontSize
+                    bubbleLabelPaint.textAlign = Paint.Align.CENTER
+                    val textY = data.bodyHeightPx / 2f - (bubbleLabelPaint.fontMetrics.ascent + bubbleLabelPaint.fontMetrics.descent) / 2f
+                    canvas.drawText(item, itemLeft + cellWidth / 2f, textY, bubbleLabelPaint)
+                }
             }
             canvas.restore()
         } else if (data.displayText != null) {

--- a/app/src/main/res/drawable/t26.xml
+++ b/app/src/main/res/drawable/t26.xml
@@ -1,0 +1,37 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M2,4L4,4A1,1 0,0 1,5 5L5,7A1,1 0,0 1,4 8L2,8A1,1 0,0 1,1 7L1,5A1,1 0,0 1,2 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M8,4L10,4A1,1 0,0 1,11 5L11,7A1,1 0,0 1,10 8L8,8A1,1 0,0 1,7 7L7,5A1,1 0,0 1,8 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M14,4L16,4A1,1 0,0 1,17 5L17,7A1,1 0,0 1,16 8L14,8A1,1 0,0 1,13 7L13,5A1,1 0,0 1,14 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M2,10L4,10A1,1 0,0 1,5 11L5,13A1,1 0,0 1,4 14L2,14A1,1 0,0 1,1 13L1,11A1,1 0,0 1,2 10z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M8,10L10,10A1,1 0,0 1,11 11L11,13A1,1 0,0 1,10 14L8,14A1,1 0,0 1,7 13L7,11A1,1 0,0 1,8 10z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M20,4L22,4A1,1 0,0 1,23 5L23,7A1,1 0,0 1,22 8L20,8A1,1 0,0 1,19 7L19,5A1,1 0,0 1,20 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M5,16L19,16A1,1 0,0 1,20 17L20,18A1,1 0,0 1,19 19L5,19A1,1 0,0 1,4 18L4,17A1,1 0,0 1,5 16z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M14,10L16,10A1,1 0,0 1,17 11L17,13A1,1 0,0 1,16 14L14,14A1,1 0,0 1,13 13L13,11A1,1 0,0 1,14 10z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M20,10L22,10A1,1 0,0 1,23 11L23,13A1,1 0,0 1,22 14L20,14A1,1 0,0 1,19 13L19,11A1,1 0,0 1,20 10z"
+        android:fillColor="#403F3F"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/t9.xml
+++ b/app/src/main/res/drawable/t9.xml
@@ -1,0 +1,37 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M5,4L7,4A1,1 0,0 1,8 5L8,7A1,1 0,0 1,7 8L5,8A1,1 0,0 1,4 7L4,5A1,1 0,0 1,5 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M11,4L13,4A1,1 0,0 1,14 5L14,7A1,1 0,0 1,13 8L11,8A1,1 0,0 1,10 7L10,5A1,1 0,0 1,11 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M17,4L19,4A1,1 0,0 1,20 5L20,7A1,1 0,0 1,19 8L17,8A1,1 0,0 1,16 7L16,5A1,1 0,0 1,17 4z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M5,10L7,10A1,1 0,0 1,8 11L8,13A1,1 0,0 1,7 14L5,14A1,1 0,0 1,4 13L4,11A1,1 0,0 1,5 10z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M11,10L13,10A1,1 0,0 1,14 11L14,13A1,1 0,0 1,13 14L11,14A1,1 0,0 1,10 13L10,11A1,1 0,0 1,11 10z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M17,10L19,10A1,1 0,0 1,20 11L20,13A1,1 0,0 1,19 14L17,14A1,1 0,0 1,16 13L16,11A1,1 0,0 1,17 10z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M5,16L7,16A1,1 0,0 1,8 17L8,19A1,1 0,0 1,7 20L5,20A1,1 0,0 1,4 19L4,17A1,1 0,0 1,5 16z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M11,16L13,16A1,1 0,0 1,14 17L14,19A1,1 0,0 1,13 20L11,20A1,1 0,0 1,10 19L10,17A1,1 0,0 1,11 16z"
+        android:fillColor="#403F3F"/>
+    <path
+        android:pathData="M17,16L19,16A1,1 0,0 1,20 17L20,19A1,1 0,0 1,19 20L17,20A1,1 0,0 1,16 19L16,17A1,1 0,0 1,17 16z"
+        android:fillColor="#403F3F"/>
+  </group>
+</vector>


### PR DESCRIPTION
- 在SwipeState中添加longPressDrawableIds参数用于存储长按图标资源ID列表
- 修改SwipeableKeyButton组件以支持传入长按图标资源ID
- 在键盘布局中将?123按键改为可滑动按钮，支持长按弹出T9/T26图标选择
- 实现T9和T26模式切换功能，通过设置保存用户选择的目标模式
- 添加t9和t26矢量图标资源文件
- 优化SwipeBubble绘制逻辑，支持显示图标而非文本标签
- 新增KEY_MODE_CHANGE_TARGET设置项用于记忆用户的模式切换目标