### PR TITLE
feat(schema-market): 添加方案版本选择功能

### DIFF
--- a/app/src/main/assets/rime/pinyin_simp.schema.yaml
+++ b/app/src/main/assets/rime/pinyin_simp.schema.yaml
@@ -62,6 +62,8 @@ speller:
 
 translator:
   dictionary: pinyin_simp
+  packs:
+    - user_simp
   preedit_format:
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/

--- a/app/src/main/assets/rime/user_simp.dict.yaml
+++ b/app/src/main/assets/rime/user_simp.dict.yaml
@@ -1,0 +1,9 @@
+# Rime dict
+---
+name: sample_pack
+version: '1.0'
+sort: original
+use_preset_vocabulary: false
+...
+
+粗鄙之语	cu bi zhi yu

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -136,10 +136,14 @@ object XimeIndexSource {
     suspend fun downloadScheme(
         context: Context,
         scheme: MarketScheme,
+        version: String? = null,
         onDownloadProgress: (Long, Long) -> Unit = { _, _ -> },
     ): InstallResult = withContext(Dispatchers.IO) {
-        val v = scheme.resolvedVersion()
-            ?: return@withContext InstallResult(false, failureReason = "无可用版本")
+        val v = if (version != null) {
+            scheme.versions.firstOrNull { it.version == version }
+        } else {
+            scheme.resolvedVersion()
+        } ?: return@withContext InstallResult(false, failureReason = "无可用版本")
         if (v.downloadUrls.isEmpty() || v.downloadUrls.all { it.url.isBlank() }) {
             return@withContext InstallResult(false, failureReason = "缺少下载地址")
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Refresh
@@ -29,6 +32,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Icon
@@ -59,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.kingzcheung.xime.settings.MarketSchemeItem
+import com.kingzcheung.xime.settings.SchemeVersion
 import com.kingzcheung.xime.viewmodel.SchemaMarketViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -198,6 +204,9 @@ fun SchemaMarketContent(
                             installed = item.scheme.id in uiState.installedIds,
                             sha256Status = uiState.sha256Status[item.scheme.id],
                             deploying = uiState.isDeploying,
+                            selectedVersion = uiState.selectedVersions[item.scheme.id]
+                                ?: item.scheme.currentVersion,
+                            onSelectVersion = { viewModel.selectVersion(item.scheme.id, it) },
                             onDownload = { viewModel.downloadScheme(item) },
                             onInstall = { viewModel.installFromMarket(item) },
                             onDeploy = { viewModel.deploy() },
@@ -236,6 +245,8 @@ private fun SchemeCard(
     installed: Boolean,
     sha256Status: Boolean?,
     deploying: Boolean,
+    selectedVersion: String,
+    onSelectVersion: (String) -> Unit,
     onDownload: () -> Unit,
     onInstall: () -> Unit,
     onDeploy: () -> Unit,
@@ -257,10 +268,16 @@ private fun SchemeCard(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false),
                 )
-                if (scheme.currentVersion.isNotEmpty()) {
+                if (scheme.versions.size > 1) {
+                    VersionSelector(
+                        versions = scheme.versions,
+                        selectedVersion = selectedVersion,
+                        onSelectVersion = onSelectVersion,
+                    )
+                } else if (selectedVersion.isNotEmpty()) {
                     Spacer(Modifier.width(8.dp))
                     Text(
-                        scheme.currentVersion,
+                        selectedVersion,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.outline,
                     )
@@ -433,6 +450,54 @@ private fun SchemeCard(
                         Text("下载")
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VersionSelector(
+    versions: List<SchemeVersion>,
+    selectedVersion: String,
+    onSelectVersion: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        TextButton(
+            onClick = { expanded = true },
+            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
+            modifier = Modifier.height(IntrinsicSize.Min),
+        ) {
+            Text(
+                selectedVersion,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Icon(
+                Icons.Default.ArrowDropDown,
+                contentDescription = "选择版本",
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            versions.forEach { v ->
+                val label = buildString {
+                    append(v.version)
+                    if (v.date.isNotBlank()) append("  ·  ${v.date}")
+                    if (v.size.isNotBlank()) append("  ·  ${v.size}")
+                }
+                DropdownMenuItem(
+                    text = { Text(label, style = MaterialTheme.typography.bodySmall) },
+                    onClick = {
+                        onSelectVersion(v.version)
+                        expanded = false
+                    },
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                )
             }
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
@@ -37,6 +37,8 @@ data class SchemaMarketUiState(
     val searchQuery: String = "",
     // 本次方案列表实际命中的来源端点主机名（如 index.ximei.me），用于在界面上显示「从哪个端点拉的」
     val source: String = "",
+    /** 用户选择的版本：schemeId → version 字符串 */
+    val selectedVersions: Map<String, String> = emptyMap(),
 ) {
     val filteredSchemes: List<MarketSchemeItem>
         get() = if (searchQuery.isBlank()) schemes else schemes.filter {
@@ -86,6 +88,17 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
                         )
                     }
                 } else {
+                    val existingSel = _uiState.value.selectedVersions
+                    val mergedSel = fetch.schemes.associate { item ->
+                        val id = item.scheme.id
+                        val keep = existingSel[id]
+                        if (keep != null && item.scheme.versions.any { it.version == keep }) {
+                            id to keep
+                        } else {
+                            val v = item.scheme.resolvedVersion()
+                            id to (v?.version ?: item.scheme.currentVersion)
+                        }
+                    }
                     _uiState.update {
                         it.copy(
                             schemes = fetch.schemes,
@@ -93,6 +106,7 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
                             source = fetch.source,
                             errorMessage = null,
                             downloadedIds = downloadedIds,
+                            selectedVersions = mergedSel,
                             toastMessage = if (manual) "已刷新 · 来源：${fetch.source}" else it.toastMessage,
                         )
                     }
@@ -113,6 +127,11 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
 
     fun setSearchQuery(q: String) = _uiState.update { it.copy(searchQuery = q) }
 
+    /** 选择指定方案的版本。 */
+    fun selectVersion(schemeId: String, version: String) {
+        _uiState.update { it.copy(selectedVersions = it.selectedVersions + (schemeId to version)) }
+    }
+
     /** 下载方案到 market 目录（仅下载，不解压）。 */
     fun downloadScheme(item: MarketSchemeItem) {
         if (_uiState.value.downloadingId != null) {
@@ -125,9 +144,11 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
         }
         viewModelScope.launch {
             _uiState.update { it.copy(downloadingId = item.scheme.id, downloadProgress = 0f) }
+            val selectedVersion = _uiState.value.selectedVersions[item.scheme.id]
             val result = withContext(Dispatchers.IO) {
                 XimeIndexSource.downloadScheme(
                     context, item.scheme,
+                    version = selectedVersion,
                     onDownloadProgress = { downloaded, total ->
                         val progress = if (total > 0) (downloaded.toFloat() / total) else 0f
                         _uiState.update { it.copy(downloadProgress = progress) }
@@ -171,8 +192,12 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
         }
         viewModelScope.launch {
             _uiState.update { it.copy(extractingId = item.scheme.id) }
+            val selVer = _uiState.value.selectedVersions
             val urlById = _uiState.value.schemes.associate { si ->
-                si.scheme.id to si.scheme.resolvedVersion()?.downloadUrls?.firstOrNull()?.url
+                val v = selVer[si.scheme.id]?.let { ver ->
+                    si.scheme.versions.firstOrNull { it.version == ver }
+                } ?: si.scheme.resolvedVersion()
+                si.scheme.id to v?.downloadUrls?.firstOrNull()?.url
             }
             val result = withContext(Dispatchers.IO) {
                 XimeIndexSource.installFromMarket(


### PR DESCRIPTION
- 在方案市场界面添加版本下拉选择器组件
- 支持用户为每个方案选择特定版本进行下载安装
- 保存用户选择的版本状态到UI state中
- 修改downloadScheme函数支持传入指定版本参数
- 更新RIME配置文件添加user_simp词典包支持

fix(download): 修复方案下载时未使用选定版本的问题

- 修改XimeIndexSource.downloadScheme方法支持版本参数
- 在ViewModel中传递选中的版本给下载逻辑
- 优化版本选择逻辑，保留用户之前的选择如果版本仍然存在