### PR TITLE
fix(XimeInputMethodService): 移除语音识别的空格键处理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -759,9 +759,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     },
                                     onKeyPressDown = { key ->
                                         feedbackManager.performKeyPressDownEffect(key)
-                                        if (key == "space" && uiState.value.isSttEnabled) {
-                                            voiceRecognitionHandler.startDelayedPreStart()
-                                        }
                                     },
                                     onCandidateSelect = { index ->
                                         selectCandidate(index)


### PR DESCRIPTION
移除了输入法服务中针对空格键触发语音识别的代码，
因为这可能导致意外的语音识别启动行为

BREAKING CHANGE: 停止支持通过空格键触发语音识别功能