### PR TITLE
feat(keyboard): 添加数字和符号键盘的直接输入功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1966,12 +1966,24 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     calculatorEngine.clear()
                     updateCalculatorCandidates()
                 }
+                "number", "common_symbol" -> {
+                    // Number/CommonSymbol 内部切换由 KeyboardView 的 key handler 处理
+                }
                 "emoji" -> {
                     withContext(Dispatchers.Main) {
                         commitText("😊")
                     }
                 }
                 else -> {
+                    val layoutState = keyboardViewModel.keyboardState.value
+                    if (key.length == 1 && (layoutState is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.Number || layoutState is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.CommonSymbol)) {
+                        withContext(Dispatchers.Main) {
+                            commitText(key)
+                        }
+                        needsUIUpdate = true
+                        Log.d(TAG, "Number/Symbol keyboard: committed '$key' directly")
+                        return@launch
+                    }
                     val pendingEnglish = candState.pendingEnglishText
                     
                     // 非计算器键（如符号键盘的符号、全键盘的字母）清除计算器状态

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
@@ -90,12 +90,13 @@ fun CommonSymbolKeyboardLayout(
                 .fillMaxWidth()
                 .fillMaxHeight()
                 .padding(start = 4.dp, end = 4.dp, bottom = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(KeyboardDimensions.RowSpacing),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 (0..9).forEach { n ->
                     val digit = ((n+1)%10).toString()
@@ -104,7 +105,7 @@ fun CommonSymbolKeyboardLayout(
                         onClick = { onKeyPress(digit) },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke(digit) },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -118,6 +119,7 @@ fun CommonSymbolKeyboardLayout(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 row2Symbols.forEach { sym ->
                     KeyButton(
@@ -125,7 +127,7 @@ fun CommonSymbolKeyboardLayout(
                         onClick = { onKeyPress(sym) },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke(sym) },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -139,13 +141,14 @@ fun CommonSymbolKeyboardLayout(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 KeyButton(
                     text = "符号",
                     onClick = { onKeyPress("symbol") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1.3f),
+                    modifier = Modifier.weight(1.3f),
                     onPress = { onKeyPressDown?.invoke("symbol") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -158,7 +161,7 @@ fun CommonSymbolKeyboardLayout(
                         onClick = { onKeyPress(sym) },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke(sym) },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -171,7 +174,7 @@ fun CommonSymbolKeyboardLayout(
                     onClick = { onKeyPress("delete") },
                     backgroundColor = specialKeyBackgroundColor,
                     iconColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                    modifier = Modifier.weight(1.2f),
                     swipeText = "清空",
                     onSwipe = { onKeyPress("clear_composition") },
                     onLongClick = { onKeyPress("delete") },
@@ -200,13 +203,14 @@ fun CommonSymbolKeyboardLayout(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 KeyButton(
                     text = "返回",
                     onClick = { onKeyPress("abc") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                    modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("abc") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -218,7 +222,7 @@ fun CommonSymbolKeyboardLayout(
                     onClick = { onKeyPress("number") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                    modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("number") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -230,7 +234,7 @@ fun CommonSymbolKeyboardLayout(
                     onClick = { onKeyPress(commaChar) },
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                    modifier = Modifier.weight(1f),
                     onPress = { onKeyPressDown?.invoke(commaChar) },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -242,7 +246,7 @@ fun CommonSymbolKeyboardLayout(
                     onClick = { onKeyPress("space") },
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(2.5f),
+                    modifier = Modifier.weight(2.5f),
                     onPress = { onKeyPressDown?.invoke("space") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -254,7 +258,7 @@ fun CommonSymbolKeyboardLayout(
                     onClick = { onKeyPress(periodChar) },
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                    modifier = Modifier.weight(1f),
                     onPress = { onKeyPressDown?.invoke(periodChar) },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -266,7 +270,7 @@ fun CommonSymbolKeyboardLayout(
                     onClick = { onKeyPress("enter") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                    modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("enter") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -257,14 +257,14 @@ fun KeyboardLayout(
                     .fillMaxWidth()
                     .fillMaxHeight()
                     .background(keyboardBackgroundColor)
-                    .padding(start = 4.dp, end = 4.dp, bottom = 8.dp)
+                    .padding(start = 4.dp, end = 4.dp, bottom = 8.dp),
             ) {
 
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(KeyboardDimensions.RowSpacing),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     // 第一行
                     if (isVoiceMode) {
@@ -369,7 +369,7 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 iconColor = keyTextColor,
                                 modifier = Modifier
-                                    .padding(2.dp,4.dp)
+                                    .padding(2.dp,0.dp)
                                     .weight(1.4f)
                                     .fillMaxHeight(),
                                 shadowEnabled = shadowEnabled,
@@ -382,6 +382,7 @@ fun KeyboardLayout(
                                         .weight(7f)
                                         .fillMaxHeight()
                                         .background(keyboardBackgroundColor),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                                 ) {
                                 val bottomKeys = listOf("z", "x", "c", "v", "b", "n", "m")
                                 bottomKeys.forEach { key ->
@@ -455,7 +456,7 @@ fun KeyboardLayout(
                                         onClick = onClick,
                                         backgroundColor = keyBackgroundColor,
                                         textColor = keyTextColor,
-                                        modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                                        modifier = Modifier.weight(1f),
                                         swipeText = swipeUpText,
                                         swipeDownText = swipeDownBubbleText,
                                         swipeUpKeyLabel = swipeUpKeyLabel,
@@ -479,7 +480,7 @@ fun KeyboardLayout(
                                 backgroundColor = specialKeyBackgroundColor,
                                 iconColor = keyTextColor,
                                 modifier = Modifier
-                                    .padding(2.dp,4.dp)
+                                    .padding(2.dp,0.dp)
                                     .weight(1.4f)
                                     .fillMaxHeight(),
                                 swipeText = "清空",
@@ -510,6 +511,7 @@ fun KeyboardLayout(
                             .fillMaxWidth()
                             .weight(1f)
                             .background(keyboardBackgroundColor),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         if (isVoiceMode) {
                             DummyKeyButton(
@@ -527,7 +529,7 @@ fun KeyboardLayout(
                                 onClick = { onKeyPress("mode_change") },
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
-                                modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                                modifier = Modifier.weight(1.2f),
                                 onPress = { onKeyPressDown?.invoke("mode_change") },
                                 onLongPressSelect = { label -> onKeyPress(if (label == "number") "mode_change_number" else "mode_change_common_symbol") },
                                 longPressItems = listOf("number", "common_symbol"),
@@ -610,7 +612,7 @@ fun KeyboardLayout(
                                     onClick = k2OnClick,
                                     backgroundColor = keyBackgroundColor,
                                     iconColor = keyTextColor,
-                                    modifier = Modifier.padding(2.dp,4.dp).weight(0.8f),
+                                    modifier = Modifier.weight(0.8f),
                                     onPress = { onKeyPressDown?.invoke(k2TapValue) },
                                     shadowEnabled = shadowEnabled,
                                     shadowElevation = shadowElevation,
@@ -622,7 +624,7 @@ fun KeyboardLayout(
                                     onClick = k2OnClick,
                                     backgroundColor = keyBackgroundColor,
                                     textColor = keyTextColor,
-                                    modifier = Modifier.padding(2.dp,4.dp).weight(0.8f),
+                                    modifier = Modifier.weight(0.8f),
                                     swipeText = k2SwipeUpLabel,
                                     swipeDownText = k2SwipeDownBubbleText,
                                     swipeDownKeyLabel = if (!isAsciiMode && (k2SwipeDownDisplay == DisplayMode.KEY || k2SwipeDownDisplay == DisplayMode.BOTH)) k2SwipeDownLabel else null,
@@ -687,7 +689,7 @@ fun KeyboardLayout(
                                         }
                                     }
                                 }
-                                .padding(horizontal = 2.dp, vertical = 4.dp)
+                                .padding(horizontal = 2.dp, vertical = 0.dp)
                                 .fillMaxWidth()
                                 .fillMaxHeight()
                                 .then(spaceShadowModifier)
@@ -816,7 +818,7 @@ fun KeyboardLayout(
                                     onClick = k4OnClick,
                                     backgroundColor = keyBackgroundColor,
                                     iconColor = keyTextColor,
-                                    modifier = Modifier.padding(2.dp,4.dp).weight(0.8f),
+                                    modifier = Modifier.weight(0.8f),
                                     onPress = { onKeyPressDown?.invoke(k4TapValue) },
                                     shadowEnabled = shadowEnabled,
                                     shadowElevation = shadowElevation,
@@ -828,7 +830,7 @@ fun KeyboardLayout(
                                     onClick = k4OnClick,
                                     backgroundColor = keyBackgroundColor,
                                     textColor = keyTextColor,
-                                    modifier = Modifier.padding(2.dp,4.dp).weight(0.8f),
+                                    modifier = Modifier.weight(0.8f),
                                     swipeText = k4SwipeUpLabel,
                                     swipeDownText = k4SwipeDownBubbleText,
                                     swipeDownKeyLabel = if (!isAsciiMode && (k4SwipeDownDisplay == DisplayMode.KEY || k4SwipeDownDisplay == DisplayMode.BOTH)) k4SwipeDownLabel else null,
@@ -852,7 +854,7 @@ fun KeyboardLayout(
                                 onClick = { onKeyPress("enter") },
                                 backgroundColor = specialKeyBackgroundColor,
                                 textColor = keyTextColor,
-                                modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                                modifier = Modifier.weight(1.2f),
                                 onPress = { onKeyPressDown?.invoke("enter") },
                                 shadowEnabled = shadowEnabled,
                                 shadowElevation = shadowElevation,
@@ -971,6 +973,7 @@ fun KeyboardRowWithConfig(
         modifier = modifier
             .fillMaxWidth()
             .background(config.keyboardBackgroundColor),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         keys.forEach { key ->
             val rawSwipeUpLabel = KeysConfigHelper.getSwipeUpLabel(key, isAsciiMode)
@@ -1042,7 +1045,7 @@ fun KeyboardRowWithConfig(
                 onClick = onClick,
                 backgroundColor = config.keyBackgroundColor,
                 textColor = config.keyTextColor,
-                modifier = Modifier.padding(2.dp,4.dp).weight(1f),
+                modifier = Modifier.weight(1f),
                 swipeText = swipeUpText,
                 swipeDownText = swipeDownBubbleText,
                 swipeUpKeyLabel = swipeUpKeyLabel,
@@ -1316,6 +1319,7 @@ private fun LandscapeKeyboardContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 ShiftCapsKeyButton(
                     shiftMode = visualShiftMode,
@@ -1382,7 +1386,7 @@ private fun LandscapeKeyboardContent(
                     backgroundColor = keyBackgroundColor,
                     textColor = keyTextColor,
                     schemaName = if (isAsciiMode) "English" else schemaName,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(3f),
+                    modifier = Modifier.weight(3f),
                     onPress = { onKeyPressDown?.invoke("space") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -1499,6 +1503,7 @@ private fun LandscapeKeyboardContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 SplitSpaceKey(
                     onClick = { onKeyPress("space") },
@@ -1516,7 +1521,7 @@ private fun LandscapeKeyboardContent(
                     onClick = { onKeyPress("mode_change") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp,4.dp).weight(1.2f),
+                    modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("mode_change") },
                     onLongPressSelect = { label -> onKeyPress(if (label == "number") "mode_change_number" else "mode_change_common_symbol") },
                     longPressItems = listOf("number", "common_symbol"),

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -64,6 +64,7 @@ fun KeyboardView(
     val isShifted by viewModel.isShifted.collectAsStateWithLifecycle()
     val keyboardState by viewModel.keyboardState.collectAsStateWithLifecycle()
     val page by viewModel.page.collectAsStateWithLifecycle()
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
     val isLandscape = if (state.isFloatingMode) false
         else LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
 
@@ -74,20 +75,15 @@ fun KeyboardView(
     }
 
     LaunchedEffect(state.inputSessionId) {
-        when {
-            page !is KeyboardPage.Main -> viewModel.switchMain(MainType.FULL)
-            (page as KeyboardPage.Main).type == MainType.FULL -> {
-                if (keyboardState !is KeyboardLayoutState.Number) {
-                    viewModel.setKeyboardState(initialKeyboardLayoutState(state.isAsciiMode, state.currentSchemaId))
-                }
-            }
-        }
+        viewModel.dispatch(
+            KeyboardDispatchAction.InputSessionStarted(state.isAsciiMode, state.currentSchemaId)
+        )
     }
 
     LaunchedEffect(state.isAsciiMode, state.currentSchemaId) {
-        if (keyboardState is KeyboardLayoutState.Number) return@LaunchedEffect
-        val newState = initialKeyboardLayoutState(state.isAsciiMode, state.currentSchemaId)
-        viewModel.setKeyboardState(newState)
+        viewModel.dispatch(
+            KeyboardDispatchAction.AsciiModeChanged(state.isAsciiMode, state.currentSchemaId)
+        )
     }
 
     var savedNumberAsciiMode by remember { mutableStateOf<Boolean?>(null) }
@@ -119,7 +115,7 @@ fun KeyboardView(
         if (keyboardState is KeyboardLayoutState.Number) {
             if (savedNumberAsciiMode == null) {
                 savedNumberAsciiMode = state.isAsciiMode
-                if (!state.isAsciiMode) {
+                if (!state.isAsciiMode && page is KeyboardPage.Main) {
                     callbacks.onKeyPress("ime_switch", false)
                 }
             }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardViewState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardViewState.kt
@@ -1,0 +1,103 @@
+package com.kingzcheung.xime.ui.keyboard
+
+import com.kingzcheung.xime.keyboard.MainType
+import com.kingzcheung.xime.keyboard.OverlayRoute
+import com.kingzcheung.xime.keyboard.PanelType
+
+/**
+ * 统一键盘视图状态 — 替代原有的 [KeyboardPage] + [KeyboardLayoutState] 双轴管理。
+ *
+ * 编码了所有键盘导航层级和内容选择，所有状态转移通过 [KeyboardDispatchAction] 驱动，
+ * 由 ViewModel 的单⼀ dispatch() 入口处理。
+ */
+sealed interface KeyboardViewState {
+
+    // ── Level 0: 主键盘（无返回按钮） ──
+
+    /** 中文全键盘 */
+    data object ChineseFull : KeyboardViewState
+
+    /** 英文全键盘 */
+    data object EnglishFull : KeyboardViewState
+
+    /** 拼音九键 */
+    data object T9PinyinFull : KeyboardViewState
+
+    /** 笔画键盘 */
+    data object StrokeFull : KeyboardViewState
+
+    /** 手写键盘 */
+    data object Handwriting : KeyboardViewState
+
+    /** 语音键盘 */
+    data object Voice : KeyboardViewState
+
+    // ── Level 1: 面板（显示返回按钮） ──
+
+    data class NumberPanel(val returnTo: MainType) : KeyboardViewState
+
+    data class CommonSymbolPanel(val returnTo: MainType) : KeyboardViewState
+
+    // ── Level 2: 覆盖层（叠在任意状态之上） ──
+
+    data class Overlay(
+        val route: OverlayRoute,
+        val backStack: List<OverlayRoute>,
+        val behind: KeyboardViewState,
+    ) : KeyboardViewState
+
+    // ── 便捷属性 ──
+
+    /** 是否属于全键盘类（ChineseFull / EnglishFull / T9PinyinFull） */
+    val isFullKeyboard: Boolean get() = this is ChineseFull || this is EnglishFull || this is T9PinyinFull
+}
+
+/**
+ * 键盘调度动作 — 所有状态转移走单一入口。
+ */
+sealed interface KeyboardDispatchAction {
+
+    // ── 布局切换 ──
+
+    /** 中/英切换 */
+    data object ToggleChineseEnglish : KeyboardDispatchAction
+
+    /** 进⼊数字面板 */
+    data object ShowNumber : KeyboardDispatchAction
+
+    /** 进⼊常用符号面板 */
+    data object ShowCommonSymbol : KeyboardDispatchAction
+
+    /** 退出面板，回到主键盘 */
+    data object ExitPanel : KeyboardDispatchAction
+
+    /** 切换到拼音九键 */
+    data object SwitchToT9Pinyin : KeyboardDispatchAction
+
+    /** 切换到笔画键盘 */
+    data object SwitchToStroke : KeyboardDispatchAction
+
+    /** 切换到手写键盘 */
+    data object SwitchToHandwriting : KeyboardDispatchAction
+
+    // ── 外部事件 ──
+
+    /** ?123 切换（按当前 modeChangeTarget 走） */
+    data class ModeChange(val targetIsNumber: Boolean, val isAsciiMode: Boolean) : KeyboardDispatchAction
+
+    /** ASCII 模式由外部（Rime）改变 */
+    data class AsciiModeChanged(val isAsciiMode: Boolean, val schemaId: String) : KeyboardDispatchAction
+
+    /** 输⼊会话开始 */
+    data class InputSessionStarted(val isAsciiMode: Boolean, val schemaId: String) : KeyboardDispatchAction
+
+    // ── Overlay ──
+
+    data class ShowOverlay(val route: OverlayRoute, val backStack: List<OverlayRoute> = emptyList()) : KeyboardDispatchAction
+
+    data object CloseOverlay : KeyboardDispatchAction
+
+    data class PushOverlay(val route: OverlayRoute) : KeyboardDispatchAction
+
+    data object PopOverlay : KeyboardDispatchAction
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -173,6 +173,7 @@ fun NumberKeyboardLayout(
                     .fillMaxHeight()
                     .background(keyboardBackgroundColor)
                     .padding(start = 4.dp, end = 4.dp, bottom = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 NumberRows(
                     onKeyPress = onKeyPress,
@@ -234,14 +235,14 @@ private fun NumberRows(
             ) {
                 Column(
                     modifier = Modifier
-                        .padding(vertical = 2.dp)
+//                        .padding(vertical = 2.dp)
                         .fillMaxHeight()
                         .weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     Column(
                         modifier = Modifier
                             .fillMaxHeight()
-                            .padding(top = 0.dp, bottom = 2.dp, start = 2.dp, end = 0.dp)
                             .weight(3f),
                     ) {
                         symbols.forEach { symbol ->
@@ -267,7 +268,7 @@ private fun NumberRows(
                             onClick = { onKeyPress("abc") },
                             backgroundColor = specialKeyBackgroundColor,
                             iconColor = keyTextColor,
-                            modifier = Modifier.padding(2.dp).weight(1f),
+                            modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("abc") },
                             shadowEnabled = shadowEnabled,
                             shadowElevation = shadowElevation,
@@ -281,11 +282,13 @@ private fun NumberRows(
                     modifier = Modifier
                         .fillMaxHeight()
                         .weight(3f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         listOf("1", "2", "3").forEach { key ->
                             KeyButton(
@@ -298,7 +301,6 @@ private fun NumberRows(
                                 shadowElevation = shadowElevation,
                                 shadowShapeRadius = shadowShapeRadius,
                                 modifier = Modifier
-                                    .padding(2.dp)
                                     .weight(1f)
                             )
                         }
@@ -308,6 +310,7 @@ private fun NumberRows(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
 
                         listOf("4", "5", "6").forEach { key ->
@@ -321,7 +324,6 @@ private fun NumberRows(
                                 shadowElevation = shadowElevation,
                                 shadowShapeRadius = shadowShapeRadius,
                                 modifier = Modifier
-                                    .padding(2.dp)
                                     .weight(1f)
                             )
                         }
@@ -331,6 +333,7 @@ private fun NumberRows(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         listOf("7", "8", "9").forEach { key ->
                             KeyButton(
@@ -339,7 +342,6 @@ private fun NumberRows(
                                 backgroundColor = keyBackgroundColor,
                                 textColor = keyTextColor,
                                 modifier = Modifier
-                                    .padding(2.dp)
                                     .weight(1f),
                                 onPress = { onKeyPressDown?.invoke(key) },
                                 shadowEnabled = shadowEnabled,
@@ -354,6 +356,7 @@ private fun NumberRows(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
 
                         KeyButton(
@@ -361,7 +364,7 @@ private fun NumberRows(
                             onClick = { onKeyPress("symbol") },
                             backgroundColor = specialKeyBackgroundColor,
                             textColor = keyTextColor,
-                            modifier = Modifier.padding(2.dp).weight(1f),
+                            modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("symbol") },
                             shadowEnabled = shadowEnabled,
                             shadowElevation = shadowElevation,
@@ -372,7 +375,7 @@ private fun NumberRows(
                             onClick = { onKeyPress("0") },
                             backgroundColor = keyBackgroundColor,
                             textColor = keyTextColor,
-                            modifier = Modifier.padding(2.dp).weight(1f),
+                            modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("0") },
                             shadowEnabled = shadowEnabled,
                             shadowElevation = shadowElevation,
@@ -383,7 +386,7 @@ private fun NumberRows(
                             onClick = { onKeyPress(".") },
                             backgroundColor = keyBackgroundColor,
                             textColor = keyTextColor,
-                            modifier = Modifier.padding(2.dp).weight(1f),
+                            modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke(".") },
                             shadowEnabled = shadowEnabled,
                             shadowElevation = shadowElevation,
@@ -397,13 +400,14 @@ private fun NumberRows(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     SwipeableIconKeyButton(
                         icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                         onClick = { onKeyPress("delete") },
                         backgroundColor = specialKeyBackgroundColor,
                         iconColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         swipeText = "清空",
                         onSwipe = { onKeyPress("clear_composition") },
                         onLongClick = { onKeyPress("delete") },
@@ -427,7 +431,7 @@ private fun NumberRows(
                         onClick = { onKeyPress("space") },
                         backgroundColor = specialKeyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("space") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -438,7 +442,7 @@ private fun NumberRows(
                         onClick = { onKeyPress("emoji") },
                         backgroundColor = specialKeyBackgroundColor,
                         iconColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("emoji") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -449,7 +453,7 @@ private fun NumberRows(
                         onClick = { onKeyPress("enter") },
                         backgroundColor = specialKeyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("enter") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -157,13 +157,13 @@ fun T9KeyboardLayout(
                 modifier = Modifier
                     .fillMaxHeight()
                     .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 // 左侧候选区：外层统一圆角/阴影，内部候选项无缝排列
                 Box(
                     modifier = Modifier
                         .fillMaxHeight()
                         .weight(3f)
-                        .padding(vertical = 2.dp)
                         .then(
                             if (shadowEnabled) {
                                 Modifier.shadow(
@@ -241,7 +241,7 @@ fun T9KeyboardLayout(
                     onClick = { onKeyPress("symbol") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp).weight(1f),
+                    modifier = Modifier.weight(1f),
                     onPress = { onKeyPressDown?.invoke("symbol") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
@@ -253,12 +253,14 @@ fun T9KeyboardLayout(
                 modifier = Modifier
                     .fillMaxHeight()
                     .weight(3f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 // 第1行
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     NineKeyButton(
                         digit = "1",
@@ -266,7 +268,7 @@ fun T9KeyboardLayout(
                         onClick = { controller.onDigitPressed("1") },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("1") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -291,7 +293,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("2") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -315,7 +317,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("3") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -329,6 +331,7 @@ fun T9KeyboardLayout(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     T9DigitKey(
                         digit = "4",
@@ -348,7 +351,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("4") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -372,7 +375,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("5") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -396,7 +399,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("6") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -410,6 +413,7 @@ fun T9KeyboardLayout(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     T9DigitKey(
                         digit = "7",
@@ -429,7 +433,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("7") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -453,7 +457,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("8") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -477,7 +481,7 @@ fun T9KeyboardLayout(
                         },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("9") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -486,13 +490,15 @@ fun T9KeyboardLayout(
                 }
                 Row(modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f),) {
+                    .weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
                     KeyButton(
                         text = "123",
                         onClick = { onKeyPress("number") },
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("mode_change") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -506,7 +512,7 @@ fun T9KeyboardLayout(
                         onVoiceModeChange = callbacks.onVoiceModeChange,
                         backgroundColor = keyBackgroundColor,
                         textColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1.8f),
+                        modifier = Modifier.weight(1.8f),
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
                         shadowShapeRadius = shadowShapeRadius,
@@ -516,7 +522,7 @@ fun T9KeyboardLayout(
                         onClick = { onKeyPress("ime_switch") },
                         backgroundColor = keyBackgroundColor,
                         iconColor = keyTextColor,
-                        modifier = Modifier.padding(2.dp).weight(1f),
+                        modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("ime_switch") },
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -528,13 +534,14 @@ fun T9KeyboardLayout(
                 modifier = Modifier
                     .fillMaxHeight()
                     .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 SwipeableIconKeyButton(
                     icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                     onClick = { handleDelete() },
                     backgroundColor = specialKeyBackgroundColor,
                     iconColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp).weight(1f),
+                    modifier = Modifier.weight(1f),
                     swipeText = "清空",
                     onSwipe = { onKeyPress("clear_composition") },
                     onPress = { onKeyPressDown?.invoke("delete") },
@@ -557,7 +564,7 @@ fun T9KeyboardLayout(
                     onPress = { onKeyPressDown?.invoke("clear") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp).weight(1f),
+                    modifier = Modifier.weight(1f),
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,
                     shadowShapeRadius = shadowShapeRadius,
@@ -567,7 +574,7 @@ fun T9KeyboardLayout(
                     onClick = { onKeyPress("enter") },
                     backgroundColor = specialKeyBackgroundColor,
                     textColor = keyTextColor,
-                    modifier = Modifier.padding(2.dp).weight(2f),
+                    modifier = Modifier.weight(2f),
                     onPress = { onKeyPressDown?.invoke("enter") },
                     shadowEnabled = shadowEnabled,
                     shadowElevation = shadowElevation,

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -15,7 +15,11 @@ import com.kingzcheung.xime.keyboard.PanelType
 import com.kingzcheung.xime.keyboard.ToolbarButton
 import com.kingzcheung.xime.settings.SchemaInfo
 import com.kingzcheung.xime.speech.RecognitionState
+import com.kingzcheung.xime.ui.keyboard.KeyboardDispatchAction
 import com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState
+import com.kingzcheung.xime.ui.keyboard.transition
+import com.kingzcheung.xime.ui.keyboard.KeyboardLayoutAction
+import com.kingzcheung.xime.ui.keyboard.KeyboardViewState
 import com.kingzcheung.xime.ui.keyboard.initialKeyboardLayoutState
 
 enum class ShiftMode { OFF, SINGLE, CAPS }
@@ -83,6 +87,180 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
     private val _page = MutableStateFlow<KeyboardPage>(KeyboardPage.Main(MainType.FULL))
     val page: StateFlow<KeyboardPage> = _page.asStateFlow()
 
+
+    /** 是否从 handwriting 进入英文键盘，用于 ASCII 切回时恢复 handwriting */
+    var handwritingShouldReturn: Boolean = false
+
+    /** 进入面板前保存的 keyboardState，用于 exitPanel 恢复 */
+    private var _savedKbStateBeforePanel: KeyboardLayoutState? = null
+
+    /** 统一视图状态（替换 keyboardState + page 双轴） */
+    private val _viewState = MutableStateFlow<KeyboardViewState>(KeyboardViewState.ChineseFull)
+    val viewState: StateFlow<KeyboardViewState> = _viewState.asStateFlow()
+
+    /**
+     * 单⼀状态转移入口 — 替代所有散落的 LaunchedEffect、setKeyboardState、switchMain 等。
+     */
+    fun dispatch(
+        action: KeyboardDispatchAction,
+        isAsciiMode: Boolean = false,
+        schemaId: String = "",
+    ) {
+        val current = _viewState.value
+        val (newState, newPage, newKbState) = when (action) {
+            is KeyboardDispatchAction.ToggleChineseEnglish -> {
+                when (current) {
+                    KeyboardViewState.ChineseFull -> Triple(KeyboardViewState.EnglishFull, KeyboardPage.Main(MainType.FULL), KeyboardLayoutState.English)
+                    KeyboardViewState.EnglishFull -> Triple(KeyboardViewState.ChineseFull, KeyboardPage.Main(MainType.FULL), KeyboardLayoutState.Chinese)
+                    is KeyboardViewState.NumberPanel -> {
+                        Triple(KeyboardViewState.ChineseFull, KeyboardPage.Main(current.returnTo), initialKeyboardLayoutState(isAsciiMode, schemaId))
+                    }
+                    is KeyboardViewState.CommonSymbolPanel -> {
+                        Triple(KeyboardViewState.ChineseFull, KeyboardPage.Main(current.returnTo), initialKeyboardLayoutState(isAsciiMode, schemaId))
+                    }
+                    else -> Triple(current, _page.value, _keyboardState.value)
+                }
+            }
+            is KeyboardDispatchAction.ModeChange -> {
+                val target = if (action.targetIsNumber) KeyboardLayoutAction.SwitchToNumber
+                    else KeyboardLayoutAction.SwitchToCommonSymbol
+                val newKb = initialKeyboardLayoutState(isAsciiMode, schemaId).transition(target, isAsciiMode, schemaId)
+                val newVs: KeyboardViewState = when (newKb) {
+                    KeyboardLayoutState.Number -> KeyboardViewState.NumberPanel(MainType.FULL)
+                    KeyboardLayoutState.CommonSymbol -> KeyboardViewState.CommonSymbolPanel(MainType.FULL)
+                    else -> when (newKb) {
+                        is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
+                        is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
+                        is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
+                        is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
+                        else -> current
+                    }
+                }
+                val newPage = if (newKb is KeyboardLayoutState.Number || newKb is KeyboardLayoutState.CommonSymbol)
+                    KeyboardPage.Panel(
+                        if (newKb is KeyboardLayoutState.Number) PanelType.NUMBER else PanelType.COMMON_SYMBOL,
+                        MainType.FULL
+                    )
+                else KeyboardPage.Main(MainType.FULL)
+                Triple(newVs, newPage, newKb)
+            }
+            is KeyboardDispatchAction.ShowNumber -> {
+                val returnTo = when (current) {
+                    is KeyboardViewState.NumberPanel -> current.returnTo
+                    is KeyboardViewState.CommonSymbolPanel -> current.returnTo
+                    else -> MainType.FULL
+                }
+                Triple(KeyboardViewState.NumberPanel(returnTo), KeyboardPage.Panel(PanelType.NUMBER, returnTo), KeyboardLayoutState.Number)
+            }
+            is KeyboardDispatchAction.ShowCommonSymbol -> {
+                val returnTo = when (current) {
+                    is KeyboardViewState.NumberPanel -> current.returnTo
+                    is KeyboardViewState.CommonSymbolPanel -> current.returnTo
+                    else -> MainType.FULL
+                }
+                Triple(KeyboardViewState.CommonSymbolPanel(returnTo), KeyboardPage.Panel(PanelType.COMMON_SYMBOL, returnTo), KeyboardLayoutState.CommonSymbol)
+            }
+            is KeyboardDispatchAction.ExitPanel -> {
+                when (current) {
+                    is KeyboardViewState.NumberPanel, is KeyboardViewState.CommonSymbolPanel -> {
+                        val returnTo = (current as? KeyboardViewState.NumberPanel)?.returnTo
+                            ?: (current as KeyboardViewState.CommonSymbolPanel).returnTo
+                        val (vs, kb) = when (returnTo) {
+                            MainType.FULL -> {
+                                val kb = initialKeyboardLayoutState(isAsciiMode, schemaId)
+                                val vs = when (kb) {
+                                    is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
+                                    is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
+                                    is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
+                                    is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
+                                    else -> KeyboardViewState.ChineseFull
+                                }
+                                vs to kb
+                            }
+                            MainType.HANDWRITING -> KeyboardViewState.Handwriting to KeyboardLayoutState.Chinese
+                            MainType.STROKE -> KeyboardViewState.StrokeFull to KeyboardLayoutState.Stroke
+                            MainType.VOICE -> KeyboardViewState.Voice to KeyboardLayoutState.English
+                        }
+                        Triple(vs, KeyboardPage.Main(returnTo), kb)
+                    }
+                    else -> Triple(current, _page.value, _keyboardState.value)
+                }
+            }
+            is KeyboardDispatchAction.SwitchToT9Pinyin -> {
+                Triple(KeyboardViewState.T9PinyinFull, KeyboardPage.Main(MainType.FULL), KeyboardLayoutState.T9Pinyin)
+            }
+            is KeyboardDispatchAction.SwitchToStroke -> {
+                Triple(KeyboardViewState.StrokeFull, KeyboardPage.Main(MainType.FULL), KeyboardLayoutState.Stroke)
+            }
+            is KeyboardDispatchAction.SwitchToHandwriting -> {
+                Triple(KeyboardViewState.Handwriting, KeyboardPage.Main(MainType.HANDWRITING), KeyboardLayoutState.Chinese)
+            }
+            is KeyboardDispatchAction.AsciiModeChanged -> {
+                if (current is KeyboardViewState.NumberPanel || current is KeyboardViewState.CommonSymbolPanel) {
+                    Triple(current, _page.value, _keyboardState.value)
+                } else if (!action.isAsciiMode && action.schemaId == "handwriting") {
+                    Triple(KeyboardViewState.Handwriting, KeyboardPage.Main(MainType.HANDWRITING), KeyboardLayoutState.Chinese)
+                } else {
+                    val kb = initialKeyboardLayoutState(action.isAsciiMode, action.schemaId)
+                    val vs = when (kb) {
+                        is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
+                        is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
+                        is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
+                        is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
+                        else -> KeyboardViewState.ChineseFull
+                    }
+                    Triple(vs, KeyboardPage.Main(MainType.FULL), kb)
+                }
+            }
+            is KeyboardDispatchAction.InputSessionStarted -> {
+                val kb = initialKeyboardLayoutState(action.isAsciiMode, action.schemaId)
+                val vs = when (kb) {
+                    is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
+                    is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
+                    is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
+                    is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
+                    else -> KeyboardViewState.ChineseFull
+                }
+                Triple(vs, KeyboardPage.Main(MainType.FULL), kb)
+            }
+            is KeyboardDispatchAction.ShowOverlay -> {
+                Triple(KeyboardViewState.Overlay(action.route, action.backStack, current), KeyboardPage.Overlay(action.route, action.backStack, _page.value), _keyboardState.value)
+            }
+            is KeyboardDispatchAction.CloseOverlay -> {
+                val behind = (current as? KeyboardViewState.Overlay)?.behind ?: current
+                val behindPage = (_page.value as? KeyboardPage.Overlay)?.behind ?: _page.value
+                Triple(behind, behindPage, _keyboardState.value)
+            }
+            is KeyboardDispatchAction.PushOverlay -> {
+                val ov = current as? KeyboardViewState.Overlay ?: return
+                val ovPage = _page.value as? KeyboardPage.Overlay ?: return
+                Triple(
+                    KeyboardViewState.Overlay(action.route, ov.backStack + ov.route, ov.behind),
+                    KeyboardPage.Overlay(action.route, ovPage.backStack + ovPage.route, ovPage.behind),
+                    _keyboardState.value
+                )
+            }
+            is KeyboardDispatchAction.PopOverlay -> {
+                val ov = current as? KeyboardViewState.Overlay ?: return
+                val ovPage = _page.value as? KeyboardPage.Overlay ?: return
+                if (ov.backStack.isEmpty()) return
+                val prevRoute = ov.backStack.last()
+                Triple(
+                    KeyboardViewState.Overlay(prevRoute, ov.backStack.dropLast(1), ov.behind),
+                    KeyboardPage.Overlay(prevRoute, ovPage.backStack.dropLast(1), ovPage.behind),
+                    _keyboardState.value
+                )
+            }
+        }
+        _viewState.value = newState
+        _page.value = newPage
+        if (newKbState is KeyboardLayoutState.English) {
+            _isShifted.value = false
+            _shiftMode.value = ShiftMode.OFF
+        }
+        _keyboardState.value = newKbState
+    }
+
     fun toggleShift() {
         _isShifted.update { !it }
     }
@@ -128,8 +306,38 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         if (state is KeyboardLayoutState.English) {
             _isShifted.value = false
             _shiftMode.value = ShiftMode.OFF
+        } else {
+            handwritingShouldReturn = false
         }
         _keyboardState.value = state
+        _syncViewState()
+    }
+    
+    private fun _syncViewState() {
+        val kb = _keyboardState.value
+        val p = _page.value
+        val vs: KeyboardViewState = when (p) {
+            is KeyboardPage.Overlay -> KeyboardViewState.Overlay(p.route, p.backStack, _viewState.value.let { if (it is KeyboardViewState.Overlay) it.behind else it })
+            is KeyboardPage.Panel -> when (p.type) {
+                com.kingzcheung.xime.keyboard.PanelType.NUMBER -> KeyboardViewState.NumberPanel(p.returnTo)
+                com.kingzcheung.xime.keyboard.PanelType.COMMON_SYMBOL -> KeyboardViewState.CommonSymbolPanel(p.returnTo)
+            }
+            is KeyboardPage.Main -> when (p.type) {
+                com.kingzcheung.xime.keyboard.MainType.FULL -> when (kb) {
+                    is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
+                    is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
+                    is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
+                    is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
+                    is KeyboardLayoutState.Number -> KeyboardViewState.NumberPanel(com.kingzcheung.xime.keyboard.MainType.FULL)
+                    is KeyboardLayoutState.CommonSymbol -> KeyboardViewState.CommonSymbolPanel(com.kingzcheung.xime.keyboard.MainType.FULL)
+                    else -> KeyboardViewState.ChineseFull
+                }
+                com.kingzcheung.xime.keyboard.MainType.HANDWRITING -> KeyboardViewState.Handwriting
+                com.kingzcheung.xime.keyboard.MainType.STROKE -> KeyboardViewState.StrokeFull
+                com.kingzcheung.xime.keyboard.MainType.VOICE -> KeyboardViewState.Voice
+            }
+        }
+        _viewState.value = vs
     }
 
     fun resetShift() {
@@ -145,6 +353,7 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         if (type == MainType.FULL) {
             _keyboardState.value = KeyboardLayoutState.Chinese
         }
+        _syncViewState()
     }
 
     /** Level 2: 进入面板（编号/符号等），可从任意页面进入 */
@@ -159,7 +368,15 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
                 else MainType.FULL
             }
         }
+        if (_savedKbStateBeforePanel == null) {
+            _savedKbStateBeforePanel = _keyboardState.value
+        }
         _page.value = KeyboardPage.Panel(type, mainType)
+        _keyboardState.value = when (type) {
+            PanelType.NUMBER -> KeyboardLayoutState.Number
+            PanelType.COMMON_SYMBOL -> KeyboardLayoutState.CommonSymbol
+        }
+        _syncViewState()
     }
 
     /** Level 2: 退出面板，回到主键盘 */
@@ -167,6 +384,13 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         val current = _page.value
         if (current is KeyboardPage.Panel) {
             _page.value = KeyboardPage.Main(current.returnTo)
+            val saved = _savedKbStateBeforePanel
+            _savedKbStateBeforePanel = null
+            _keyboardState.value = when (current.returnTo) {
+                com.kingzcheung.xime.keyboard.MainType.FULL -> saved ?: KeyboardLayoutState.Chinese
+                else -> KeyboardLayoutState.Chinese
+            }
+            _syncViewState()
         }
     }
 
@@ -175,6 +399,7 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         val current = _page.value
         val behind = if (current is KeyboardPage.Overlay) current.behind else current
         _page.value = KeyboardPage.Overlay(route, initialBackStack, behind)
+        _syncViewState()
     }
 
     /** Level 3: 在覆盖页面内推入子页 */
@@ -185,6 +410,7 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
                 route = route,
                 backStack = current.backStack + current.route
             )
+            _syncViewState()
         }
     }
 
@@ -197,6 +423,7 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
                 route = prev,
                 backStack = current.backStack.dropLast(1)
             )
+            _syncViewState()
         }
     }
 
@@ -205,6 +432,7 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         val current = _page.value
         if (current is KeyboardPage.Overlay) {
             _page.value = current.behind
+            _syncViewState()
         }
     }
 


### PR DESCRIPTION
实现数字键盘和符号键盘中单字符按键的直接输入，
无需通过计算器引擎处理，提升输入效率。

fix(layout): 修复键盘布局间距问题

调整数字键盘、符号键盘和全键盘布局中的
垂直和水平间距设置，统一使用 Arrangement.spacedBy
替代 padding，改善视觉效果。

refactor(service): 优化键盘状态管理和输入处理

重构 XimeInputMethodService 中的键盘状态管理逻辑，
添加 Number/CommonSymbol 键盘内部切换处理，
优化单字符直接提交流程，并移除冗余的 padding 设置。