### PR TITLE
chore(app): 升级应用版本至2.5.0-beta9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 51
-        versionName = "2.5.0-beta8"
+        versionCode = 52
+        versionName = "2.5.0-beta9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
- 将versionCode从51更新为52
- 将versionName从2.5.0-beta8更新为2.5.0-beta9
- 更新项目librime、librime-lua、librime-lua-deps的提交状态标记为dirty