### PR TITLE
feat(input): 优化数字键盘计算器功能处理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/calculator/CalculatorKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/calculator/CalculatorKeyRouter.kt
@@ -1,0 +1,50 @@
+package com.kingzcheung.xime.calculator
+
+private val calculatorKeyPattern = Regex("[0-9]")
+private val calculatorKeys = listOf("+", "-", "*", "/", ".")
+
+/**
+ * 计算器模式按键路由的结果。
+ */
+sealed class CalculatorRouteResult {
+    /** 按键已被计算器路由处理，调用者应跳过后续 Rime 管线 */
+    data class Handled(val commitText: String) : CalculatorRouteResult()
+    /** 按键不由计算器路由处理，调用者应按正常流程继续 */
+    data object NotHandled : CalculatorRouteResult()
+}
+
+/**
+ * 计算器模式按键路由 — 决定按键应由计算器引擎处理还是直接提交。
+ *
+ * 返回 [CalculatorRouteResult.Handled] 表示按键已被路由处理，
+ * 调用者应提交 [commitText] 并跳过后续 Rime 管线。
+ * 返回 [CalculatorRouteResult.NotHandled] 表示调用者应按正常流程继续处理。
+ *
+ * 路由规则：
+ * - CommonSymbol 键盘：所有单字符键直接提交，不经过计算器（符号无计算器支持）
+ * - Number 键盘：数字/运算符/小数点先经计算器引擎，再直接提交（不经过 Rime）
+ * - 其他键盘：返回 [NotHandled]
+ */
+fun routeCalculatorKey(
+    key: String,
+    isNumberKeyboard: Boolean,
+    isCommonSymbolKeyboard: Boolean,
+    calculatorEngine: CalculatorEngine,
+): CalculatorRouteResult {
+    if (key.length == 1 && isCommonSymbolKeyboard) {
+        return CalculatorRouteResult.Handled(key)
+    }
+
+    if (isNumberKeyboard) {
+        if (key.matches(calculatorKeyPattern) || key in calculatorKeys) {
+            if (key.matches(calculatorKeyPattern) || key == ".") {
+                calculatorEngine.handleDigit(key)
+            } else {
+                calculatorEngine.handleOperator(key)
+            }
+        }
+        return CalculatorRouteResult.Handled(key)
+    }
+
+    return CalculatorRouteResult.NotHandled
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1995,18 +1995,25 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     }
                 }
                 else -> {
-                    val layoutState = keyboardViewModel.keyboardState.value
-                    if (key.length == 1 && (layoutState is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.Number || layoutState is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.CommonSymbol)) {
-                        withContext(Dispatchers.Main) {
-                            commitText(key)
-                        }
+                    val isNumberKeyboard = keyboardViewModel.keyboardState.value is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.Number
+                    val isCommonSymbolKeyboard = keyboardViewModel.keyboardState.value is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.CommonSymbol
+
+                    val routeResult = com.kingzcheung.xime.calculator.routeCalculatorKey(
+                        key = key,
+                        isNumberKeyboard = isNumberKeyboard,
+                        isCommonSymbolKeyboard = isCommonSymbolKeyboard,
+                        calculatorEngine = calculatorEngine,
+                    )
+                    if (routeResult is com.kingzcheung.xime.calculator.CalculatorRouteResult.Handled) {
+                        withContext(Dispatchers.Main) { commitText(routeResult.commitText) }
+                        if (isNumberKeyboard) updateCalculatorCandidates()
                         needsUIUpdate = true
-                        Log.d(TAG, "Number/Symbol keyboard: committed '$key' directly")
                         return@launch
                     }
+
                     val pendingEnglish = candState.pendingEnglishText
                     
-                    // 非计算器键（如符号键盘的符号、全键盘的字母）清除计算器状态
+                    // 非计算器键清除计算器状态
                     if (!key.matches(Regex("[0-9]")) && key !in listOf("+", "-", "*", "/", ".")) {
                         if (calculatorEngine.isActive() || calculatorEngine.getCandidate() != null) {
                             calculatorEngine.clear()

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
@@ -32,6 +32,10 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Storefront
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.twotone.CloudDownload
+import androidx.compose.material.icons.twotone.Computer
+import androidx.compose.material.icons.twotone.DriveFolderUpload
+import androidx.compose.material.icons.twotone.Storefront
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -322,7 +326,7 @@ fun SchemaSettingsContent(
                                     onNavigateToMarket()
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.Default.Storefront, null,
+                                    Icon(Icons.TwoTone.Storefront, null,
                                         tint = MaterialTheme.colorScheme.primary,
                                         modifier = Modifier.size(20.dp))
                                 }
@@ -338,7 +342,7 @@ fun SchemaSettingsContent(
                                     requireImportWarning { showWirelessSheet = true }
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.Default.Computer, null,
+                                    Icon(Icons.TwoTone.Computer, null,
                                         tint = MaterialTheme.colorScheme.primary,
                                         modifier = Modifier.size(20.dp))
                                 }
@@ -350,7 +354,7 @@ fun SchemaSettingsContent(
                                     requireImportWarning { showUrlDialog = true }
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.Default.CloudDownload, null,
+                                    Icon(Icons.TwoTone.CloudDownload, null,
                                         tint = MaterialTheme.colorScheme.primary,
                                         modifier = Modifier.size(20.dp))
                                 }
@@ -362,7 +366,7 @@ fun SchemaSettingsContent(
                                     requireImportWarning { importLauncher.launch(arrayOf("*/*")) }
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.Default.FolderOpen, null,
+                                    Icon(Icons.TwoTone.DriveFolderUpload, null,
                                         tint = MaterialTheme.colorScheme.primary,
                                         modifier = Modifier.size(20.dp))
                                 }

--- a/app/src/test/java/com/kingzcheung/xime/calculator/CalculatorModeIntegrationTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/calculator/CalculatorModeIntegrationTest.kt
@@ -1,0 +1,122 @@
+package com.kingzcheung.xime.calculator
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * 计算器模式集成测试 — 验证键盘布局与 CalculatorEngine 的交互行为。
+ *
+ * 直接测试生产代码 [routeCalculatorKey] 函数，确保：
+ * - Number 键盘下的数字/运算符先经计算器引擎再直接提交（不绕过计算器）
+ * - CommonSymbol 键盘下的符号直接提交（不经过计算器）
+ * - 全键盘下的计算器键返回 NotHandled（由下游 Rime 管线处理）
+ *
+ * 如果将来有人修改 [XimeInputMethodService.handleKeyPress] 中的计算器路由逻辑，
+ * 必须同步修改 [routeCalculatorKey]，这组测试会立即暴露不匹配行为。
+ */
+class CalculatorModeIntegrationTest {
+
+    @Test
+    fun `Number键盘_数字触发计算器并提交`() {
+        val engine = CalculatorEngine()
+
+        val result = routeCalculatorKey(
+            key = "5",
+            isNumberKeyboard = true,
+            isCommonSymbolKeyboard = false,
+            calculatorEngine = engine,
+        )
+
+        assertTrue("Number keyboard key should be handled", result is CalculatorRouteResult.Handled)
+        assertEquals("5", (result as CalculatorRouteResult.Handled).commitText)
+        assertNull("Only digit entered, calculator should not be active", engine.getCandidate())
+    }
+
+    @Test
+    fun `Number键盘_数字加运算符进入计算器模式`() {
+        val engine = CalculatorEngine()
+
+        routeCalculatorKey("1", true, false, engine)
+        routeCalculatorKey("+", true, false, engine)
+        routeCalculatorKey("2", true, false, engine)
+
+        assertTrue(engine.isActive())
+        assertEquals("1+2 = 3", engine.getCandidate())
+    }
+
+    @Test
+    fun `Number键盘_链式计算`() {
+        val engine = CalculatorEngine()
+
+        routeCalculatorKey("4", true, false, engine)
+        routeCalculatorKey("*", true, false, engine)
+        routeCalculatorKey("5", true, false, engine)
+        routeCalculatorKey("+", true, false, engine)
+        routeCalculatorKey("2", true, false, engine)
+
+        assertTrue(engine.isActive())
+        assertEquals("4*5+2 = 22", engine.getCandidate())
+    }
+
+    @Test
+    fun `Number键盘_小数计算`() {
+        val engine = CalculatorEngine()
+
+        routeCalculatorKey("0", true, false, engine)
+        routeCalculatorKey(".", true, false, engine)
+        routeCalculatorKey("1", true, false, engine)
+        routeCalculatorKey("+", true, false, engine)
+        routeCalculatorKey("0", true, false, engine)
+        routeCalculatorKey(".", true, false, engine)
+        routeCalculatorKey("2", true, false, engine)
+
+        assertTrue(engine.isActive())
+        assertEquals("0.1+0.2 = 0.3", engine.getCandidate())
+    }
+
+    @Test
+    fun `CommonSymbol键盘_直接提交不经过计算器`() {
+        val engine = CalculatorEngine()
+
+        val result = routeCalculatorKey(
+            key = "@",
+            isNumberKeyboard = false,
+            isCommonSymbolKeyboard = true,
+            calculatorEngine = engine,
+        )
+
+        assertTrue("CommonSymbol key should be handled", result is CalculatorRouteResult.Handled)
+        assertEquals("@", (result as CalculatorRouteResult.Handled).commitText)
+        assertNull("Calculator engine should not be affected", engine.getCandidate())
+        assertFalse(engine.isActive())
+    }
+
+    @Test
+    fun `CommonSymbol键盘_多个符号直接提交`() {
+        val engine = CalculatorEngine()
+
+        for (sym in listOf("#", "\$", "%", "&", "?")) {
+            val result = routeCalculatorKey(sym, false, true, engine)
+            assertTrue("Symbol $sym should be handled", result is CalculatorRouteResult.Handled)
+            assertEquals(sym, (result as CalculatorRouteResult.Handled).commitText)
+        }
+
+        assertNull(engine.getCandidate())
+        assertFalse(engine.isActive())
+    }
+
+    @Test
+    fun `全键盘_计算器键返回NotHandled交下游管线`() {
+        val engine = CalculatorEngine()
+
+        val result = routeCalculatorKey(
+            key = "5",
+            isNumberKeyboard = false,
+            isCommonSymbolKeyboard = false,
+            calculatorEngine = engine,
+        )
+
+        assertTrue("Full keyboard key should NOT be handled", result is CalculatorRouteResult.NotHandled)
+        assertNull("Calculator engine should not be touched", engine.getCandidate())
+    }
+}


### PR DESCRIPTION
- 将数字键盘和符号键盘的计算器键处理逻辑抽取到独立的路由函数中
- 使用CalculatorRouteResult来统一处理计算器结果返回
- 保留对数字键盘的特殊更新逻辑以支持实时计算预览

style(settings): 统一设置界面图标样式为TwoTone主题

- 将商店、电脑、云下载等图标的样式从Default改为TwoTone
- 保持原有的颜色和尺寸配置不变
- 提升界面视觉一致性

chore(deps): 更新子项目依赖状态标记

- 标记librime、librime-lua和librime-lua-deps为dirty状态
- 反映本地修改但未提交的依赖项变更