### PR TITLE
fix(handwriting): 添加手写键盘清除功能并优化输入会话启动逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingKeyboardLayout.kt
@@ -83,6 +83,7 @@ fun HandwritingKeyboardLayout(
             dragVersion++
         }
     }
+    LaunchedEffect(clearSignal) { strokes.clear(); dragVersion++ }
 
     suspend fun runPrediction() {
         if (!HandwritingEngine.isInitialized()) return

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -213,15 +213,20 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
                 }
             }
             is KeyboardDispatchAction.InputSessionStarted -> {
-                val kb = initialKeyboardLayoutState(action.isAsciiMode, action.schemaId)
-                val vs = when (kb) {
-                    is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
-                    is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
-                    is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
-                    is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
-                    else -> KeyboardViewState.ChineseFull
+                val currentPage = _page.value
+                if (currentPage is KeyboardPage.Main && currentPage.type == MainType.HANDWRITING) {
+                    Triple(_viewState.value, currentPage, _keyboardState.value)
+                } else {
+                    val kb = initialKeyboardLayoutState(action.isAsciiMode, action.schemaId)
+                    val vs = when (kb) {
+                        is KeyboardLayoutState.Chinese -> KeyboardViewState.ChineseFull
+                        is KeyboardLayoutState.English -> KeyboardViewState.EnglishFull
+                        is KeyboardLayoutState.T9Pinyin -> KeyboardViewState.T9PinyinFull
+                        is KeyboardLayoutState.Stroke -> KeyboardViewState.StrokeFull
+                        else -> KeyboardViewState.ChineseFull
+                    }
+                    Triple(vs, KeyboardPage.Main(MainType.FULL), kb)
                 }
-                Triple(vs, KeyboardPage.Main(MainType.FULL), kb)
             }
             is KeyboardDispatchAction.ShowOverlay -> {
                 Triple(KeyboardViewState.Overlay(action.route, action.backStack, current), KeyboardPage.Overlay(action.route, action.backStack, _page.value), _keyboardState.value)


### PR DESCRIPTION
在HandwritingKeyboardLayout中添加LaunchedEffect监听clearSignal， 实现手势轨迹清除功能；修改KeyboardViewModel中的InputSessionStarted 处理逻辑，保留手写页面状态避免不必要的重置。

fix(handwriting): 修复手写键盘状态管理问题

当输入会话开始时，检查当前页面是否为手写模式，如果是则保
持现有状态而不是强制切换到全键盘布局，确保手写体验的连续性。

chore(deps): 更新子模块依赖状态