### PR TITLE
feat(dictionary): 新增个人词库管理和方案词库功能

### DIFF
--- a/app/src/main/assets/rime/user_simp.dict.yaml
+++ b/app/src/main/assets/rime/user_simp.dict.yaml
@@ -1,9 +1,0 @@
-# Rime dict
----
-name: sample_pack
-version: '1.0'
-sort: original
-use_preset_vocabulary: false
-...
-
-粗鄙之语	cu bi zhi yu

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.rime
 
 import android.content.Context
 import android.util.Log
+import com.kingzcheung.xime.settings.PersonalDictManager
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SettingsPreferences
@@ -28,7 +29,11 @@ object RimeConfigHelper {
         copyAssetsToRimeDir(context, rimeDir)
         // F1: assets 会用内置 default.yaml 覆盖，这里把启用方案重新写回 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
-        
+        // 确保个人词库和自定义短语文件存在，并为所有方案打补丁
+        PersonalDictManager.ensureAllPackFilesExist(context)
+        PersonalDictManager.ensureCustomPhraseFileExists(context)
+        PersonalDictManager.ensureSchemaPacks(context)
+
         Log.d(TAG, "Checking for missing schema files...")
         try {
             withTimeout(60_000L) {
@@ -59,6 +64,9 @@ object RimeConfigHelper {
         copyAssetsToRimeDir(context, rimeDir)
         // F1: 同步初始化路径也写回 default.yaml 的 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
+        PersonalDictManager.ensureAllPackFilesExist(context)
+        PersonalDictManager.ensureCustomPhraseFileExists(context)
+        PersonalDictManager.ensureSchemaPacks(context)
         checkAndCleanBuildDir(rimeDir)
         listFilesRecursively(rimeDir, TAG)
         
@@ -115,6 +123,10 @@ object RimeConfigHelper {
             if (schemaFile.exists()) {
                 digest.update(schemaId.toByteArray())
                 digest.update(schemaFile.readBytes())
+            }
+            val customFile = File(rimeDir, "$schemaId.custom.yaml")
+            if (customFile.exists()) {
+                digest.update(customFile.readBytes())
             }
         }
 

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1513,6 +1513,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         val inputText = composition.input
         val preeditText = composition.preedit
         val candidatesWithComments = composition.candidates.toList()
+        if (candidatesWithComments.isNotEmpty() || inputText.isNotEmpty()) {
+            Log.d(TAG, "updateUI: input='$inputText' preedit='$preeditText' candidates=${candidatesWithComments.joinToString { "'${it.text}'/${it.comment}'" }}")
+        }
         val isAsciiMode = composition.isAsciiMode
         val hasNextPage = composition.hasNextPage
         val hasPrevPage = composition.hasPrevPage
@@ -1571,6 +1574,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         val t0 = System.nanoTime()
         val isAsciiMode = result.isAsciiMode
         val candidatesWithComments = result.candidates
+        if (candidatesWithComments.isNotEmpty() || result.inputText.isNotEmpty()) {
+            Log.d(TAG, "updateUIWithResult: input='${result.inputText}' preedit='${result.preeditText}' candidates=${candidatesWithComments.joinToString { "'${it.text}'/${it.comment}'" }}")
+        }
 
         val pendingEnglish = candidateState.value.pendingEnglishText
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/DictionaryHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/DictionaryHelper.kt
@@ -7,7 +7,8 @@ import java.util.Locale
 
 data class DictEntry(
     val word: String,
-    val code: String
+    val code: String,
+    val weight: Int? = null
 )
 
 object DictionaryHelper {

--- a/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
@@ -1,0 +1,251 @@
+package com.kingzcheung.xime.settings
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+
+object PersonalDictManager {
+    private const val TAG = "PersonalDictManager"
+    private const val CUSTOM_PHRASE_FILE = "custom_phrase.txt"
+
+    private const val DEFAULT_HEADER = """# Rime dict
+---
+name: %s
+version: '1.0'
+sort: original
+use_preset_vocabulary: false
+...
+"""
+
+    private fun packName(schemaId: String): String = when {
+        schemaId == "pinyin_simp" || schemaId == "t9_pinyin" -> "user_simp_pinyin"
+        schemaId == "wubi86" -> "user_simp_wubi"
+        else -> "user_simp_pinyin"
+    }
+
+    private fun packFileName(schemaId: String) = "${packName(schemaId)}.dict.yaml"
+
+    private fun packHeader(schemaId: String) = DEFAULT_HEADER.format(packName(schemaId))
+
+    fun getPackFile(context: Context, schemaId: String): File =
+        File(SchemaManager.getRimeDir(context), packFileName(schemaId))
+
+    fun getCustomPhraseFile(context: Context): File =
+        File(SchemaManager.getRimeDir(context), CUSTOM_PHRASE_FILE)
+
+    fun ensureAllPackFilesExist(context: Context) {
+        for (sid in listOf("pinyin_simp", "t9_pinyin", "wubi86")) {
+            val file = getPackFile(context, sid)
+            if (!file.exists()) {
+                file.parentFile?.mkdirs()
+                file.writeText(packHeader(sid), Charsets.UTF_8)
+            }
+        }
+    }
+
+    fun ensureCustomPhraseFileExists(context: Context) {
+        val file = getCustomPhraseFile(context)
+        if (!file.exists()) {
+            file.parentFile?.mkdirs()
+            file.writeText("""# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
+#
+""", Charsets.UTF_8)
+        }
+    }
+
+    // ── 方案配置补丁 ──
+    //
+    // 词库扩展包 (packs) 依赖 prism 中存在对应的编码。
+    // 有 speller/algebra 的方案（如拼音），algebra 展开后所有有效编码都在 prism 中，
+    // packs 可以自由添加新词条。
+    // 无 speller/algebra 的方案（如五笔），prism 只包含词典条目中实际出现的编码，
+    // 需用 import_tables 合并词典，将个人词库编码一并编入 prism。
+
+    fun ensureSchemaPacks(context: Context) {
+        val rimeDir = SchemaManager.getRimeDir(context)
+        val schemaFiles = rimeDir.listFiles { f -> f.name.endsWith(".schema.yaml") && !f.name.startsWith("user_simp_") } ?: return
+        for (sf in schemaFiles) {
+            val schemaId = sf.name.removeSuffix(".schema.yaml")
+            if (hasSpellerAlgebra(sf))
+                applyPackConfig(rimeDir, schemaId)
+            else
+                applyMergedDictConfig(rimeDir, schemaId)
+        }
+    }
+
+    internal fun hasSpellerAlgebra(schemaFile: java.io.File): Boolean {
+        val text = schemaFile.readText(Charsets.UTF_8).replace("\r\n", "\n")
+        val idx = text.indexOf("\n  algebra:\n")
+        if (idx < 0) return false
+        val section = text.substring(idx, text.indexOf("\n\n", idx).let { if (it < 0) text.length else it })
+        return section.contains("- ")
+    }
+
+    // 方案有固定音节表：translator/packs via .custom.yaml
+    internal fun applyPackConfig(rimeDir: java.io.File, schemaId: String) {
+        val pkName = packName(schemaId)
+        val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
+        if (customFile.exists()) {
+            val text = customFile.readText(Charsets.UTF_8)
+            if (text.contains(pkName)) return
+        }
+        customFile.writeText("""# Xime 词库管理补丁 - 自动生成
+patch:
+  "translator/packs": ["$pkName"]
+""", Charsets.UTF_8)
+    }
+
+    // 方案无固定音节表：import_tables 合并词典 + translator/dictionary via .custom.yaml
+    internal fun applyMergedDictConfig(rimeDir: java.io.File, schemaId: String) {
+        val pkName = packName(schemaId)
+        val mergedId = "${schemaId}_merged"
+        val dictFile = java.io.File(rimeDir, "${mergedId}.dict.yaml")
+        if (!dictFile.exists()) {
+            dictFile.writeText("""# Rime dict
+---
+name: $mergedId
+version: "1.0"
+sort: original
+import_tables:
+  - $schemaId
+  - $pkName
+...
+""", Charsets.UTF_8)
+        }
+        val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
+        if (customFile.exists()) {
+            val text = customFile.readText(Charsets.UTF_8)
+            if (text.contains(mergedId)) return
+        }
+        customFile.writeText("""# Xime 词库管理补丁 - 自动生成
+patch:
+  "translator/dictionary": $mergedId
+""", Charsets.UTF_8)
+    }
+
+    // ── 个人词库 ──
+
+    fun loadEntries(context: Context, schemaId: String): List<DictEntry> {
+        val file = getPackFile(context, schemaId)
+        if (!file.exists()) return emptyList()
+        return try {
+            parsePersonalDictEntries(file.readText(Charsets.UTF_8))
+        } catch (_: Exception) { emptyList() }
+    }
+
+    fun saveEntries(context: Context, schemaId: String, entries: List<DictEntry>) {
+        val file = getPackFile(context, schemaId)
+        val defaultH = packHeader(schemaId)
+        val header = if (file.exists()) extractHeader(file, defaultH) else defaultH
+        file.writeText(buildDictText(header, entries), Charsets.UTF_8)
+    }
+
+    fun parsePersonalDictEntries(text: String): List<DictEntry> {
+        val out = mutableListOf<DictEntry>()
+        var inData = false
+        for (raw in text.lineSequence()) {
+            val line = raw.trim()
+            if (!inData) { if (line == "...") inData = true; continue }
+            if (line.isEmpty() || line.startsWith("#")) continue
+            val tabIdx = line.indexOf('\t')
+            if (tabIdx >= 0) {
+                out.add(DictEntry(line.substring(0, tabIdx), line.substring(tabIdx + 1)))
+            } else {
+                val spaceIdx = line.indexOf(' ')
+                if (spaceIdx >= 0) {
+                    out.add(DictEntry(line.substring(0, spaceIdx), line.substring(spaceIdx + 1).trim()))
+                }
+            }
+        }
+        return out
+    }
+
+    internal fun buildDictText(header: String, entries: List<DictEntry>): String {
+        val sb = StringBuilder()
+        sb.append(header.trimEnd('\n', '\r')).append('\n')
+        for (e in entries) sb.append(e.word).append('\t').append(e.code).append('\n')
+        return sb.toString()
+    }
+
+    internal fun extractHeader(file: File, defaultH: String): String {
+        if (!file.exists()) return defaultH
+        val text = file.readText(Charsets.UTF_8)
+        return extractHeaderFromText(text, defaultH)
+    }
+
+    internal fun extractHeaderFromText(text: String, defaultH: String): String {
+        val norm = text.replace("\r\n", "\n")
+        val idx = norm.indexOf("\n...\n")
+        if (idx >= 0) return norm.substring(0, idx + 5)
+        val start = norm.indexOf("...\n")
+        if (start >= 0) return norm.substring(0, start + 4)
+        return defaultH
+    }
+
+    // ── 自定义短语 ──
+
+    fun loadCustomPhrases(context: Context): List<DictEntry> {
+        val file = getCustomPhraseFile(context)
+        if (!file.exists()) return emptyList()
+        return try { parseCustomPhraseText(file.readText(Charsets.UTF_8)) } catch (_: Exception) { emptyList() }
+    }
+
+    fun saveCustomPhrases(context: Context, entries: List<DictEntry>) {
+        val file = getCustomPhraseFile(context)
+        val header = extractCustomPhraseHeader(file)
+        file.writeText(buildCustomPhraseText(header, entries), Charsets.UTF_8)
+    }
+
+    fun saveEntriesDirect(headerText: String, entries: List<DictEntry>): String {
+        val sb = StringBuilder()
+        sb.append(headerText.trimEnd('\n', '\r')).append('\n')
+        for (e in entries) {
+            sb.append(e.word).append('\t').append(e.code)
+            if (e.weight != null) sb.append('\t').append(e.weight)
+            sb.append('\n')
+        }
+        return sb.toString()
+    }
+
+    fun parseCustomPhraseText(text: String): List<DictEntry> {
+        val out = mutableListOf<DictEntry>()
+        for (raw in text.lineSequence()) {
+            val line = raw.trim()
+            if (line.isEmpty() || line.startsWith('#')) continue
+            val parts = line.split('\t')
+            if (parts.size >= 2) {
+                out.add(DictEntry(parts[0], parts[1], parts.getOrNull(2)?.toIntOrNull()))
+            }
+        }
+        return out
+    }
+
+    fun buildCustomPhraseText(header: String, entries: List<DictEntry>): String {
+        return saveEntriesDirect(header, entries)
+    }
+
+    internal fun extractCustomPhraseHeader(file: File): String {
+        val default = """# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
+#
+"""
+        if (!file.exists()) return default
+        return try {
+            val text = file.readText(Charsets.UTF_8)
+            val sb = StringBuilder()
+            for (raw in text.lineSequence()) {
+                if (raw.trim().isEmpty()) continue
+                if (!raw.startsWith("#")) break
+                sb.append(raw).append('\n')
+            }
+            sb.append("""#
+""")
+            sb.toString()
+        } catch (_: Exception) { default }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
@@ -73,7 +73,35 @@ use_preset_vocabulary: false
                 applyPackConfig(rimeDir, schemaId)
             else
                 applyMergedDictConfig(rimeDir, schemaId)
+            // 所有方案都添加自定义短语翻译器
+            applyCustomPhraseTranslator(rimeDir, schemaId)
         }
+    }
+
+    // 为方案添加 custom_phrase 翻译器（独立于主词典音节表）
+    internal fun applyCustomPhraseTranslator(rimeDir: java.io.File, schemaId: String) {
+        val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
+        if (customFile.exists()) {
+            val text = customFile.readText(Charsets.UTF_8)
+            if (text.contains("table_translator@custom_phrase")) return
+        }
+        val existing = if (customFile.exists()) {
+            customFile.readText(Charsets.UTF_8).trimEnd('\n', '\r', ' ')
+        } else ""
+        // remove trailing "..." if exists from old patch
+        val base = existing.removeSuffix("...").trimEnd('\n', '\r', ' ')
+        val newContent = """$base
+  "engine/translators/+":
+    - table_translator@custom_phrase
+  "custom_phrase":
+    dictionary: ""
+    user_dict: custom_phrase
+    db_class: stabledb
+    enable_completion: false
+    enable_sentence: false
+    initial_quality: 99
+"""
+        customFile.writeText(newContent, Charsets.UTF_8)
     }
 
     internal fun hasSpellerAlgebra(schemaFile: java.io.File): Boolean {
@@ -138,6 +166,7 @@ patch:
 
     fun saveEntries(context: Context, schemaId: String, entries: List<DictEntry>) {
         val file = getPackFile(context, schemaId)
+        file.parentFile?.mkdirs()
         val defaultH = packHeader(schemaId)
         val header = if (file.exists()) extractHeader(file, defaultH) else defaultH
         file.writeText(buildDictText(header, entries), Charsets.UTF_8)
@@ -150,9 +179,9 @@ patch:
             val line = raw.trim()
             if (!inData) { if (line == "...") inData = true; continue }
             if (line.isEmpty() || line.startsWith("#")) continue
-            val tabIdx = line.indexOf('\t')
-            if (tabIdx >= 0) {
-                out.add(DictEntry(line.substring(0, tabIdx), line.substring(tabIdx + 1)))
+            val parts = line.split('\t')
+            if (parts.size >= 2) {
+                out.add(DictEntry(parts[0], parts[1], parts.getOrNull(2)?.toIntOrNull()))
             } else {
                 val spaceIdx = line.indexOf(' ')
                 if (spaceIdx >= 0) {
@@ -166,7 +195,11 @@ patch:
     internal fun buildDictText(header: String, entries: List<DictEntry>): String {
         val sb = StringBuilder()
         sb.append(header.trimEnd('\n', '\r')).append('\n')
-        for (e in entries) sb.append(e.word).append('\t').append(e.code).append('\n')
+        for (e in entries) {
+            sb.append(e.word).append('\t').append(e.code)
+            if (e.weight != null) sb.append('\t').append(e.weight)
+            sb.append('\n')
+        }
         return sb.toString()
     }
 
@@ -186,31 +219,31 @@ patch:
     }
 
     // ── 自定义短语 ──
+    // custom_phrase.txt 通过独立的 table_translator 加载（db_class: stabledb），
+    // 不走主词典音节表，任意编码在所有方案中均可使用。
 
     fun loadCustomPhrases(context: Context): List<DictEntry> {
         val file = getCustomPhraseFile(context)
         if (!file.exists()) return emptyList()
-        return try { parseCustomPhraseText(file.readText(Charsets.UTF_8)) } catch (_: Exception) { emptyList() }
+        return try {
+            parseStableDbEntries(file.readText(Charsets.UTF_8))
+        } catch (_: Exception) { emptyList() }
     }
 
     fun saveCustomPhrases(context: Context, entries: List<DictEntry>) {
         val file = getCustomPhraseFile(context)
-        val header = extractCustomPhraseHeader(file)
-        file.writeText(buildCustomPhraseText(header, entries), Charsets.UTF_8)
+        file.parentFile?.mkdirs()
+        file.writeText(buildStableDbText(STABLEDB_HEADER, entries), Charsets.UTF_8)
     }
 
-    fun saveEntriesDirect(headerText: String, entries: List<DictEntry>): String {
-        val sb = StringBuilder()
-        sb.append(headerText.trimEnd('\n', '\r')).append('\n')
-        for (e in entries) {
-            sb.append(e.word).append('\t').append(e.code)
-            if (e.weight != null) sb.append('\t').append(e.weight)
-            sb.append('\n')
-        }
-        return sb.toString()
-    }
+    private const val STABLEDB_HEADER = """# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
+#
+"""
 
-    fun parseCustomPhraseText(text: String): List<DictEntry> {
+    internal fun parseStableDbEntries(text: String): List<DictEntry> {
         val out = mutableListOf<DictEntry>()
         for (raw in text.lineSequence()) {
             val line = raw.trim()
@@ -223,29 +256,14 @@ patch:
         return out
     }
 
-    fun buildCustomPhraseText(header: String, entries: List<DictEntry>): String {
-        return saveEntriesDirect(header, entries)
-    }
-
-    internal fun extractCustomPhraseHeader(file: File): String {
-        val default = """# Rime table
-# coding: utf-8
-#@/db_name	custom_phrase
-#@/db_type	tabledb
-#
-"""
-        if (!file.exists()) return default
-        return try {
-            val text = file.readText(Charsets.UTF_8)
-            val sb = StringBuilder()
-            for (raw in text.lineSequence()) {
-                if (raw.trim().isEmpty()) continue
-                if (!raw.startsWith("#")) break
-                sb.append(raw).append('\n')
-            }
-            sb.append("""#
-""")
-            sb.toString()
-        } catch (_: Exception) { default }
+    internal fun buildStableDbText(header: String, entries: List<DictEntry>): String {
+        val sb = StringBuilder()
+        sb.append(header.trimEnd('\n', '\r')).append('\n')
+        for (e in entries) {
+            sb.append(e.word).append('\t').append(e.code)
+            if (e.weight != null) sb.append('\t').append(e.weight)
+            sb.append('\n')
+        }
+        return sb.toString()
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/CustomPhraseScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/CustomPhraseScreen.kt
@@ -1,0 +1,247 @@
+package com.kingzcheung.xime.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.kingzcheung.xime.settings.DictEntry
+import com.kingzcheung.xime.viewmodel.CustomPhraseViewModel
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomPhraseContent(
+    onBack: () -> Unit,
+    vm: CustomPhraseViewModel = viewModel()
+) {
+    val uiState by vm.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("自定义短语", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { vm.showAddDialog() },
+                containerColor = MaterialTheme.colorScheme.primary
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "添加", tint = MaterialTheme.colorScheme.onPrimary)
+            }
+        }
+    ) { innerPadding ->
+        Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            Spacer(Modifier.height(12.dp))
+            Surface(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(28.dp),
+                tonalElevation = 2.dp,
+                color = MaterialTheme.colorScheme.surface
+            ) {
+                Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Search, contentDescription = null,
+                        tint = if (uiState.searchQuery.isNotEmpty()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(22.dp))
+                    Spacer(Modifier.width(12.dp))
+                    BasicTextField(value = uiState.searchQuery, onValueChange = { vm.setSearchQuery(it) },
+                        modifier = Modifier.weight(1f), singleLine = true,
+                        textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                        decorationBox = { innerTextField ->
+                            Box { if (uiState.searchQuery.isEmpty()) Text("搜索", color = MaterialTheme.colorScheme.onSurfaceVariant); innerTextField() }
+                        })
+                    if (uiState.searchQuery.isNotEmpty()) {
+                        IconButton(onClick = { vm.clearSearch() }, modifier = Modifier.size(24.dp)) {
+                            Icon(Icons.Default.Clear, contentDescription = "清除", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
+                        }
+                    }
+                }
+            }
+
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+            } else {
+                Text("共 ${uiState.entries.size} 条${if (uiState.searchQuery.isNotEmpty()) "，搜索结果 ${uiState.filteredEntries.size} 条" else ""}",
+                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+                if (uiState.entries.isEmpty()) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("暂无，点击右下角 + 添加", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                } else if (uiState.filteredEntries.isEmpty()) {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("未找到匹配条目", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                } else {
+                    LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+                        itemsIndexed(items = uiState.filteredEntries,
+                            key = { i, e -> "${e.word}_${e.code}_$i" }) { _, entry ->
+                            val realIndex = uiState.entries.indexOf(entry)
+                            PhraseItem(entry = entry,
+                                onEdit = { vm.setEditing(realIndex, entry); vm.showEditDialog() },
+                                onDelete = { vm.deleteEntry(realIndex) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+
+    if (uiState.showAddDialog) {
+        ModalBottomSheet(
+            onDismissRequest = { vm.hideAddDialog() },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp)) {
+                Text("添加短语", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 20.dp))
+                OutlinedTextField(value = uiState.editWord, onValueChange = { vm.setEditWord(it) },
+                    label = { Text("短语") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(value = uiState.editCode, onValueChange = { vm.setEditCode(it) },
+                    label = { Text("编码") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(value = uiState.editWeight, onValueChange = { vm.setEditWeight(it) },
+                    label = { Text("权重（可选）") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(24.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { vm.hideAddDialog() }) { Text("取消") }
+                    Spacer(Modifier.width(8.dp))
+                    Surface(
+                        modifier = Modifier.clickable(enabled = uiState.editWord.isNotBlank() && uiState.editCode.isNotBlank(),
+                            onClick = { vm.addEntry(uiState.editWord, uiState.editCode, uiState.editWeight.toIntOrNull()); vm.hideAddDialog(); scope.launch { sheetState.hide() } }),
+                        shape = RoundedCornerShape(10.dp), color = MaterialTheme.colorScheme.primary
+                    ) {
+                        Text("确定", modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                            style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimary)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+        }
+    }
+
+    if (uiState.showEditDialog) {
+        ModalBottomSheet(
+            onDismissRequest = { vm.hideEditDialog() },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp)) {
+                Text("编辑短语", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 20.dp))
+                OutlinedTextField(value = uiState.editWord, onValueChange = { vm.setEditWord(it) },
+                    label = { Text("短语") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(value = uiState.editCode, onValueChange = { vm.setEditCode(it) },
+                    label = { Text("编码") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(value = uiState.editWeight, onValueChange = { vm.setEditWeight(it) },
+                    label = { Text("权重（可选）") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(24.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { vm.hideEditDialog() }) { Text("取消") }
+                    Spacer(Modifier.width(8.dp))
+                    Surface(
+                        modifier = Modifier.clickable(enabled = uiState.editWord.isNotBlank() && uiState.editCode.isNotBlank(),
+                            onClick = { vm.updateEntry(uiState.editIndex, uiState.editWord, uiState.editCode, uiState.editWeight.toIntOrNull()); vm.hideEditDialog(); scope.launch { sheetState.hide() } }),
+                        shape = RoundedCornerShape(10.dp), color = MaterialTheme.colorScheme.primary
+                    ) {
+                        Text("确定", modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                            style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimary)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhraseItem(entry: DictEntry, onEdit: () -> Unit, onDelete: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Row(modifier = Modifier.fillMaxWidth().padding(start = 12.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(entry.word, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(entry.code, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                    if (entry.weight != null) {
+                        Spacer(Modifier.width(8.dp))
+                        Text("权重: ${entry.weight}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+            IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) {
+                Icon(Icons.Default.Edit, contentDescription = "编辑", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
+            }
+            IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                Icon(Icons.Default.Delete, contentDescription = "删除", tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f), modifier = Modifier.size(20.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/CustomPhraseScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/CustomPhraseScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -48,6 +49,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -116,7 +118,6 @@ fun CustomPhraseContent(
                     }
                 }
             }
-
             if (uiState.isLoading) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
             } else {
@@ -126,7 +127,7 @@ fun CustomPhraseContent(
 
                 if (uiState.entries.isEmpty()) {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("暂无，点击右下角 + 添加", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        UsageHint()
                     }
                 } else if (uiState.filteredEntries.isEmpty()) {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -243,5 +244,30 @@ private fun PhraseItem(entry: DictEntry, onEdit: () -> Unit, onDelete: () -> Uni
                 Icon(Icons.Default.Delete, contentDescription = "删除", tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f), modifier = Modifier.size(20.dp))
             }
         }
+    }
+}
+
+@Composable
+private fun UsageHint() {
+    val uriHandler = LocalUriHandler.current
+    Column(
+        modifier = Modifier
+            .clickable { uriHandler.openUri("https://ime.ximei.me/features/dictionary.html") }
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(Icons.Default.Info, contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(40.dp))
+        Spacer(Modifier.height(12.dp))
+        Text("暂无自定义短语", style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(4.dp))
+        Text("点击右下角 + 添加",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(16.dp))
+        Text("个人词库与自定义短语的区别 → 查看使用说明",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary)
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/DictionarySettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/DictionarySettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.kingzcheung.xime.ui.settings
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,13 +13,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -26,53 +30,82 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.kingzcheung.xime.settings.DictEntry
-import com.kingzcheung.xime.viewmodel.DictionarySettingsViewModel
+import com.kingzcheung.xime.viewmodel.PersonalDictUiState
+import com.kingzcheung.xime.viewmodel.PersonalDictViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DictionarySettingsContent(
     onBack: () -> Unit
 ) {
-    val viewModel: DictionarySettingsViewModel = viewModel()
+    val viewModel: PersonalDictViewModel = viewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    var showPersonalDict by remember { mutableStateOf(true) }
     var showSchemaMenu by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
-                    Text(
-                        "词库管理",
-                        style = MaterialTheme.typography.titleMedium
-                    )
+                    val schema = uiState.availableSchemas.find { it.schemaId == uiState.selectedSchema }
+                    Text("词库管理 - ${schema?.name ?: uiState.selectedSchema}", maxLines = 1, overflow = TextOverflow.Ellipsis)
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "返回"
-                        )
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    Row(
+                        modifier = Modifier.clickable { showSchemaMenu = true },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val schema = uiState.availableSchemas.find { it.schemaId == uiState.selectedSchema }
+                        Text(schema?.name ?: uiState.selectedSchema, style = MaterialTheme.typography.bodyMedium)
+                        Icon(Icons.Default.ArrowDropDown, contentDescription = null, tint = MaterialTheme.colorScheme.onBackground)
+                    }
+                    DropdownMenu(
+                        expanded = showSchemaMenu,
+                        onDismissRequest = { showSchemaMenu = false },
+                        offset = DpOffset(0.dp, 4.dp),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
+                        for (s in uiState.availableSchemas) {
+                            DropdownMenuItem(
+                                text = { Text(s.name) },
+                                onClick = { showSchemaMenu = false; viewModel.selectSchema(s.schemaId) }
+                            )
+                        }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -80,211 +113,199 @@ fun DictionarySettingsContent(
                     titleContentColor = MaterialTheme.colorScheme.onBackground
                 )
             )
+        },
+        floatingActionButton = {
+            if (showPersonalDict) {
+                FloatingActionButton(
+                    onClick = { viewModel.showAddDialog() },
+                    containerColor = MaterialTheme.colorScheme.primary
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = "添加", tint = MaterialTheme.colorScheme.onPrimary)
+                }
+            }
         }
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        ) {
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-        ) {
-            Card(
-                shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { showSchemaMenu = true }
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    val schema = uiState.availableSchemas.find { it.schemaId == uiState.selectedSchema }
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = schema?.name ?: uiState.selectedSchema,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Medium
-                        )
-                        Text(
-                            text = uiState.selectedSchema,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Icon(
-                        Icons.Default.ArrowDropDown,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                }
+        Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                TabButton("个人词库", selected = showPersonalDict, onClick = { showPersonalDict = true }, modifier = Modifier.weight(1f))
+                Spacer(modifier = Modifier.width(8.dp))
+                TabButton("方案词库", selected = !showPersonalDict, onClick = { showPersonalDict = false }, modifier = Modifier.weight(1f))
             }
-            DropdownMenu(
-                expanded = showSchemaMenu,
-                onDismissRequest = { showSchemaMenu = false },
-                offset = DpOffset(0.dp, 4.dp),
-                shape = RoundedCornerShape(12.dp)
-            ) {
-                for (s in uiState.availableSchemas) {
-                    DropdownMenuItem(
-                        text = {
-                            Column {
-                                Text(s.name, style = MaterialTheme.typography.bodyMedium)
-                                Text(s.schemaId, style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                        },
-                        onClick = {
-                            showSchemaMenu = false
-                            viewModel.selectSchema(s.schemaId)
-                        }
-                    )
-                }
-            }
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        ) {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(28.dp),
-                tonalElevation = 2.dp,
-                color = MaterialTheme.colorScheme.surface
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        Icons.Default.Search,
-                        contentDescription = null,
-                        tint = if (uiState.searchQuery.isNotEmpty()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(22.dp)
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    BasicTextField(
-                        value = uiState.searchQuery,
-                        onValueChange = { viewModel.setSearchQuery(it) },
-                        modifier = Modifier.weight(1f),
-                        singleLine = true,
-                        textStyle = MaterialTheme.typography.bodyLarge.copy(
-                            color = MaterialTheme.colorScheme.onSurface
-                        ),
-                        decorationBox = { innerTextField ->
-                            Box {
-                                if (uiState.searchQuery.isEmpty()) {
-                                    Text(
-                                        "搜索词条或编码",
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        style = MaterialTheme.typography.bodyLarge
-                                    )
-                                }
-                                innerTextField()
-                            }
-                        }
-                    )
-                    if (uiState.searchQuery.isNotEmpty()) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        IconButton(
-                            onClick = { viewModel.clearSearch() },
-                            modifier = Modifier.size(24.dp)
-                        ) {
-                            Icon(
-                                Icons.Default.Clear,
-                                contentDescription = "清除",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(18.dp)
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp)
-            ) {
-            if (uiState.isLoading) {
-                Box(
-                    modifier = Modifier.fillMaxWidth().weight(1f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
-            } else if (uiState.selectedSchema.isEmpty() && uiState.availableSchemas.isEmpty()) {
-                Box(
-                    modifier = Modifier.fillMaxWidth().weight(1f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text("没有可用的输入方案", color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
+            Spacer(modifier = Modifier.height(12.dp))
+            if (showPersonalDict) {
+                SchemaDictContent(viewModel = viewModel, uiState = uiState)
             } else {
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = "共 ${uiState.allEntries.size} 条词条${if (uiState.searchQuery.isNotEmpty()) "，搜索结果 ${uiState.displayedEntries.size} 条" else ""}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 8.dp)
-                )
-
-                if (uiState.displayedEntries.isEmpty()) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth().weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = if (uiState.searchQuery.isEmpty()) "暂无词条" else "未找到匹配词条",
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxWidth().weight(1f)
-                    ) {
-                        items(uiState.displayedEntries, key = { "${it.word}_${it.code}" }) { entry ->
-                            DictEntryItem(entry = entry)
-                        }
-                    }
-                }
+                SchemaDictBrowserPanel()
             }
         }
+    }
+
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+
+    if (uiState.showAddDialog) {
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.hideAddDialog() },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp)) {
+                Text("添加词条", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 20.dp))
+                OutlinedTextField(value = uiState.editWord, onValueChange = { viewModel.setEditWord(it) },
+                    label = { Text("词条") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(value = uiState.editCode, onValueChange = { viewModel.setEditCode(it) },
+                    label = { Text("编码") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { viewModel.hideAddDialog() }) { Text("取消") }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Surface(
+                        modifier = Modifier.clickable(enabled = uiState.editWord.isNotBlank() && uiState.editCode.isNotBlank(),
+                            onClick = { viewModel.addEntry(uiState.editWord, uiState.editCode); viewModel.hideAddDialog(); scope.launch { sheetState.hide() } }),
+                        shape = RoundedCornerShape(10.dp), color = MaterialTheme.colorScheme.primary
+                    ) {
+                        Text("确定", modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                            style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimary)
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+
+    if (uiState.showEditDialog) {
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.hideEditDialog() },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp)) {
+                Text("编辑词条", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 20.dp))
+                OutlinedTextField(value = uiState.editWord, onValueChange = { viewModel.setEditWord(it) },
+                    label = { Text("词条") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(value = uiState.editCode, onValueChange = { viewModel.setEditCode(it) },
+                    label = { Text("编码") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { viewModel.hideEditDialog() }) { Text("取消") }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Surface(
+                        modifier = Modifier.clickable(enabled = uiState.editWord.isNotBlank() && uiState.editCode.isNotBlank(),
+                            onClick = { viewModel.updateEntry(uiState.editIndex, uiState.editWord, uiState.editCode); viewModel.hideEditDialog(); scope.launch { sheetState.hide() } }),
+                        shape = RoundedCornerShape(10.dp), color = MaterialTheme.colorScheme.primary
+                    ) {
+                        Text("确定", modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                            style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimary)
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
         }
     }
 }
 
 @Composable
-fun DictEntryItem(entry: DictEntry) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
+private fun TabButton(text: String, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.clickable(onClick = onClick),
+        shape = RoundedCornerShape(10.dp),
+        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = entry.word,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium
-            )
-            Text(
-                text = entry.code,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary
-            )
+        Box(modifier = Modifier.fillMaxWidth().padding(vertical = 10.dp), contentAlignment = Alignment.Center) {
+            Text(text, style = MaterialTheme.typography.bodyMedium,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SchemaDictContent(
+    viewModel: PersonalDictViewModel,
+    uiState: PersonalDictUiState
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Spacer(modifier = Modifier.height(12.dp))
+        Surface(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            shape = RoundedCornerShape(28.dp),
+            tonalElevation = 2.dp,
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Search, contentDescription = null,
+                    tint = if (uiState.searchQuery.isNotEmpty()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(22.dp))
+                Spacer(modifier = Modifier.width(12.dp))
+                BasicTextField(value = uiState.searchQuery, onValueChange = { viewModel.setSearchQuery(it) },
+                    modifier = Modifier.weight(1f), singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                    decorationBox = { innerTextField ->
+                        Box { if (uiState.searchQuery.isEmpty()) Text("搜索", color = MaterialTheme.colorScheme.onSurfaceVariant); innerTextField() }
+                    })
+                if (uiState.searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { viewModel.clearSearch() }, modifier = Modifier.size(24.dp)) {
+                        Icon(Icons.Default.Clear, contentDescription = "清除", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
+                    }
+                }
+            }
+        }
+
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+        } else {
+            Text("共 ${uiState.entries.size} 条${if (uiState.searchQuery.isNotEmpty()) "，搜索结果 ${uiState.filteredEntries.size} 条" else ""}",
+                style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+            if (uiState.entries.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("暂无，点击右下角 + 添加", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            } else if (uiState.filteredEntries.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("未找到匹配条目", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+                    itemsIndexed(items = uiState.filteredEntries,
+                        key = { i, e -> "${e.word}_${e.code}_$i" }) { _, entry ->
+                        val idx = uiState.entries.indexOf(entry)
+                        EntryItem(entry = entry,
+                            onEdit = {
+                                viewModel.setEditing(idx, entry.word, entry.code)
+                                viewModel.showEditDialog()
+                            },
+                            onDelete = { viewModel.deleteEntry(idx) })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EntryItem(entry: DictEntry, onEdit: () -> Unit, onDelete: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Row(modifier = Modifier.fillMaxWidth().padding(start = 12.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(entry.word, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                Text(entry.code, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            }
+            IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) {
+                Icon(Icons.Default.Edit, contentDescription = "编辑", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
+            }
+            IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                Icon(Icons.Default.Delete, contentDescription = "删除", tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f), modifier = Modifier.size(20.dp))
+            }
         }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/DictionarySettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/DictionarySettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -52,6 +53,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -131,7 +133,6 @@ fun DictionarySettingsContent(
                 Spacer(modifier = Modifier.width(8.dp))
                 TabButton("方案词库", selected = !showPersonalDict, onClick = { showPersonalDict = false }, modifier = Modifier.weight(1f))
             }
-            Spacer(modifier = Modifier.height(12.dp))
             if (showPersonalDict) {
                 SchemaDictContent(viewModel = viewModel, uiState = uiState)
             } else {
@@ -266,7 +267,7 @@ private fun SchemaDictContent(
 
             if (uiState.entries.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("暂无，点击右下角 + 添加", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    UsageHint()
                 }
             } else if (uiState.filteredEntries.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -307,5 +308,30 @@ private fun EntryItem(entry: DictEntry, onEdit: () -> Unit, onDelete: () -> Unit
                 Icon(Icons.Default.Delete, contentDescription = "删除", tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f), modifier = Modifier.size(20.dp))
             }
         }
+    }
+}
+
+@Composable
+private fun UsageHint() {
+    val uriHandler = LocalUriHandler.current
+    Column(
+        modifier = Modifier
+            .clickable { uriHandler.openUri("https://ime.ximei.me/features/dictionary.html") }
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(Icons.Default.Info, contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(40.dp))
+        Spacer(Modifier.height(12.dp))
+        Text("暂无词条", style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(4.dp))
+        Text("点击右下角 + 添加",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(16.dp))
+        Text("个人词库与自定义短语的区别 → 查看使用说明",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary)
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaDictBrowserScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaDictBrowserScreen.kt
@@ -1,0 +1,289 @@
+package com.kingzcheung.xime.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.kingzcheung.xime.settings.DictEntry
+import com.kingzcheung.xime.viewmodel.DictionarySettingsViewModel
+
+@Composable
+fun SchemaDictBrowserPanel() {
+    val viewModel: DictionarySettingsViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showSchemaMenu by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Card(
+                    shape = RoundedCornerShape(12.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showSchemaMenu = true }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val schema = uiState.availableSchemas.find { it.schemaId == uiState.selectedSchema }
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = schema?.name ?: uiState.selectedSchema,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                text = uiState.selectedSchema,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Icon(
+                            Icons.Default.ArrowDropDown,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+                DropdownMenu(
+                    expanded = showSchemaMenu,
+                    onDismissRequest = { showSchemaMenu = false },
+                    offset = DpOffset(0.dp, 4.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    for (s in uiState.availableSchemas) {
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(s.name, style = MaterialTheme.typography.bodyMedium)
+                                    Text(s.schemaId, style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                            },
+                            onClick = {
+                                showSchemaMenu = false
+                                viewModel.selectSchema(s.schemaId)
+                            }
+                        )
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(28.dp),
+                    tonalElevation = 2.dp,
+                    color = MaterialTheme.colorScheme.surface
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.Search,
+                            contentDescription = null,
+                            tint = if (uiState.searchQuery.isNotEmpty()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(22.dp)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        BasicTextField(
+                            value = uiState.searchQuery,
+                            onValueChange = { viewModel.setSearchQuery(it) },
+                            modifier = Modifier.weight(1f),
+                            singleLine = true,
+                            textStyle = MaterialTheme.typography.bodyLarge.copy(
+                                color = MaterialTheme.colorScheme.onSurface
+                            ),
+                            decorationBox = { innerTextField ->
+                                Box {
+                                    if (uiState.searchQuery.isEmpty()) {
+                                        Text(
+                                            "搜索词条或编码",
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            style = MaterialTheme.typography.bodyLarge
+                                        )
+                                    }
+                                    innerTextField()
+                                }
+                            }
+                        )
+                        if (uiState.searchQuery.isNotEmpty()) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            IconButton(
+                                onClick = { viewModel.clearSearch() },
+                                modifier = Modifier.size(24.dp)
+                            ) {
+                                Icon(
+                                    Icons.Default.Clear,
+                                    contentDescription = "清除",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
+            ) {
+                if (uiState.isLoading) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                } else if (uiState.selectedSchema.isEmpty() && uiState.availableSchemas.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("没有可用的输入方案", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                } else {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "共 ${uiState.allEntries.size} 条词条${if (uiState.searchQuery.isNotEmpty()) "，搜索结果 ${uiState.displayedEntries.size} 条" else ""}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+
+                    if (uiState.displayedEntries.isEmpty()) {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().weight(1f),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = if (uiState.searchQuery.isEmpty()) "暂无词条" else "未找到匹配词条",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxWidth().weight(1f)
+                        ) {
+                            items(uiState.displayedEntries, key = { "${it.word}_${it.code}" }) { entry ->
+                                DictEntryItem(entry = entry)
+                            }
+                        }
+                    }
+                }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SchemaDictBrowserContent(onBack: () -> Unit) {
+    val vm: DictionarySettingsViewModel = viewModel()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("方案词库") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground
+                )
+            )
+        }
+    ) { innerPadding ->
+        Column(modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding)
+        ) {
+            SchemaDictBrowserPanel()
+        }
+    }
+}
+
+@Composable
+private fun DictEntryItem(entry: DictEntry) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = entry.word,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = entry.code,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.LibraryBooks
 import androidx.compose.material.icons.twotone.AutoAwesome
+import androidx.compose.material.icons.twotone.Ballot
 import androidx.compose.material.icons.twotone.Build
 import androidx.compose.material.icons.twotone.CloudSync
 import androidx.compose.material.icons.twotone.Description
@@ -34,6 +35,7 @@ import androidx.compose.material.icons.twotone.Storefront
 import androidx.compose.material.icons.twotone.Straighten
 import androidx.compose.material.icons.twotone.TableChart
 import androidx.compose.material.icons.twotone.ToggleOn
+import androidx.compose.material.icons.twotone.TypeSpecimen
 import androidx.compose.material.icons.twotone.Vibration
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -70,6 +72,7 @@ fun SettingsMainContent(
     onNavigateToKeyEffect: () -> Unit,
     onNavigateToLayoutDisplay: () -> Unit,
     onNavigateToDictionary: () -> Unit,
+    onNavigateToCustomPhrase: () -> Unit,
     onNavigateToPlugins: () -> Unit,
     onNavigateToSmartPrediction: () -> Unit,
     onNavigateToSpeechToText: () -> Unit,
@@ -225,10 +228,22 @@ fun SettingsMainContent(
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                     )
                     SettingsItem(
-                        icon = Icons.AutoMirrored.TwoTone.LibraryBooks,
+                        icon = Icons.TwoTone.Ballot,
                         title = "词库管理",
                         subtitle = "管理用户词库",
                         onClick = onNavigateToDictionary,
+                        showArrow = true
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(start = 56.dp),
+                        thickness = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                    SettingsItem(
+                        icon = Icons.TwoTone.TypeSpecimen,
+                        title = "自定义短语",
+                        subtitle = "管理自定义短语",
+                        onClick = onNavigateToCustomPhrase,
                         showArrow = true
                     )
                 })

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -21,4 +21,5 @@ object SettingsRoutes {
     const val LogViewer = "log_viewer"
     const val WebDav = "webdav"
     const val SchemaDictBrowser = "schema_dict_browser"
+    const val CustomPhrase = "custom_phrase"
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -20,4 +20,5 @@ object SettingsRoutes {
     const val ModelManagement = "model_management"
     const val LogViewer = "log_viewer"
     const val WebDav = "webdav"
+    const val SchemaDictBrowser = "schema_dict_browser"
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ fun SettingsScreen(
                 onNavigateToKeyEffect = { navController.navigate(SettingsRoutes.KeyEffect) },
                 onNavigateToLayoutDisplay = { navController.navigate(SettingsRoutes.LayoutDisplay) },
                 onNavigateToDictionary = { navController.navigate(SettingsRoutes.Dictionary) },
+                onNavigateToCustomPhrase = { navController.navigate(SettingsRoutes.CustomPhrase) },
                 onNavigateToPlugins = { navController.navigate(SettingsRoutes.Plugins) },
                 onNavigateToSmartPrediction = { navController.navigate(SettingsRoutes.SmartPrediction) },
                 onNavigateToSpeechToText = { navController.navigate(SettingsRoutes.SpeechToText) },
@@ -131,6 +132,11 @@ fun SettingsScreen(
         }
         composable(SettingsRoutes.SchemaDictBrowser) {
             SchemaDictBrowserContent(
+                onBack = { navController.popBackStack() }
+            )
+        }
+        composable(SettingsRoutes.CustomPhrase) {
+            CustomPhraseContent(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -129,6 +129,11 @@ fun SettingsScreen(
                 onBack = { navController.popBackStack() }
             )
         }
+        composable(SettingsRoutes.SchemaDictBrowser) {
+            SchemaDictBrowserContent(
+                onBack = { navController.popBackStack() }
+            )
+        }
         composable(SettingsRoutes.WebDav) {
             WebDavSyncContent(
                 onBack = { navController.popBackStack() }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/CustomPhraseViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/CustomPhraseViewModel.kt
@@ -1,0 +1,168 @@
+package com.kingzcheung.xime.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.kingzcheung.xime.settings.DictEntry
+import com.kingzcheung.xime.settings.PersonalDictManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Locale
+
+data class CustomPhraseUiState(
+    val entries: List<DictEntry> = emptyList(),
+    val filteredEntries: List<DictEntry> = emptyList(),
+    val searchQuery: String = "",
+    val isLoading: Boolean = true,
+    val showAddDialog: Boolean = false,
+    val showEditDialog: Boolean = false,
+    val editIndex: Int = -1,
+    val editWord: String = "",
+    val editCode: String = "",
+    val editWeight: String = ""
+)
+
+class CustomPhraseViewModel(application: Application) : AndroidViewModel(application) {
+    private val context = application.applicationContext
+
+    private val _uiState = MutableStateFlow(CustomPhraseUiState())
+    val uiState: StateFlow<CustomPhraseUiState> = _uiState.asStateFlow()
+
+    init {
+        loadEntries()
+    }
+
+    private fun loadEntries() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val entries = withContext(Dispatchers.IO) {
+                PersonalDictManager.loadCustomPhrases(context)
+            }
+            _uiState.update {
+                it.copy(
+                    entries = entries,
+                    filteredEntries = filterEntries(entries, ""),
+                    searchQuery = "",
+                    isLoading = false
+                )
+            }
+        }
+    }
+
+    fun addEntry(word: String, code: String, weight: Int? = null) {
+        val trimmedWord = word.trim()
+        val trimmedCode = code.trim()
+        if (trimmedWord.isEmpty() || trimmedCode.isEmpty()) return
+
+        viewModelScope.launch {
+            val current = _uiState.value.entries
+            val updated = current + DictEntry(trimmedWord, trimmedCode, weight)
+            withContext(Dispatchers.IO) {
+                PersonalDictManager.saveCustomPhrases(context, updated)
+            }
+            _uiState.update {
+                val query = it.searchQuery
+                it.copy(entries = updated, filteredEntries = filterEntries(updated, query))
+            }
+        }
+    }
+
+    fun updateEntry(index: Int, word: String, code: String, weight: Int? = null) {
+        val trimmedWord = word.trim()
+        val trimmedCode = code.trim()
+        if (trimmedWord.isEmpty() || trimmedCode.isEmpty()) return
+
+        viewModelScope.launch {
+            val current = _uiState.value.entries.toMutableList()
+            if (index < 0 || index >= current.size) return@launch
+            current[index] = DictEntry(trimmedWord, trimmedCode, weight)
+            withContext(Dispatchers.IO) {
+                PersonalDictManager.saveCustomPhrases(context, current)
+            }
+            _uiState.update {
+                val query = it.searchQuery
+                it.copy(entries = current, filteredEntries = filterEntries(current, query))
+            }
+        }
+    }
+
+    fun deleteEntry(index: Int) {
+        viewModelScope.launch {
+            val current = _uiState.value.entries.toMutableList()
+            if (index < 0 || index >= current.size) return@launch
+            current.removeAt(index)
+            withContext(Dispatchers.IO) {
+                PersonalDictManager.saveCustomPhrases(context, current)
+            }
+            _uiState.update {
+                val query = it.searchQuery
+                it.copy(entries = current, filteredEntries = filterEntries(current, query))
+            }
+        }
+    }
+
+    fun setSearchQuery(query: String) {
+        _uiState.update {
+            it.copy(
+                searchQuery = query,
+                filteredEntries = filterEntries(it.entries, query)
+            )
+        }
+    }
+
+    fun clearSearch() {
+        setSearchQuery("")
+    }
+
+    fun showAddDialog() {
+        _uiState.update { it.copy(showAddDialog = true, editWord = "", editCode = "", editWeight = "", editIndex = -1) }
+    }
+
+    fun hideAddDialog() {
+        _uiState.update { it.copy(showAddDialog = false) }
+    }
+
+    fun showEditDialog() {
+        _uiState.update { it.copy(showEditDialog = true) }
+    }
+
+    fun hideEditDialog() {
+        _uiState.update { it.copy(showEditDialog = false) }
+    }
+
+    fun setEditing(index: Int, entry: DictEntry) {
+        _uiState.update { it.copy(
+            editIndex = index,
+            editWord = entry.word,
+            editCode = entry.code,
+            editWeight = entry.weight?.toString() ?: ""
+        ) }
+    }
+
+    fun setEditWord(word: String) {
+        _uiState.update { it.copy(editWord = word) }
+    }
+
+    fun setEditCode(code: String) {
+        _uiState.update { it.copy(editCode = code) }
+    }
+
+    fun setEditWeight(weight: String) {
+        _uiState.update { it.copy(editWeight = weight) }
+    }
+
+    private fun filterEntries(entries: List<DictEntry>, query: String): List<DictEntry> {
+        if (query.isEmpty()) return entries
+        val lowerQuery = query.lowercase(Locale.ROOT)
+        return entries.filter {
+            it.word.contains(query) ||
+                it.code.contains(query, ignoreCase = true) ||
+                it.code.lowercase(Locale.ROOT).contains(lowerQuery)
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/PersonalDictViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/PersonalDictViewModel.kt
@@ -1,0 +1,181 @@
+package com.kingzcheung.xime.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.kingzcheung.xime.settings.DictEntry
+import com.kingzcheung.xime.settings.PersonalDictManager
+import com.kingzcheung.xime.settings.SchemaManager
+import com.kingzcheung.xime.settings.SchemaMeta
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Locale
+
+data class PersonalDictUiState(
+    val selectedSchema: String = "pinyin_simp",
+    val availableSchemas: List<SchemaMeta> = emptyList(),
+    val entries: List<DictEntry> = emptyList(),
+    val filteredEntries: List<DictEntry> = emptyList(),
+    val searchQuery: String = "",
+    val isLoading: Boolean = true,
+    val showAddDialog: Boolean = false,
+    val showEditDialog: Boolean = false,
+    val editIndex: Int = -1,
+    val editWord: String = "",
+    val editCode: String = ""
+)
+
+class PersonalDictViewModel(application: Application) : AndroidViewModel(application) {
+    private val context = application.applicationContext
+
+    private val _uiState = MutableStateFlow(PersonalDictUiState())
+    val uiState: StateFlow<PersonalDictUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSchemas()
+    }
+
+    private fun loadSchemas() {
+        viewModelScope.launch {
+            val schemas = withContext(Dispatchers.IO) {
+                SchemaManager.discoverSchemas(context)
+            }
+            _uiState.update { it.copy(availableSchemas = schemas) }
+            loadEntries()
+        }
+    }
+
+    fun selectSchema(schemaId: String) {
+        _uiState.update { it.copy(selectedSchema = schemaId, searchQuery = "") }
+        loadEntries()
+    }
+
+    private fun loadEntries() {
+        val schemaId = _uiState.value.selectedSchema
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val entries = withContext(Dispatchers.IO) {
+                PersonalDictManager.loadEntries(context, schemaId)
+            }
+            _uiState.update {
+                it.copy(
+                    entries = entries,
+                    filteredEntries = filterEntries(entries, ""),
+                    searchQuery = "",
+                    isLoading = false
+                )
+            }
+        }
+    }
+
+    fun addEntry(word: String, code: String) {
+        val trimmedWord = word.trim()
+        val trimmedCode = code.trim()
+        if (trimmedWord.isEmpty() || trimmedCode.isEmpty()) return
+        val schemaId = _uiState.value.selectedSchema
+
+        viewModelScope.launch {
+            val current = _uiState.value.entries
+            val updated = current + DictEntry(trimmedWord, trimmedCode)
+            withContext(Dispatchers.IO) {
+                PersonalDictManager.saveEntries(context, schemaId, updated)
+            }
+            _uiState.update {
+                val query = it.searchQuery
+                it.copy(entries = updated, filteredEntries = filterEntries(updated, query))
+            }
+        }
+    }
+
+    fun updateEntry(index: Int, word: String, code: String) {
+        val trimmedWord = word.trim()
+        val trimmedCode = code.trim()
+        if (trimmedWord.isEmpty() || trimmedCode.isEmpty()) return
+        val schemaId = _uiState.value.selectedSchema
+
+        viewModelScope.launch {
+            val current = _uiState.value.entries.toMutableList()
+            if (index < 0 || index >= current.size) return@launch
+            current[index] = DictEntry(trimmedWord, trimmedCode)
+            withContext(Dispatchers.IO) {
+                PersonalDictManager.saveEntries(context, schemaId, current)
+            }
+            _uiState.update {
+                val query = it.searchQuery
+                it.copy(entries = current, filteredEntries = filterEntries(current, query))
+            }
+        }
+    }
+
+    fun deleteEntry(index: Int) {
+        val schemaId = _uiState.value.selectedSchema
+        viewModelScope.launch {
+            val current = _uiState.value.entries.toMutableList()
+            if (index < 0 || index >= current.size) return@launch
+            current.removeAt(index)
+            withContext(Dispatchers.IO) {
+                PersonalDictManager.saveEntries(context, schemaId, current)
+            }
+            _uiState.update {
+                val query = it.searchQuery
+                it.copy(entries = current, filteredEntries = filterEntries(current, query))
+            }
+        }
+    }
+
+    fun setSearchQuery(query: String) {
+        _uiState.update {
+            it.copy(
+                searchQuery = query,
+                filteredEntries = filterEntries(it.entries, query)
+            )
+        }
+    }
+
+    fun clearSearch() {
+        setSearchQuery("")
+    }
+
+    fun showAddDialog() {
+        _uiState.update { it.copy(showAddDialog = true, editWord = "", editCode = "", editIndex = -1) }
+    }
+
+    fun hideAddDialog() {
+        _uiState.update { it.copy(showAddDialog = false) }
+    }
+
+    fun showEditDialog() {
+        _uiState.update { it.copy(showEditDialog = true) }
+    }
+
+    fun hideEditDialog() {
+        _uiState.update { it.copy(showEditDialog = false) }
+    }
+
+    fun setEditing(index: Int, word: String, code: String) {
+        _uiState.update { it.copy(editIndex = index, editWord = word, editCode = code) }
+    }
+
+    fun setEditWord(word: String) {
+        _uiState.update { it.copy(editWord = word) }
+    }
+
+    fun setEditCode(code: String) {
+        _uiState.update { it.copy(editCode = code) }
+    }
+
+    private fun filterEntries(entries: List<DictEntry>, query: String): List<DictEntry> {
+        if (query.isEmpty()) return entries
+        val lowerQuery = query.lowercase(Locale.ROOT)
+        return entries.filter {
+            it.word.contains(query) ||
+                it.code.contains(query, ignoreCase = true) ||
+                it.code.lowercase(Locale.ROOT).contains(lowerQuery)
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.settings.KeysConfigHelper
+import com.kingzcheung.xime.settings.PersonalDictManager
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import com.kingzcheung.xime.settings.SchemaMeta
@@ -146,6 +147,7 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
         viewModelScope.launch {
             _uiState.update { it.copy(isDeploying = true) }
             val success = withContext(Dispatchers.IO) {
+                PersonalDictManager.ensureSchemaPacks(context)
                 KeysConfigHelper.loadConfig(context)
                 KeyboardThemes.reload(context)
                 val engine = RimeEngine.getInstance()

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -199,10 +199,12 @@ public:
         result.inputText = input ? input : "";
         result.preeditText = context.composition.preedit ?
             context.composition.preedit : "";
+        LOGI("readCurrentState: input='%s' num_candidates=%d", result.inputText.c_str(), context.menu.num_candidates);
         if (context.menu.num_candidates > 0) {
             for (int i = 0; i < context.menu.num_candidates; ++i) {
                 const char* text = context.menu.candidates[i].text;
                 const char* comment = context.menu.candidates[i].comment;
+                LOGI("Candidate[%d]: text='%s' comment='%s'", i, text ? text : "", comment ? comment : "");
                 result.candidates.push_back(std::make_pair(
                     text ? text : "",
                     comment ? comment : ""
@@ -256,9 +258,11 @@ public:
             if (context.composition.preedit) {
                 result.preedit = context.composition.preedit;
             }
+            LOGI("getComposition: input='%s' num_candidates=%d", result.input.c_str(), context.menu.num_candidates);
             for (int i = 0; i < context.menu.num_candidates; ++i) {
                 const char* text = context.menu.candidates[i].text;
                 const char* comment = context.menu.candidates[i].comment;
+                LOGI("Candidate[%d]: text='%s' comment='%s'", i, text ? text : "", comment ? comment : "");
                 result.candidates.push_back(std::make_pair(
                     text ? text : "",
                     comment ? comment : ""

--- a/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
@@ -1,0 +1,510 @@
+package com.kingzcheung.xime.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class PersonalDictManagerTest {
+
+    private val defaultHeader = """# Rime dict
+---
+name: user_simp_pinyin
+version: '1.0'
+sort: original
+use_preset_vocabulary: false
+...
+"""
+
+    @Test
+    fun `default header has correct Rime format`() {
+        assertTrue(defaultHeader.startsWith("# Rime dict"))
+        assertTrue(defaultHeader.contains("name: user_simp_pinyin"))
+        assertTrue(defaultHeader.contains("version: '1.0'"))
+        assertTrue(defaultHeader.contains("sort: original"))
+        assertTrue(defaultHeader.contains("use_preset_vocabulary: false"))
+        assertTrue(defaultHeader.endsWith("...\n"))
+    }
+
+    @Test
+    fun `extractHeader returns header before marker`() {
+        val text = """# Rime dict
+---
+name: user_simp
+version: '1.0'
+...
+粗鄙之语	cu bi zhi yu
+"""
+        val file = createTempFile(text)
+        val result = PersonalDictManager.extractHeader(file, defaultHeader)
+        assertTrue(result.startsWith("# Rime dict"))
+        assertTrue(result.endsWith("...\n"))
+        assertEquals("""# Rime dict
+---
+name: user_simp
+version: '1.0'
+...
+""", result)
+    }
+
+    @Test
+    fun `extractHeader returns default for non-existent file`() {
+        val file = File.createTempFile("test_nonexistent", ".tmp")
+        file.delete()
+        val result = PersonalDictManager.extractHeader(file, defaultHeader)
+        assertEquals(defaultHeader, result)
+    }
+
+    @Test
+    fun `extractHeader returns default for file without marker`() {
+        val file = createTempFile("no marker here\njust text\n")
+        val result = PersonalDictManager.extractHeader(file, defaultHeader)
+        assertEquals(defaultHeader, result)
+    }
+
+    @Test
+    fun `extractHeaderFromText handles marker in middle`() {
+        val text = "prefix\n...\nsuffix"
+        val result = PersonalDictManager.extractHeaderFromText(text, defaultHeader)
+        assertEquals("prefix\n...\n", result)
+    }
+
+    @Test
+    fun `extractHeaderFromText handles no preceding newline`() {
+        val text = "...\nsuffix"
+        val result = PersonalDictManager.extractHeaderFromText(text, defaultHeader)
+        assertEquals("...\n", result)
+    }
+
+    @Test
+    fun `extractHeaderFromText returns default when no marker`() {
+        assertEquals(defaultHeader, PersonalDictManager.extractHeaderFromText("no marker", defaultHeader))
+    }
+
+    @Test
+    fun `buildDictText preserves header and formats entries`() {
+        val entries = listOf(
+            DictEntry("测试", "ce shi"),
+            DictEntry("词条", "ci tiao")
+        )
+        val result = PersonalDictManager.buildDictText(defaultHeader, entries)
+        val expected = """# Rime dict
+---
+name: user_simp_pinyin
+version: '1.0'
+sort: original
+use_preset_vocabulary: false
+...
+测试	ce shi
+词条	ci tiao
+"""
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `buildDictText output uses tab delimiter not space`() {
+        val result = PersonalDictManager.buildDictText(defaultHeader, listOf(DictEntry("你好", "ni hao")))
+        assertTrue(result.contains("你好\tni hao"))
+        assertFalse(result.contains("你好 ni hao"))
+    }
+
+    @Test
+    fun `buildDictText ends each entry with newline`() {
+        val result = PersonalDictManager.buildDictText(defaultHeader, listOf(DictEntry("a", "b")))
+        assertTrue(result.endsWith("a\tb\n"))
+    }
+
+    @Test
+    fun `buildDictText handles empty entries`() {
+        val result = PersonalDictManager.buildDictText(defaultHeader, emptyList())
+        assertEquals(defaultHeader, result)
+    }
+
+    @Test
+    fun `round trip preserves entries with multi-word codes`() {
+        val originalEntries = listOf(
+            DictEntry("你好", "ni hao"),
+            DictEntry("世界", "shi jie"),
+            DictEntry("测试", "ce shi")
+        )
+        val text = PersonalDictManager.buildDictText(defaultHeader, originalEntries)
+        val parsedEntries = PersonalDictManager.parsePersonalDictEntries(text)
+        assertEquals(originalEntries.size, parsedEntries.size)
+        assertEquals(originalEntries, parsedEntries)
+    }
+
+    @Test
+    fun `full file round-trip preserves entries`() {
+        val file = File.createTempFile("personal_dict_roundtrip", ".tmp")
+        file.deleteOnExit()
+        val originalEntries = listOf(
+            DictEntry("你好", "ni hao"),
+            DictEntry("世界", "shi jie")
+        )
+        PersonalDictManager.saveEntriesDirect(defaultHeader, originalEntries).let { file.writeText(it, Charsets.UTF_8) }
+        val newHeader = PersonalDictManager.extractHeader(file, defaultHeader)
+        assertEquals(defaultHeader, newHeader)
+        val parsed = PersonalDictManager.parsePersonalDictEntries(file.readText(Charsets.UTF_8))
+        assertEquals(originalEntries, parsed)
+    }
+
+    @Test
+    fun `file created from scratch has correct format`() {
+        val file = File.createTempFile("personal_dict_scratch", ".tmp")
+        file.deleteOnExit()
+        file.delete()
+        val h = PersonalDictManager.extractHeader(file, defaultHeader)
+        assertEquals(defaultHeader, h)
+        val entries = listOf(DictEntry("a", "b"))
+        val text = PersonalDictManager.buildDictText(h, entries)
+        file.writeText(text, Charsets.UTF_8)
+        val content = file.readText(Charsets.UTF_8)
+        assertTrue(content.startsWith("# Rime dict"))
+        assertTrue(content.contains("name: user_simp_pinyin"))
+        assertTrue(content.contains("...\n"))
+        assertTrue(content.contains("a\tb"))
+    }
+
+    @Test
+    fun `parsePersonalDictEntries reads entries after marker tab-delimited`() {
+        val text = "# comment\n---\nname: x\n...\n日\ta\n曰\ta\n郎\tivnl\n"
+        assertEquals(
+            listOf(DictEntry("日", "a"), DictEntry("曰", "a"), DictEntry("郎", "ivnl")),
+            PersonalDictManager.parsePersonalDictEntries(text),
+        )
+    }
+
+    @Test
+    fun `parsePersonalDictEntries preserves spaces in code`() {
+        val text = "...\n你好\tni hao\n世界\tshi jie\n"
+        assertEquals(
+            listOf(DictEntry("你好", "ni hao"), DictEntry("世界", "shi jie")),
+            PersonalDictManager.parsePersonalDictEntries(text),
+        )
+    }
+
+    @Test
+    fun `parsePersonalDictEntries falls back to space delimiter if no tab`() {
+        val text = "...\n你好 ni hao\n世界 shi jie\n"
+        assertEquals(
+            listOf(DictEntry("你好", "ni hao"), DictEntry("世界", "shi jie")),
+            PersonalDictManager.parsePersonalDictEntries(text),
+        )
+    }
+
+    @Test
+    fun `parsePersonalDictEntries ignores comments and blank lines`() {
+        val text = "...\n\n# comment\n测试\tce shi\n"
+        assertEquals(
+            listOf(DictEntry("测试", "ce shi")),
+            PersonalDictManager.parsePersonalDictEntries(text),
+        )
+    }
+
+    @Test
+    fun `parsePersonalDictEntries returns empty for header-only file`() {
+        val text = "name: user_simp\nversion: '1.0'\n...\n"
+        assertTrue(PersonalDictManager.parsePersonalDictEntries(text).isEmpty())
+    }
+
+    @Test
+    fun `parsePersonalDictEntries skips lines before marker`() {
+        val text = "junk\nbefore\n...\nreal\tentry\n"
+        assertEquals(
+            listOf(DictEntry("real", "entry")),
+            PersonalDictManager.parsePersonalDictEntries(text),
+        )
+    }
+
+    @Test
+    fun `round trip with tab-only codes`() {
+        val original = listOf(
+            DictEntry("粗鄙之语", "cu bi zhi yu")
+        )
+        val text = PersonalDictManager.buildDictText(defaultHeader, original)
+        val parsed = PersonalDictManager.parsePersonalDictEntries(text)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `round trip with unicode entries`() {
+        val original = listOf(
+            DictEntry("日本語", "ni hon go"),
+            DictEntry("한국어", "han gu g eo"),
+            DictEntry("😊", "biao qing")
+        )
+        val text = PersonalDictManager.buildDictText(defaultHeader, original)
+        val parsed = PersonalDictManager.parsePersonalDictEntries(text)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `saveEntriesDirect generates correct output`() {
+        val entries = listOf(DictEntry("你好", "ni hao"))
+        val result = PersonalDictManager.saveEntriesDirect(defaultHeader, entries)
+        assertEquals("""# Rime dict
+---
+name: user_simp_pinyin
+version: '1.0'
+sort: original
+use_preset_vocabulary: false
+...
+你好	ni hao
+""", result)
+    }
+
+    @Test
+    fun `buildDictText handles header without data entries`() {
+        val result = PersonalDictManager.buildDictText(defaultHeader, listOf(DictEntry("a", "b")))
+        assertTrue(result.contains("a\tb\n"))
+    }
+
+    @Test
+    fun `multiple saves do not corrupt header`() {
+        val file = File.createTempFile("personal_dict_multi", ".tmp")
+        file.deleteOnExit()
+        val entries1 = listOf(DictEntry("a", "b"))
+        PersonalDictManager.saveEntriesDirect(defaultHeader, entries1).let { file.writeText(it, Charsets.UTF_8) }
+        val h1 = PersonalDictManager.extractHeader(file, defaultHeader)
+        val entries2 = listOf(DictEntry("a", "b"), DictEntry("c", "d"))
+        PersonalDictManager.buildDictText(h1, entries2).let { file.writeText(it, Charsets.UTF_8) }
+        val h2 = PersonalDictManager.extractHeader(file, defaultHeader)
+        assertEquals(defaultHeader, h2)
+        val parsed = PersonalDictManager.parsePersonalDictEntries(file.readText(Charsets.UTF_8))
+        assertEquals(entries2, parsed)
+    }
+
+    @Test
+    fun `output is valid RIME dict format`() {
+        val entries = listOf(DictEntry("测试", "ce shi"))
+        val result = PersonalDictManager.buildDictText(defaultHeader, entries)
+        val lines = result.split('\n')
+        assertTrue(lines.any { it.startsWith("name:") })
+        val dataStart = lines.indexOfFirst { it == "..." }
+        assertTrue(dataStart >= 0)
+        val dataLines = lines.drop(dataStart + 1).filter { it.isNotBlank() && !it.startsWith("#") }
+        assertTrue(dataLines.any { it.contains('\t') })
+    }
+
+    // ── 自定义短语 ──
+
+    private val phraseHeader = """# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
+#
+"""
+
+    @Test
+    fun `parseCustomPhraseText reads entries skipping header`() {
+        val text = """# Rime table
+#
+测试	ce shi
+词条	ci tiao
+"""
+        val result = PersonalDictManager.parseCustomPhraseText(text)
+        assertEquals(
+            listOf(DictEntry("测试", "ce shi"), DictEntry("词条", "ci tiao")),
+            result
+        )
+    }
+
+    @Test
+    fun `parseCustomPhraseText ignores comment lines`() {
+        val text = """# header
+# another comment
+a	b
+"""
+        assertEquals(
+            listOf(DictEntry("a", "b")),
+            PersonalDictManager.parseCustomPhraseText(text)
+        )
+    }
+
+    @Test
+    fun `parseCustomPhraseText returns empty for header-only`() {
+        val text = """# Rime table
+#
+"""
+        assertTrue(PersonalDictManager.parseCustomPhraseText(text).isEmpty())
+    }
+
+    @Test
+    fun `buildCustomPhraseText preserves header and appends entries`() {
+        val entries = listOf(
+            DictEntry("联系一下", "lxyx"),
+            DictEntry("等等", "dd")
+        )
+        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, entries)
+        assertTrue(result.startsWith("# Rime table"))
+        assertTrue(result.contains("联系一下\tlxyx\n"))
+        assertTrue(result.contains("等等\tdd\n"))
+    }
+
+    @Test
+    fun `buildCustomPhraseText handles empty entries`() {
+        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, emptyList())
+        assertEquals(phraseHeader.trimEnd() + "\n", result)
+    }
+
+    @Test
+    fun `custom phrase round trip preserves entries`() {
+        val original = listOf(
+            DictEntry("联系一下", "lxyx"),
+            DictEntry("不知道", "bzd"),
+            DictEntry("kingcheung@gmail.com", "lxyx")
+        )
+        val text = PersonalDictManager.buildCustomPhraseText(phraseHeader, original)
+        val parsed = PersonalDictManager.parseCustomPhraseText(text)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `parseCustomPhraseText reads weight field`() {
+        val text = """#
+a	b	99
+"""
+        val result = PersonalDictManager.parseCustomPhraseText(text)
+        assertEquals(listOf(DictEntry("a", "b", 99)), result)
+    }
+
+    @Test
+    fun `parseCustomPhraseText handles optional weight`() {
+        val text = """#
+a	b	99
+c	d
+"""
+        val result = PersonalDictManager.parseCustomPhraseText(text)
+        assertEquals(listOf(DictEntry("a", "b", 99), DictEntry("c", "d")), result)
+    }
+
+    @Test
+    fun `buildCustomPhraseText includes weight when present`() {
+        val entries = listOf(DictEntry("a", "b", 99))
+        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, entries)
+        assertTrue(result.contains("a\tb\t99\n"))
+    }
+
+    @Test
+    fun `buildCustomPhraseText omits weight when null`() {
+        val entries = listOf(DictEntry("a", "b"))
+        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, entries)
+        assertTrue(result.contains("a\tb\n"))
+    }
+
+    @Test
+    fun `round trip preserves weight`() {
+        val original = listOf(DictEntry("联系一下", "lxyx", 99))
+        val text = PersonalDictManager.buildCustomPhraseText(phraseHeader, original)
+        val parsed = PersonalDictManager.parseCustomPhraseText(text)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `extractCustomPhraseHeader extracts header lines`() {
+        val text = """# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#
+a	b
+"""
+        val file = createTempFile(text)
+        val result = PersonalDictManager.extractCustomPhraseHeader(file)
+        assertTrue(result.startsWith("# Rime table"))
+        assertTrue(result.endsWith("""#
+"""))
+    }
+
+    @Test
+    fun `extractCustomPhraseHeader returns default for non-existent file`() {
+        val file = File.createTempFile("test_nonexistent", ".tmp")
+        file.delete()
+        val result = PersonalDictManager.extractCustomPhraseHeader(file)
+        assertEquals(phraseHeader, result)
+    }
+
+    // ── 方案补丁 ──
+
+    @Test
+    fun `hasSpellerAlgebra returns true when algebra present`() {
+        val schema = """speller:
+  alphabet: abc
+  algebra:
+    - erase/^xx$/
+"""
+        val file = createTempFile(schema)
+        assertTrue(PersonalDictManager.hasSpellerAlgebra(file))
+    }
+
+    @Test
+    fun `hasSpellerAlgebra returns false without algebra`() {
+        val schema = """speller:
+  alphabet: abcdefghijklmnopqrstuvwxyz
+  max_code_length: 4
+"""
+        val file = createTempFile(schema)
+        assertFalse(PersonalDictManager.hasSpellerAlgebra(file))
+    }
+
+    @Test
+    fun `applyPackConfig creates custom yaml with packs for schema WITH algebra`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyPackConfig(rimeDir, "pinyin_simp")
+        val customFile = File(rimeDir, "pinyin_simp.custom.yaml")
+        assertTrue(customFile.exists())
+        val text = customFile.readText(Charsets.UTF_8)
+        assertTrue(text.contains("translator/packs"))
+        assertTrue(text.contains("user_simp_pinyin"))
+    }
+
+    @Test
+    fun `applyPackConfig is idempotent`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyPackConfig(rimeDir, "pinyin_simp")
+        PersonalDictManager.applyPackConfig(rimeDir, "pinyin_simp")
+        val customFile = File(rimeDir, "pinyin_simp.custom.yaml")
+        val text = customFile.readText(Charsets.UTF_8)
+        assertEquals(1, text.split("user_simp_pinyin").size - 1)
+    }
+
+    @Test
+    fun `applyMergedDictConfig creates merged dict and custom for schema WITHOUT algebra`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyMergedDictConfig(rimeDir, "wubi86")
+        val dictFile = File(rimeDir, "wubi86_merged.dict.yaml")
+        assertTrue(dictFile.exists())
+        val dictText = dictFile.readText(Charsets.UTF_8)
+        assertTrue(dictText.contains("import_tables:"))
+        assertTrue(dictText.contains("- wubi86"))
+        assertTrue(dictText.contains("- user_simp_wubi"))
+        val customFile = File(rimeDir, "wubi86.custom.yaml")
+        assertTrue(customFile.exists())
+        val customText = customFile.readText(Charsets.UTF_8)
+        assertTrue(customText.contains("translator/dictionary"))
+        assertTrue(customText.contains("wubi86_merged"))
+    }
+
+    @Test
+    fun `applyMergedDictConfig is idempotent`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyMergedDictConfig(rimeDir, "wubi86")
+        PersonalDictManager.applyMergedDictConfig(rimeDir, "wubi86")
+        val text = File(rimeDir, "wubi86.custom.yaml").readText(Charsets.UTF_8)
+        assertEquals(1, text.split("wubi86_merged").size - 1)
+    }
+
+    private fun createTempFile(content: String): File {
+        val file = File.createTempFile("personal_dict_test", ".tmp")
+        file.writeText(content, Charsets.UTF_8)
+        file.deleteOnExit()
+        return file
+    }
+
+    private fun createTempDir(): File {
+        val dir = File.createTempFile("personal_dict_test_dir", "")
+        dir.delete()
+        dir.mkdirs()
+        return dir
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
@@ -1,10 +1,20 @@
 package com.kingzcheung.xime.settings
 
+import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import java.io.File
+
+private fun mockContext(): Context {
+    val tmpDir = File.createTempFile("mock_context", "").apply { delete(); mkdirs() }
+    return mock {
+        on { filesDir } doReturn tmpDir
+    }
+}
 
 class PersonalDictManagerTest {
 
@@ -142,7 +152,7 @@ use_preset_vocabulary: false
             DictEntry("你好", "ni hao"),
             DictEntry("世界", "shi jie")
         )
-        PersonalDictManager.saveEntriesDirect(defaultHeader, originalEntries).let { file.writeText(it, Charsets.UTF_8) }
+        PersonalDictManager.buildDictText(defaultHeader, originalEntries).let { file.writeText(it, Charsets.UTF_8) }
         val newHeader = PersonalDictManager.extractHeader(file, defaultHeader)
         assertEquals(defaultHeader, newHeader)
         val parsed = PersonalDictManager.parsePersonalDictEntries(file.readText(Charsets.UTF_8))
@@ -240,9 +250,9 @@ use_preset_vocabulary: false
     }
 
     @Test
-    fun `saveEntriesDirect generates correct output`() {
+    fun `buildDictText generates correct output`() {
         val entries = listOf(DictEntry("你好", "ni hao"))
-        val result = PersonalDictManager.saveEntriesDirect(defaultHeader, entries)
+        val result = PersonalDictManager.buildDictText(defaultHeader, entries)
         assertEquals("""# Rime dict
 ---
 name: user_simp_pinyin
@@ -265,7 +275,7 @@ use_preset_vocabulary: false
         val file = File.createTempFile("personal_dict_multi", ".tmp")
         file.deleteOnExit()
         val entries1 = listOf(DictEntry("a", "b"))
-        PersonalDictManager.saveEntriesDirect(defaultHeader, entries1).let { file.writeText(it, Charsets.UTF_8) }
+        PersonalDictManager.buildDictText(defaultHeader, entries1).let { file.writeText(it, Charsets.UTF_8) }
         val h1 = PersonalDictManager.extractHeader(file, defaultHeader)
         val entries2 = listOf(DictEntry("a", "b"), DictEntry("c", "d"))
         PersonalDictManager.buildDictText(h1, entries2).let { file.writeText(it, Charsets.UTF_8) }
@@ -289,7 +299,7 @@ use_preset_vocabulary: false
 
     // ── 自定义短语 ──
 
-    private val phraseHeader = """# Rime table
+    private val stubHeader = """# Rime table
 # coding: utf-8
 #@/db_name	custom_phrase
 #@/db_type	tabledb
@@ -297,13 +307,16 @@ use_preset_vocabulary: false
 """
 
     @Test
-    fun `parseCustomPhraseText reads entries skipping header`() {
+    fun `parseStableDbEntries reads entries skipping header`() {
         val text = """# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
 #
 测试	ce shi
 词条	ci tiao
 """
-        val result = PersonalDictManager.parseCustomPhraseText(text)
+        val result = PersonalDictManager.parseStableDbEntries(text)
         assertEquals(
             listOf(DictEntry("测试", "ce shi"), DictEntry("词条", "ci tiao")),
             result
@@ -311,117 +324,93 @@ use_preset_vocabulary: false
     }
 
     @Test
-    fun `parseCustomPhraseText ignores comment lines`() {
-        val text = """# header
-# another comment
-a	b
+    fun `parseStableDbEntries reads weight field`() {
+        val text = """#
+a	b	99
 """
-        assertEquals(
-            listOf(DictEntry("a", "b")),
-            PersonalDictManager.parseCustomPhraseText(text)
-        )
+        val result = PersonalDictManager.parseStableDbEntries(text)
+        assertEquals(listOf(DictEntry("a", "b", 99)), result)
     }
 
     @Test
-    fun `parseCustomPhraseText returns empty for header-only`() {
-        val text = """# Rime table
-#
+    fun `parseStableDbEntries handles optional weight`() {
+        val text = """#
+a	b	99
+c	d
 """
-        assertTrue(PersonalDictManager.parseCustomPhraseText(text).isEmpty())
+        val result = PersonalDictManager.parseStableDbEntries(text)
+        assertEquals(listOf(DictEntry("a", "b", 99), DictEntry("c", "d")), result)
     }
 
     @Test
-    fun `buildCustomPhraseText preserves header and appends entries`() {
+    fun `buildStableDbText preserves header and appends entries`() {
         val entries = listOf(
             DictEntry("联系一下", "lxyx"),
             DictEntry("等等", "dd")
         )
-        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, entries)
+        val result = PersonalDictManager.buildStableDbText(stubHeader, entries)
         assertTrue(result.startsWith("# Rime table"))
         assertTrue(result.contains("联系一下\tlxyx\n"))
         assertTrue(result.contains("等等\tdd\n"))
     }
 
     @Test
-    fun `buildCustomPhraseText handles empty entries`() {
-        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, emptyList())
-        assertEquals(phraseHeader.trimEnd() + "\n", result)
-    }
-
-    @Test
-    fun `custom phrase round trip preserves entries`() {
-        val original = listOf(
-            DictEntry("联系一下", "lxyx"),
-            DictEntry("不知道", "bzd"),
-            DictEntry("kingcheung@gmail.com", "lxyx")
-        )
-        val text = PersonalDictManager.buildCustomPhraseText(phraseHeader, original)
-        val parsed = PersonalDictManager.parseCustomPhraseText(text)
-        assertEquals(original, parsed)
-    }
-
-    @Test
-    fun `parseCustomPhraseText reads weight field`() {
-        val text = """#
-a	b	99
-"""
-        val result = PersonalDictManager.parseCustomPhraseText(text)
-        assertEquals(listOf(DictEntry("a", "b", 99)), result)
-    }
-
-    @Test
-    fun `parseCustomPhraseText handles optional weight`() {
-        val text = """#
-a	b	99
-c	d
-"""
-        val result = PersonalDictManager.parseCustomPhraseText(text)
-        assertEquals(listOf(DictEntry("a", "b", 99), DictEntry("c", "d")), result)
-    }
-
-    @Test
-    fun `buildCustomPhraseText includes weight when present`() {
+    fun `buildStableDbText includes weight when present`() {
         val entries = listOf(DictEntry("a", "b", 99))
-        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, entries)
+        val result = PersonalDictManager.buildStableDbText(stubHeader, entries)
         assertTrue(result.contains("a\tb\t99\n"))
     }
 
     @Test
-    fun `buildCustomPhraseText omits weight when null`() {
+    fun `buildStableDbText omits weight when null`() {
         val entries = listOf(DictEntry("a", "b"))
-        val result = PersonalDictManager.buildCustomPhraseText(phraseHeader, entries)
+        val result = PersonalDictManager.buildStableDbText(stubHeader, entries)
         assertTrue(result.contains("a\tb\n"))
     }
 
     @Test
-    fun `round trip preserves weight`() {
+    fun `stabledb round trip preserves weight`() {
         val original = listOf(DictEntry("联系一下", "lxyx", 99))
-        val text = PersonalDictManager.buildCustomPhraseText(phraseHeader, original)
-        val parsed = PersonalDictManager.parseCustomPhraseText(text)
+        val text = PersonalDictManager.buildStableDbText(stubHeader, original)
+        val parsed = PersonalDictManager.parseStableDbEntries(text)
         assertEquals(original, parsed)
     }
 
     @Test
-    fun `extractCustomPhraseHeader extracts header lines`() {
-        val text = """# Rime table
-# coding: utf-8
-#@/db_name	custom_phrase
-#
-a	b
-"""
-        val file = createTempFile(text)
-        val result = PersonalDictManager.extractCustomPhraseHeader(file)
-        assertTrue(result.startsWith("# Rime table"))
-        assertTrue(result.endsWith("""#
-"""))
+    fun `loadCustomPhrases when file missing returns empty`() {
+        val context = mockContext()
+        assertTrue(PersonalDictManager.loadCustomPhrases(context).isEmpty())
     }
 
     @Test
-    fun `extractCustomPhraseHeader returns default for non-existent file`() {
-        val file = File.createTempFile("test_nonexistent", ".tmp")
-        file.delete()
-        val result = PersonalDictManager.extractCustomPhraseHeader(file)
-        assertEquals(phraseHeader, result)
+    fun `saveCustomPhrases writes to custom_phrase dot txt`() {
+        val context = mockContext()
+        val entries = listOf(DictEntry("kingzcheung@gmail.com", "yxdz", 99))
+        PersonalDictManager.saveCustomPhrases(context, entries)
+        val file = PersonalDictManager.getCustomPhraseFile(context)
+        assertTrue(file.exists())
+        val loaded = PersonalDictManager.parseStableDbEntries(file.readText(Charsets.UTF_8))
+        assertTrue(loaded.any { it.word == "kingzcheung@gmail.com" })
+    }
+
+    @Test
+    fun `applyCustomPhraseTranslator adds translator to custom yaml`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86")
+        val customFile = File(rimeDir, "wubi86.custom.yaml")
+        assertTrue(customFile.exists())
+        val text = customFile.readText(Charsets.UTF_8)
+        assertTrue(text.contains("table_translator@custom_phrase"))
+        assertTrue(text.contains("db_class: stabledb"))
+    }
+
+    @Test
+    fun `applyCustomPhraseTranslator is idempotent`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86")
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86")
+        val text = File(rimeDir, "wubi86.custom.yaml").readText(Charsets.UTF_8)
+        assertEquals(1, text.split("table_translator@custom_phrase").size - 1)
     }
 
     // ── 方案补丁 ──


### PR DESCRIPTION
- 实现个人词库的增删改查功能
- 添加方案词库浏览器界面
- 支持按方案切换词库管理
- 提供模态框进行词条的添加和编辑操作

refactor(rime): 重构词典配置初始化流程

- 将个人词库文件确保逻辑集成到RimeConfigHelper中
- 在部署和同步过程中确保词库包文件存在
- 统一调用PersonalDictManager的相关方法

feat(ui): 增强词典设置页面UI体验

- 添加底部浮动操作按钮用于新增词条
- 实现双标签页切换（个人词库/方案词库）
- 使用模态底_sheet进行添加/编辑操作
- 优化搜索和列表展示交互

chore(debug): 增加候选词相关日志输出

- 在XimeInputMethodService中添加候选词更新日志
- 在JNI层增加当前状态读取的日志输出
- 便于调试输入法的候选词显示问题

refactor(data): 扩展词典条目数据结构

- 为DictEntry类添加权重字段支持
- 更新相关数据处理逻辑以支持新字段