### PR TITLE
fix(app): 修复SchemaMarketScreen中下载文件大小的计算和显示逻辑，改为计算总字节数

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 50
-        versionName = "2.5.0-beta7"
+        versionCode = 51
+        versionName = "2.5.0-beta8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexModels.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexModels.kt
@@ -74,8 +74,8 @@ data class MarketScheme(
 @Serializable
 data class DownloadItem(
     val url: String = "",
-    val sha256: String = "",
-    val size: String = "",
+    val sha256: String? = null,
+    val size: String? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -53,7 +53,7 @@ object XimeIndexSource {
             ?: "file.${url.substringAfterLast('.').takeIf { it.length in 1..6 } ?: "bin"}"
 
     private val DownloadItem.sizeBytes: Long
-        get() = size.removeSuffix(" MB").trim().toDoubleOrNull()
+        get() = size?.removeSuffix(" MB")?.trim()?.toDoubleOrNull()
             ?.let { (it * 1024.0 * 1024.0).toLong() } ?: 0L
 
     private fun buildMirrors(userUrls: List<String>): List<String> = userUrls
@@ -155,7 +155,7 @@ object XimeIndexSource {
 
         for (dl in items) {
             val result = SchemaManager.downloadToMarket(
-                context, dl.url, scheme.id, dl.fileName, dl.sha256.takeIf { it.isNotBlank() },
+                context, dl.url, scheme.id, dl.fileName, dl.sha256?.takeIf { it.isNotBlank() },
                 onProgress = { read, _ ->
                     val overall = accumulatedBytes + read
                     if (totalBytesAll > 0) onDownloadProgress(overall, totalBytesAll)

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
@@ -369,9 +369,13 @@ private fun SchemeCard(
             }
             Spacer(Modifier.height(10.dp))
             val versionForSize = scheme.versions.firstOrNull { it.version == selectedVersion }
-            val sizeLabel = versionForSize?.size?.ifBlank {
-                versionForSize.downloadUrls.firstOrNull { it.size.isNotBlank() }?.size
-            }
+            val totalBytes = versionForSize?.downloadUrls?.sumOf { dl ->
+                dl.size?.removeSuffix(" MB")?.trim()?.toDoubleOrNull()
+                    ?.let { (it * 1024.0 * 1024.0).toLong() } ?: 0L
+            } ?: 0L
+            val sizeLabel = if (totalBytes > 0) {
+                "%.1f MB".format(totalBytes / (1024.0 * 1024.0))
+            } else null
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
- 将应用版本从2.5.0-beta7更新到2.5.0-beta8，versionCode从50更新到51
- 修改DownloadItem数据类中的sha256和size字段为可空类型(String?)
- 更新XimeIndexSource中对sizeBytes的计算逻辑，支持可空值处理
- 修复SchemaMarketScreen中下载文件大小的计算和显示逻辑，改为计算总字节数
- 处理downloadToMarket函数中sha256参数的空值安全调用
- 更新librime和librime-lua-deps子项目提交记录