### PR TITLE
feat(core): 添加模型运行时管理器用于统一模型生命周期管理

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
+++ b/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
@@ -6,6 +6,7 @@ import com.kingzcheung.xime.plugin.ExtensionManager
 import com.kingzcheung.xime.util.FileLogger
 import com.kingzcheung.xime.plugin.core.runtime.PluginManager
 import com.kingzcheung.xime.rime.RimeConfigHelper
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.settings.SettingsPreferences
@@ -67,6 +68,10 @@ class XimeApplication : Application() {
         // 从 xime.yaml 的 style.color_scheme 读取默认主题
         SettingsPreferences.defaultKeyboardTheme = KeysConfigHelper.loadDefaultThemeId(this)
         Log.d(TAG, "Default keyboard theme: ${SettingsPreferences.defaultKeyboardTheme}")
+
+        // 初始化模型运行时（内存管理 + 生命周期）
+        ModelRuntime.attach(this)
+        Log.d(TAG, "ModelRuntime initialized")
 
         preInitializeRimeEngine()
         

--- a/app/src/main/java/com/kingzcheung/xime/association/AssociationManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/AssociationManager.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.association
 
 import android.content.Context
 import android.util.Log
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.util.FileLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -35,20 +36,26 @@ object AssociationManager {
             try {
                 fusionEngine = NgramFusionEngine(ctx)
                 
-                FileLogger.i(TAG, "Starting OnnxAssociationEngine initialization...")
-                val modelInit = OnnxAssociationEngine.initialize(ctx)
-                FileLogger.i(TAG, "OnnxAssociationEngine init result: $modelInit")
+                ModelRuntime.register(
+                    id = "predictive_text",
+                    loader = { OnnxAssociationEngine.initialize(ctx) },
+                    releaser = { OnnxAssociationEngine.release() },
+                    label = "智能联想模型"
+                )
+                val modelLoaded = ModelRuntime.load("predictive_text")
+                FileLogger.i(TAG, "ModelRuntime.load(predictive_text) result: $modelLoaded")
 
-                if (modelInit) {
+                if (modelLoaded) {
+                    ModelRuntime.keepWarm("predictive_text")
                     OnnxAssociationEngine.startWarmup()
                 }
 
                 val cacheInit = fusionEngine.initialize()
                 FileLogger.i(TAG, "NgramFusionEngine init result: $cacheInit")
                 
-                isInitialized = modelInit
+                isInitialized = modelLoaded
                 
-                FileLogger.i(TAG, "AssociationManager initialized: model=$modelInit, cache=$cacheInit")
+                FileLogger.i(TAG, "AssociationManager initialized: model=$modelLoaded, cache=$cacheInit")
                 isInitialized
                 
             } catch (e: Exception) {
@@ -115,7 +122,7 @@ object AssociationManager {
     
     fun release() {
         if (isInitialized) {
-            OnnxAssociationEngine.release()
+            ModelRuntime.unload("predictive_text")
             isInitialized = false
             context = null
             Log.d(TAG, "AssociationManager released")

--- a/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/association/OnnxAssociationEngine.kt
@@ -1,6 +1,7 @@
 package com.kingzcheung.xime.association
 
 import android.content.Context
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.util.FileLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,6 +25,13 @@ object OnnxAssociationEngine {
             FileLogger.d(TAG, "Already initialized")
             return true
         }
+
+        ModelRuntime.register(
+            id = "predictive_text",
+            loader = { initialize(context) },
+            releaser = { release() },
+            label = "智能联想模型"
+        )
 
         try {
             val modelDir = context.filesDir
@@ -67,6 +75,7 @@ object OnnxAssociationEngine {
             if (success) {
                 isInitialized = true
                 FileLogger.i(TAG, "ONNX Runtime initialized successfully")
+                ModelRuntime.markLoaded("predictive_text")
                 return true
             } else {
                 FileLogger.e(TAG, "Failed to initialize ONNX Runtime - NativeOnnxEngine.initialize returned false")
@@ -136,6 +145,7 @@ object OnnxAssociationEngine {
     fun release() {
         NativeOnnxEngine.release()
         isInitialized = false
+        ModelRuntime.markUnloaded("predictive_text")
         FileLogger.d(TAG, "ONNX Runtime released")
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/model/ModelRuntime.kt
+++ b/app/src/main/java/com/kingzcheung/xime/model/ModelRuntime.kt
@@ -9,6 +9,18 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * 模型运行时生命周期管理器。
+ *
+ * 统一管理 AI 模型的内存加载、释放、引用计数和内存压力回调。
+ * 三个等级：
+ * - **HOT**（[keepWarm]）：常驻内存，`onTrimMemory` 不会释放
+ * - **WARM**（默认）：引用计数归零后自动释放
+ * - **COLD** / **OFF**：未加载
+ *
+ * 业务层通过 [load]/[unload] 管理引用计数，通过 [keepWarm]/[releaseWarm] 控制常驻标记。
+ * 引擎自身在 [markLoaded]/[markUnloaded] 同步状态。
+ */
 object ModelRuntime {
 
     private const val TAG = "ModelRuntime"
@@ -30,6 +42,7 @@ object ModelRuntime {
     private val states = ConcurrentHashMap<String, State>()
     private var attached = false
 
+    /** 注册 [ComponentCallbacks2] 监听系统内存压力。在 [Application.onCreate] 中调用一次。 */
     fun attach(context: Context) {
         if (attached) return
         attached = true
@@ -37,6 +50,11 @@ object ModelRuntime {
         FileLogger.i(TAG, "ModelRuntime attached")
     }
 
+    /**
+     * 注册模型的加载/释放函数。
+     * [loader] 在首次 [load] 时调用，[releaser] 在引用归零且非 HOT 时触发。
+     * 重复注册同一 [id] 会被跳过。
+     */
     fun register(
         id: String,
         loader: suspend () -> Boolean,
@@ -51,6 +69,10 @@ object ModelRuntime {
         FileLogger.i(TAG, "Registered model: $label ($id)")
     }
 
+    /**
+     * 由引擎在初始化成功后调用，标记模型为已加载。
+     * 用于引擎自注册场景（引擎在 [initialize] 内主动同步状态到 ModelRuntime）。
+     */
     fun markLoaded(id: String) {
         val state = states.getOrPut(id) { State() }
         if (!state.loaded) {
@@ -59,6 +81,7 @@ object ModelRuntime {
         }
     }
 
+    /** 由引擎在释放后调用，标记模型为未加载。 */
     fun markUnloaded(id: String) {
         states[id]?.let {
             it.loaded = false
@@ -66,6 +89,11 @@ object ModelRuntime {
         }
     }
 
+    /**
+     * 加载模型（引用计数 +1）。
+     * 首次加载时调用 [register] 注册的 [loader]，后续调用仅递增引用计数。
+     * @return 加载是否成功
+     */
     suspend fun load(id: String): Boolean {
         val reg = registry[id] ?: run {
             FileLogger.w(TAG, "load: unknown model '$id'")
@@ -93,6 +121,10 @@ object ModelRuntime {
         }
     }
 
+    /**
+     * 尝试引用已加载的模型（引用计数 +1）。
+     * 如果模型尚未加载则返回 false，不触发加载。
+     */
     fun tryLoad(id: String): Boolean {
         val state = states[id] ?: return false
         if (!state.loaded) return false
@@ -100,6 +132,10 @@ object ModelRuntime {
         return true
     }
 
+    /**
+     * 卸载模型（引用计数 -1）。
+     * 引用计数归零且非 HOT 时调用 [register] 注册的 [releaser]，释放引擎资源。
+     */
     fun unload(id: String) {
         val state = states[id] ?: return
         val reg = registry[id] ?: return
@@ -116,19 +152,27 @@ object ModelRuntime {
         }
     }
 
+    /** 标记模型为常驻（HOT），[onTrimMemory] 和引用归零不会释放它。 */
     fun keepWarm(id: String) {
         states[id]?.hot = true
     }
 
+    /** 取消常驻标记，允许引用归零时释放。 */
     fun releaseWarm(id: String) {
         states[id]?.hot = false
     }
 
+    /** 查询模型是否已加载。 */
     fun isLoaded(id: String): Boolean = states[id]?.loaded ?: false
 
+    /** 返回所有已加载模型及其常驻状态。 */
     fun getLoadedModels(): Map<String, Boolean> =
         states.filter { it.value.loaded }.mapValues { it.value.hot }
 
+    /**
+     * 响应系统内存压力。
+     * [ComponentCallbacks2.TRIM_MEMORY_MODERATE] 及以上释放所有非 HOT 模型。
+     */
     fun onTrimMemory(level: Int) {
         val shouldRelease = level >= ComponentCallbacks2.TRIM_MEMORY_MODERATE
         if (!shouldRelease) return

--- a/app/src/main/java/com/kingzcheung/xime/model/ModelRuntime.kt
+++ b/app/src/main/java/com/kingzcheung/xime/model/ModelRuntime.kt
@@ -1,0 +1,167 @@
+package com.kingzcheung.xime.model
+
+import android.app.Application
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.content.res.Configuration
+import com.kingzcheung.xime.util.FileLogger
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+
+object ModelRuntime {
+
+    private const val TAG = "ModelRuntime"
+
+    private data class Registration(
+        val loader: suspend () -> Boolean,
+        val releaser: () -> Unit,
+        val label: String
+    )
+
+    private class State {
+        @Volatile var refCount = 0
+        @Volatile var loaded = false
+        @Volatile var hot = false
+        val mutex = Mutex()
+    }
+
+    private val registry = ConcurrentHashMap<String, Registration>()
+    private val states = ConcurrentHashMap<String, State>()
+    private var attached = false
+
+    fun attach(context: Context) {
+        if (attached) return
+        attached = true
+        (context.applicationContext as Application).registerComponentCallbacks(trimCallbacks)
+        FileLogger.i(TAG, "ModelRuntime attached")
+    }
+
+    fun register(
+        id: String,
+        loader: suspend () -> Boolean,
+        releaser: () -> Unit,
+        label: String = id
+    ) {
+        if (registry.containsKey(id)) {
+            FileLogger.w(TAG, "Model '$id' already registered, skipping")
+            return
+        }
+        registry[id] = Registration(loader, releaser, label)
+        FileLogger.i(TAG, "Registered model: $label ($id)")
+    }
+
+    fun markLoaded(id: String) {
+        val state = states.getOrPut(id) { State() }
+        if (!state.loaded) {
+            state.loaded = true
+            state.refCount = 1
+        }
+    }
+
+    fun markUnloaded(id: String) {
+        states[id]?.let {
+            it.loaded = false
+            it.refCount = 0
+        }
+    }
+
+    suspend fun load(id: String): Boolean {
+        val reg = registry[id] ?: run {
+            FileLogger.w(TAG, "load: unknown model '$id'")
+            return false
+        }
+        val state = states.getOrPut(id) { State() }
+        state.mutex.withLock {
+            if (state.loaded) {
+                state.refCount++
+                FileLogger.d(TAG, "${reg.label}: already loaded (refCount=${state.refCount})")
+                return true
+            }
+            FileLogger.i(TAG, "${reg.label}: loading...")
+            state.loaded = try {
+                reg.loader()
+            } catch (e: Exception) {
+                FileLogger.e(TAG, "${reg.label}: load failed", e)
+                false
+            }
+            if (state.loaded) {
+                state.refCount = 1
+                FileLogger.i(TAG, "${reg.label}: loaded (refCount=1)")
+            }
+            return state.loaded
+        }
+    }
+
+    fun tryLoad(id: String): Boolean {
+        val state = states[id] ?: return false
+        if (!state.loaded) return false
+        state.refCount++
+        return true
+    }
+
+    fun unload(id: String) {
+        val state = states[id] ?: return
+        val reg = registry[id] ?: return
+
+        state.refCount = (state.refCount - 1).coerceAtLeast(0)
+        if (state.refCount == 0 && !state.hot && state.loaded) {
+            FileLogger.i(TAG, "${reg.label}: releasing (refCount=0, !hot)")
+            try {
+                reg.releaser()
+            } catch (e: Exception) {
+                FileLogger.e(TAG, "${reg.label}: release failed", e)
+            }
+            state.loaded = false
+        }
+    }
+
+    fun keepWarm(id: String) {
+        states[id]?.hot = true
+    }
+
+    fun releaseWarm(id: String) {
+        states[id]?.hot = false
+    }
+
+    fun isLoaded(id: String): Boolean = states[id]?.loaded ?: false
+
+    fun getLoadedModels(): Map<String, Boolean> =
+        states.filter { it.value.loaded }.mapValues { it.value.hot }
+
+    fun onTrimMemory(level: Int) {
+        val shouldRelease = level >= ComponentCallbacks2.TRIM_MEMORY_MODERATE
+        if (!shouldRelease) return
+
+        val toRelease = states.filter { (_, state) ->
+            state.loaded && !state.hot
+        }
+
+        if (toRelease.isEmpty()) return
+
+        FileLogger.i(TAG, "onTrimMemory($level): releasing ${toRelease.size} model(s)")
+        toRelease.forEach { (id, state) ->
+            val reg = registry[id]
+            FileLogger.i(TAG, "  releasing: ${reg?.label ?: id}")
+            try {
+                reg?.releaser?.invoke()
+            } catch (e: Exception) {
+                FileLogger.e(TAG, "  release failed: ${reg?.label ?: id}", e)
+            }
+            state.loaded = false
+            state.refCount = 0
+        }
+    }
+
+    private val trimCallbacks = object : ComponentCallbacks2 {
+        override fun onTrimMemory(level: Int) {
+            this@ModelRuntime.onTrimMemory(level)
+        }
+
+        override fun onLowMemory() {
+            onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+        }
+
+        override fun onConfigurationChanged(newConfig: Configuration) {}
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/VoiceRecognitionHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/VoiceRecognitionHandler.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.inputmethod.InputConnection
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.speech.SpeechRecognitionManager
 import com.kingzcheung.xime.speech.punctuation.PunctuationInference
@@ -93,6 +94,7 @@ class VoiceRecognitionHandler(
         val modelFile = punctuationManager.getModelFile()
         val vocabFile = punctuationManager.getVocabFile()
         if (PunctuationInference.initialize(context, modelFile.absolutePath, vocabFile.absolutePath)) {
+            ModelRuntime.keepWarm("punctuation")
             punctuationInitialized = true
             FileLogger.i(TAG, "Punctuation model initialized successfully")
         } else {
@@ -160,6 +162,7 @@ class VoiceRecognitionHandler(
             speechRecognitionManager.release()
         }
         if (punctuationInitialized) {
+            ModelRuntime.releaseWarm("punctuation")
             PunctuationInference.release()
             punctuationInitialized = false
         }

--- a/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/SpeechRecognitionManager.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import android.util.Log
 
 import androidx.annotation.RequiresPermission
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.speech.funasr.FunAsrAsrBackend
 import com.kingzcheung.xime.speech.sherpa.SherpaAsrBackend
@@ -95,6 +96,7 @@ class SpeechRecognitionManager(private val context: Context) {
             }
             
             FileLogger.i(TAG, "ASR backend initialized successfully")
+            ModelRuntime.keepWarm("asr")
         }
 
         val currentBackend = backend!!
@@ -127,6 +129,7 @@ class SpeechRecognitionManager(private val context: Context) {
 
                 if (!SettingsPreferences.isSttKeepModelInRam(context)) {
                     Log.d(TAG, "Release mode: freeing backend resources")
+                    ModelRuntime.releaseWarm("asr")
                     backend?.release()
                     backend = null
                 }
@@ -149,6 +152,7 @@ class SpeechRecognitionManager(private val context: Context) {
                 stateCallback?.invoke(RecognitionState.IDLE)
 
                 if (!SettingsPreferences.isSttKeepModelInRam(context)) {
+                    ModelRuntime.releaseWarm("asr")
                     backend?.release()
                     backend = null
                 }
@@ -244,6 +248,7 @@ class SpeechRecognitionManager(private val context: Context) {
             preloadLock.notifyAll()
         }
 
+        ModelRuntime.keepWarm("asr")
         newBackend.start()
         newBackend.stop()
     }

--- a/app/src/main/java/com/kingzcheung/xime/speech/punctuation/PunctuationInference.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/punctuation/PunctuationInference.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.speech.punctuation
 
 import android.content.Context
 import android.util.Log
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.util.FileLogger
 import org.json.JSONObject
 import java.io.File
@@ -157,6 +158,13 @@ object PunctuationInference {
     }
 
     fun initialize(context: Context, modelPath: String, vocabPath: String): Boolean {
+        ModelRuntime.register(
+            id = "punctuation",
+            loader = { initialize(context, modelPath, vocabPath) },
+            releaser = { release() },
+            label = "标点预测模型"
+        )
+
         if (!loadVocabFromFile(vocabPath)) {
             FileLogger.e(TAG, "Failed to load vocab")
             return false
@@ -165,6 +173,7 @@ object PunctuationInference {
         try {
             nativeInitialize(modelPath)
             Log.d(TAG, "Native method already available")
+            ModelRuntime.markLoaded("punctuation")
             return true
         } catch (e: UnsatisfiedLinkError) {
             Log.d(TAG, "Native method not available, loading libraries...")
@@ -176,7 +185,11 @@ object PunctuationInference {
         }
         
         return try {
-            nativeInitialize(modelPath)
+            val ok = nativeInitialize(modelPath)
+            if (ok) {
+                ModelRuntime.markLoaded("punctuation")
+            }
+            ok
         } catch (e: UnsatisfiedLinkError) {
             FileLogger.e(TAG, "Native method still unavailable: ${e.message}")
             nativeLoaded = false
@@ -245,6 +258,7 @@ object PunctuationInference {
             Log.d(TAG, "Native release not available")
         }
         nativeLoaded = false
+        ModelRuntime.markUnloaded("punctuation")
     }
     
     fun isInitialized(): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/speech/sherpa/SherpaAsrEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/speech/sherpa/SherpaAsrEngine.kt
@@ -5,6 +5,7 @@ package com.kingzcheung.xime.speech.sherpa
 import android.content.Context
 import android.util.Log
 import com.k2fsa.sherpa.onnx.*
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.util.FileLogger
 import kotlinx.coroutines.CoroutineScope
@@ -124,6 +125,13 @@ class SherpaAsrEngine(private val context: Context) {
             return false
         }
 
+        ModelRuntime.register(
+            id = "asr",
+            loader = { false },
+            releaser = { release() },
+            label = "语音识别模型"
+        )
+
         val modelDir = getSelectedModelDir()
         if (!modelDir.exists()) {
             FileLogger.e(TAG, "Model directory not found: ${modelDir.absolutePath}")
@@ -160,6 +168,7 @@ class SherpaAsrEngine(private val context: Context) {
             recognizer = OnlineRecognizer(config = config)
             FileLogger.i(TAG, "Local ASR model initialized successfully: ${modelInfo.name}")
             Log.d(TAG, "Recognizer initialized from ${modelDir.absolutePath}")
+            ModelRuntime.markLoaded("asr")
             return true
         } catch (e: Exception) {
             FileLogger.e(TAG, "Failed to initialize recognizer: ${e.message}", e)
@@ -331,6 +340,7 @@ class SherpaAsrEngine(private val context: Context) {
         recognizer = null
         loadedModelId = null
         coroutineScope.cancel()
+        ModelRuntime.markUnloaded("asr")
         Log.d(TAG, "SherpaAsrEngine released")
     }
     

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SmartPredictionSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SmartPredictionSettingsViewModel.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.kingzcheung.xime.association.AssociationManager
+import com.kingzcheung.xime.model.ModelRuntime
 import com.kingzcheung.xime.settings.SettingsPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -85,7 +86,11 @@ class SmartPredictionSettingsViewModel(application: Application) : AndroidViewMo
         
         if (enabled && !_uiState.value.isInitialized && _uiState.value.hasModel) {
             loadModel()
+            if (_uiState.value.isInitialized) {
+                ModelRuntime.keepWarm("predictive_text")
+            }
         } else if (!enabled && _uiState.value.isInitialized) {
+            ModelRuntime.releaseWarm("predictive_text")
             releaseModel()
         }
     }


### PR DESCRIPTION
引入ModelRuntime作为统一的模型资源管理器，实现对预测文本、语音识别和标点预测模型
的集中化生命周期管理。通过注册机制统一处理模型的加载、释放、预热等操作，优化内
存使用和性能表现。

主要变更包括：
- 在XimeApplication中初始化ModelRuntime
- 将AssociationManager、SpeechRecognitionManager、PunctuationInference等组件 的模型管理逻辑迁移到ModelRuntime统一处理
- 实现模型预热和内存管理功能，提升应用性能