### PR TITLE
feat(keyboard): 添加逗号键长按功能

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -146,7 +146,7 @@ keyboard:
       n: { tap: "n", swipe_up: { label: "％", value: "%" }, swipe_down: { label: "已己巳心忄羽乙𠃜", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["n", "N", "ñ"] } }
       m: { tap: "m", swipe_up: { label: "＃", value: "#" }, swipe_down: { label: "山由贝冂冎几", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["m", "M"] } }
       #  逗号键，label 为中文显示，value 为英文显示+提交值
-      "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } }
+      "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } , long_press: { display: "bubble", values: [ ",","."] }}
       # 中/英切换键，label 为按键显示文字
       shift_l: { tap: { label: "英", action: "toggle_ascii" } }
    


### PR DESCRIPTION
为逗号键添加长按弹出气泡显示的功能，长按时可选择逗号或句号符号，
提升用户输入体验和操作便利性