### PR TITLE
chore(app): 升级应用版本号至beta6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 48
-        versionName = "2.5.0-beta5"
+        versionCode = 49
+        versionName = "2.5.0-beta6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
版本号从48升级到49
版本名称从2.5.0-beta5更新为2.5.0-beta6