### PR TITLE
feat(SchemaManager): 添加Apple Double文件过滤和优化下载功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -51,6 +51,12 @@ object SchemaManager {
     private const val CUSTOM_YAML = "default.custom.yaml"
     internal val yaml = Yaml(configuration = YamlConfiguration(strictMode = false))
 
+    private val downloadClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .build()
+
     fun getRimeDir(context: Context): File =
         File(context.filesDir, "rime")
 
@@ -222,6 +228,10 @@ object SchemaManager {
         val base = name.substringAfterLast('/')
         return base == "default.yaml"
     }
+
+    /** macOS Apple Double 资源分支文件（__MACOSX/ 或 ._ 前缀），应当在解压时跳过。 */
+    private fun isAppleDouble(name: String): Boolean =
+        name.startsWith("__MACOSX/") || name.contains("/._") || name.startsWith("._")
 
     /** 把归档条目解析到 targetDir 下，越界（zip-slip，如 ../../x）返回 null。 */
     private fun safeChild(targetDir: File, name: String): File? {
@@ -492,7 +502,7 @@ object SchemaManager {
                 ZipInputStream(input.buffered()).use { zis ->
                     var entry = zis.nextEntry
                     while (entry != null) {
-                        if (!entry.isDirectory) entryNames.add(entry.name)
+                        if (!entry.isDirectory && !isAppleDouble(entry.name)) entryNames.add(entry.name)
                         zis.closeEntry()
                         entry = zis.nextEntry
                     }
@@ -513,7 +523,7 @@ object SchemaManager {
                     while (entry != null) {
                         val originalName = entry.name
                         val name = originalName.removePrefix(baseDir)
-                        if (!entry.isDirectory && !isProtectedImportName(name)) {
+                        if (!entry.isDirectory && !isAppleDouble(originalName) && !isProtectedImportName(name)) {
                             val file = safeChild(targetDir, name)
                             if (file == null) {
                                 Log.w(TAG, "Skip unsafe path: $name")
@@ -532,13 +542,6 @@ object SchemaManager {
                                 }
 
                                 Log.d(TAG, "Extracted: $name")
-
-                                when {
-                                    name.endsWith(".schema.yaml") ->
-                                        importedSchemas.add(name.removeSuffix(".schema.yaml").substringAfterLast('/'))
-                                    name.endsWith(".dict.yaml") ->
-                                        importedSchemas.add(name.removeSuffix(".dict.yaml").substringAfterLast('/'))
-                                }
                             }
                         }
                         zis.closeEntry()
@@ -575,12 +578,7 @@ object SchemaManager {
             if (!schemeDir.exists()) schemeDir.mkdirs()
             val targetFile = File(schemeDir, fileName)
 
-            val client = OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(120, TimeUnit.SECONDS)
-                .followRedirects(true)
-                .build()
-            client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+            downloadClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
                 if (!response.isSuccessful) {
                     Log.e(TAG, "Download failed: ${response.code} $url")
                     return@withContext DownloadResult(false)
@@ -625,10 +623,13 @@ object SchemaManager {
             }
         } catch (e: Exception) {
             Log.e(TAG, "downloadToMarket failed: $url", e)
-            // 删除可能残留的损坏文件
+            // 删除可能残留的损坏文件及空目录，防止 isSchemeDownloaded 误判
             val schemeDir = getMarketDir(context, schemeId)
             val targetFile = File(schemeDir, fileName)
             if (targetFile.exists()) targetFile.delete()
+            if (schemeDir.exists() && schemeDir.listFiles().isNullOrEmpty()) {
+                schemeDir.delete()
+            }
             DownloadResult(false)
         }
     }
@@ -761,11 +762,13 @@ object SchemaManager {
 
     private fun importZipFromFile(zipFile: File, targetDir: File): Boolean {
         return try {
-            // 第一趟：收集文件名以检测共同根目录
+            // 第一趟：收集文件名以检测共同根目录（排除 Apple Double）
             val entryNames = mutableListOf<String>()
             ZipFile(zipFile).use { zip ->
                 zip.entries().asSequence().forEach { entry ->
-                    if (!entry.isDirectory) entryNames.add(entry.name)
+                    if (!entry.isDirectory && !isAppleDouble(entry.name)) {
+                        entryNames.add(entry.name)
+                    }
                 }
             }
 
@@ -779,19 +782,18 @@ object SchemaManager {
             ZipFile(zipFile).use { zip ->
                 zip.entries().asSequence().forEach { entry ->
                     val originalName = entry.name
+                    if (entry.isDirectory || isAppleDouble(originalName)) return@forEach
                     val name = originalName.removePrefix(baseDir)
-                    if (!entry.isDirectory) {
-                        val file = if (isProtectedImportName(name)) null else safeChild(targetDir, name)
-                        if (file == null) {
-                            Log.d(TAG, "Skip protected/unsafe entry: $name")
-                        } else {
-                            file.parentFile?.mkdirs()
-                            zip.getInputStream(entry).use { input ->
-                                FileOutputStream(file).use { output -> input.copyTo(output) }
-                            }
-                            count++
-                            Log.d(TAG, "Extracted zip entry: $name")
+                    val file = if (isProtectedImportName(name)) null else safeChild(targetDir, name)
+                    if (file == null) {
+                        Log.d(TAG, "Skip protected/unsafe entry: $name")
+                    } else {
+                        file.parentFile?.mkdirs()
+                        zip.getInputStream(entry).use { input ->
+                            FileOutputStream(file).use { output -> input.copyTo(output) }
                         }
+                        count++
+                        Log.d(TAG, "Extracted zip entry: $name")
                     }
                 }
             }
@@ -821,12 +823,14 @@ object SchemaManager {
 
     private fun importTarGzFromFile(tarGzFile: File, targetDir: File): Boolean {
         return try {
-            // 第一趟：收集文件名以检测共同根目录（注意 .tar.gz 需先 gunzip 再解 tar）
+            // 第一趟：收集文件名以检测共同根目录（排除 Apple Double）
             val entryNames = mutableListOf<String>()
             TarArchiveInputStream(GzipCompressorInputStream(tarGzFile.inputStream().buffered())).use { tarIn ->
                 var entry = tarIn.nextEntry
                 while (entry != null) {
-                    if (!entry.isDirectory) entryNames.add(entry.name)
+                    if (!entry.isDirectory && !isAppleDouble(entry.name)) {
+                        entryNames.add(entry.name)
+                    }
                     entry = tarIn.nextEntry
                 }
             }
@@ -841,17 +845,20 @@ object SchemaManager {
             TarArchiveInputStream(GzipCompressorInputStream(tarGzFile.inputStream().buffered())).use { tarIn ->
                 var entry = tarIn.nextEntry
                 while (entry != null) {
-                    val name = entry.name.removePrefix(baseDir)
-                    if (!entry.isDirectory) {
-                        val file = if (isProtectedImportName(name)) null else safeChild(targetDir, name)
-                        if (file == null) {
-                            Log.d(TAG, "Skip protected/unsafe entry: $name")
-                        } else {
-                            file.parentFile?.mkdirs()
-                            FileOutputStream(file).use { output -> tarIn.copyTo(output) }
-                            count++
-                            Log.d(TAG, "Extracted tar.gz entry: $name")
-                        }
+                    val originalName = entry.name
+                    if (entry.isDirectory || isAppleDouble(originalName)) {
+                        entry = tarIn.nextEntry
+                        continue
+                    }
+                    val name = originalName.removePrefix(baseDir)
+                    val file = if (isProtectedImportName(name)) null else safeChild(targetDir, name)
+                    if (file == null) {
+                        Log.d(TAG, "Skip protected/unsafe entry: $name")
+                    } else {
+                        file.parentFile?.mkdirs()
+                        FileOutputStream(file).use { output -> tarIn.copyTo(output) }
+                        count++
+                        Log.d(TAG, "Extracted tar.gz entry: $name")
                     }
                     entry = tarIn.nextEntry
                 }

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -37,15 +37,27 @@ data class SchemesFetch(
  */
 object XimeIndexSource {
     private const val TAG = "XimeIndexSource"
-    // 默认端点，会被 xime.yaml 中的值覆盖
     private val defaultBaseUrls = listOf("https://index.ximei.me/")
 
     private var baseUrls: List<String> = defaultBaseUrls
+    private var mirrors: List<String> = buildMirrors(defaultBaseUrls)
 
-    /** 构建完整镜像列表：直接使用用户配置的 base_urls。 */
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .build()
+
+    private val DownloadItem.fileName: String
+        get() = url.substringAfterLast('/').takeIf { it.isNotBlank() }
+            ?: "file.${url.substringAfterLast('.').takeIf { it.length in 1..6 } ?: "bin"}"
+
+    private val DownloadItem.sizeBytes: Long
+        get() = size.removeSuffix(" MB").trim().toDoubleOrNull()
+            ?.let { (it * 1024.0 * 1024.0).toLong() } ?: 0L
+
     private fun buildMirrors(userUrls: List<String>): List<String> = userUrls
 
-    /** 从 xime.yaml 加载 xime-index 配置。每次网络请求前调用以确保使用最新配置。 */
     private fun ensureConfigured(context: Context) {
         val cfg = KeysConfigHelper.loadXimeIndexConfig(context)
         if (cfg.baseUrls != baseUrls) {
@@ -54,14 +66,6 @@ object XimeIndexSource {
             Log.d(TAG, "XimeIndex configured: baseUrls=$baseUrls")
         }
     }
-
-    private var mirrors: List<String> = buildMirrors(defaultBaseUrls)
-
-    private val client = OkHttpClient.Builder()
-        .connectTimeout(15, TimeUnit.SECONDS)
-        .readTimeout(20, TimeUnit.SECONDS)
-        .followRedirects(true)
-        .build()
 
     /** 镜像 base → 展示用主机名（如 index.ximei.me / fastly.jsdelivr.net）。 */
     private fun hostOf(base: String): String =
@@ -140,46 +144,31 @@ object XimeIndexSource {
             return@withContext InstallResult(false, failureReason = "缺少下载地址")
         }
 
-        // 汇总所有文件的校验状态
-        var anyFailed = false
-        var anyMismatch = false
-        var anyVerified = false
-
-        data class DlItem(val item: DownloadItem, val fileName: String, val sizeBytes: Long)
-        val items = v.downloadUrls.filter { it.url.isNotBlank() }.map { dl ->
-            val fn = dl.url.substringAfterLast('/').takeIf { it.isNotBlank() }
-                ?: "file.${dl.url.substringAfterLast('.').takeIf { it.length in 1..6 } ?: "bin"}"
-            val bytes = dl.size.removeSuffix(" MB").trim().toDoubleOrNull()
-                ?.let { (it * 1024.0 * 1024.0).toLong() } ?: 0L
-            DlItem(dl, fn, bytes)
-        }
+        val items = v.downloadUrls.filter { it.url.isNotBlank() }
         val totalBytesAll = items.sumOf { it.sizeBytes }
         var accumulatedBytes = 0L
+        var anyVerified = false
 
-        for ((dl, fn, sz) in items) {
+        for (dl in items) {
             val result = SchemaManager.downloadToMarket(
-                context, dl.url, scheme.id, fn, dl.sha256.takeIf { it.isNotBlank() },
+                context, dl.url, scheme.id, dl.fileName, dl.sha256.takeIf { it.isNotBlank() },
                 onProgress = { read, _ ->
-                    // 跨文件合并进度：前序文件已下载完 + 当前文件进度
                     val overall = accumulatedBytes + read
                     if (totalBytesAll > 0) onDownloadProgress(overall, totalBytesAll)
                 },
             )
-            accumulatedBytes += sz
+            accumulatedBytes += dl.sizeBytes
             if (!result.success) {
-                anyFailed = true
-                if (result.sha256Verified == false) anyMismatch = true
+                val schemeDir = SchemaManager.getMarketDir(context, scheme.id)
+                if (schemeDir.exists()) schemeDir.deleteRecursively()
+                val reason = if (result.sha256Verified == false)
+                    "文件校验失败（sha256 不匹配），文件可能不完整" else "下载失败"
+                return@withContext InstallResult(
+                    false, failureReason = reason, sha256Status = result.sha256Verified
+                )
             } else if (result.sha256Verified == true) {
                 anyVerified = true
             }
-        }
-
-        if (anyFailed) {
-            val reason = when {
-                anyMismatch -> "文件校验失败（sha256 不匹配），部分文件可能不完整"
-                else -> "下载失败"
-            }
-            return@withContext InstallResult(false, failureReason = reason, sha256Status = if (anyMismatch) false else null)
         }
         InstallResult(success = true, sha256Status = if (anyVerified) true else null)
     }
@@ -200,14 +189,24 @@ object XimeIndexSource {
         val ok = SchemaManager.installFromMarketToRime(context, scheme.id)
         if (!ok) return@withContext InstallResult(false, failureReason = "安装失败")
 
-        // 找到新落盘的真实 rime schema id
         val after = SchemaManager.discoverSchemas(context).map { it.schemaId }.toSet()
-        val newSchemaId = (after - before).firstOrNull() ?: scheme.id
+        val newIds = after - before
+        val installedSchemaId = when {
+            scheme.id in newIds -> scheme.id
+            newIds.size == 1 -> newIds.first()
+            newIds.isNotEmpty() -> {
+                Log.w(TAG, "installFromMarket ${scheme.id}: multiple new schemas detected: $newIds, using ${newIds.first()}")
+                newIds.first()
+            }
+            else -> {
+                Log.w(TAG, "installFromMarket ${scheme.id}: no new schema detected, falling back to market id")
+                scheme.id
+            }
+        }
 
-        // 依赖补齐
         val completion = RimeDependencyResolver.complete(
             context = context,
-            schemaId = newSchemaId,
+            schemaId = installedSchemaId,
             dependencies = scheme.dependencies,
             resolveUrl = resolveDepUrl,
         )


### PR DESCRIPTION
- 新增downloadClient单例用于HTTP下载请求复用
- 实现isAppleDouble函数过滤macOS资源分支文件(__MACOSX/和._前缀)
- 在ZIP/TAR.GZ解压过程中跳过Apple Double文件避免无用文件导入
- 移除重复的schema/dict文件类型识别逻辑
- 清理下载失败后的残留空目录防止误判
- 修复解压循环中的逻辑错误并优化性能

refactor(XimeIndexSource): 重构下载项处理和安装流程

- 提取DownloadItem扩展属性获取文件名和字节大小
- 简化下载项处理逻辑移除中间数据类
- 改进下载失败时的错误处理和目录清理机制
- 优化新安装方案ID识别逻辑增加多方案检测日志