### PR TITLE
feat(market): 添加WAKE_LOCK权限并实现下载时唤醒锁管理

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     
     <!-- Android 11+ 需要此权限才能查询其他应用 -->
     <uses-permission

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.settings
 
 import android.content.Context
 import android.net.Uri
+import android.os.PowerManager
 import android.util.Log
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
@@ -573,6 +574,10 @@ object SchemaManager {
         expectedSha256: String? = null,
         onProgress: (Long, Long) -> Unit = { _, _ -> },
     ): DownloadResult = withContext(Dispatchers.IO) {
+        val wakeLock = (context.getSystemService(Context.POWER_SERVICE) as PowerManager)
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Xime:SchemaDownload")
+        wakeLock.setReferenceCounted(false)
+        wakeLock.acquire(5 * 60 * 1000L)
         try {
             val schemeDir = getMarketDir(context, schemeId)
             if (!schemeDir.exists()) schemeDir.mkdirs()
@@ -610,7 +615,6 @@ object SchemaManager {
                     Log.i(TAG, "Downloaded (sha256 verified): ${targetFile.absolutePath}")
                     DownloadResult(true, sha256Verified = true)
                 } else {
-                    // 无 sha256：校验压缩包完整性（zip/tar.gz），防止下载不完整
                     val valid = validateArchive(targetFile)
                     if (!valid) {
                         Log.e(TAG, "Archive validation failed for $url, file is corrupted")
@@ -623,7 +627,6 @@ object SchemaManager {
             }
         } catch (e: Exception) {
             Log.e(TAG, "downloadToMarket failed: $url", e)
-            // 删除可能残留的损坏文件及空目录，防止 isSchemeDownloaded 误判
             val schemeDir = getMarketDir(context, schemeId)
             val targetFile = File(schemeDir, fileName)
             if (targetFile.exists()) targetFile.delete()
@@ -631,6 +634,8 @@ object SchemaManager {
                 schemeDir.delete()
             }
             DownloadResult(false)
+        } finally {
+            if (wakeLock.isHeld) wakeLock.release()
         }
     }
 


### PR DESCRIPTION
- 在AndroidManifest.xml中添加WAKE_LOCK权限
- 在SchemaManager中引入PowerManager用于唤醒锁管理
- 在下载市场方案时获取部分唤醒锁，防止设备休眠中断下载
- 确保唤醒锁正确释放，避免电量消耗
- 移除过时的注释代码