### PR TITLE
fix(t9): 修复T9输入时, 切换词库管理页面返回后左侧候选区未清空问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -74,18 +74,6 @@ fun KeyboardView(
         callbacks.onKeyboardModeChange?.invoke(active)
     }
 
-    LaunchedEffect(state.inputSessionId) {
-        viewModel.dispatch(
-            KeyboardDispatchAction.InputSessionStarted(state.isAsciiMode, state.currentSchemaId)
-        )
-    }
-
-    LaunchedEffect(state.isAsciiMode, state.currentSchemaId) {
-        viewModel.dispatch(
-            KeyboardDispatchAction.AsciiModeChanged(state.isAsciiMode, state.currentSchemaId)
-        )
-    }
-
     var savedNumberAsciiMode by remember { mutableStateOf<Boolean?>(null) }
 
     val t9Controller = remember {
@@ -97,6 +85,19 @@ fun KeyboardView(
             onRightCommitUndone = { count ->
                 callbacks.onT9RightCommitUndone?.invoke(count)
             }
+        )
+    }
+
+    LaunchedEffect(state.inputSessionId) {
+        t9Controller.reset()
+        viewModel.dispatch(
+            KeyboardDispatchAction.InputSessionStarted(state.isAsciiMode, state.currentSchemaId)
+        )
+    }
+
+    LaunchedEffect(state.isAsciiMode, state.currentSchemaId) {
+        viewModel.dispatch(
+            KeyboardDispatchAction.AsciiModeChanged(state.isAsciiMode, state.currentSchemaId)
         )
     }
 


### PR DESCRIPTION
@kingzcheung 
关联 Issue： #336，只解决issue中问题二，新增问题会单独修复，问题一根据反馈复测，beta8版本测试失败。问题一依然存在，待后续沟通确认如何处理。

### 问题二：
根因：T9InputController 独立持有输入状态（firstOptions/inputBuffer）， 页面切换时 onFinishInput/onStartInput 仅清空 RIME composition 和 candidateState，但未重置 T9InputController，导致左侧候选区显示残留。

修复：将 t9Controller 定义提前，在 KeyboardView 的
LaunchedEffect(state.inputSessionId) 中调用 t9Controller.reset()。 每次新输入会话开始时自动清空 T9 状态，不上屏任何文本。

### 测试结果：
本地实体机Android10版上测试通过
./gradlew test 测试通过。

### 其他信息
issue中提到的：问题一在：beta8版本下的截图：
<img width="1080" height="2107" alt="wenti1" src="https://github.com/user-attachments/assets/9d2e199c-b9e1-4e84-9974-93e4a71379dc" />

