### PR TITLE
feat(keyboard): 增加滑动按键文本显示长度限制

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -275,7 +275,7 @@ fun KeyButton(
         )
         
         if (!swipeText.isNullOrEmpty()) {
-            val displayText = if (swipeText.length <= 2) swipeText else swipeText.take(2)
+            val displayText = if (swipeText.length <= 4) swipeText else swipeText.take(4)
             Text(
                 text = displayText,
                 color = textColor.copy(alpha = 0.5f),
@@ -591,7 +591,7 @@ fun SwipeableKeyButton(
         
         if (!(swipeUpKeyLabel ?: swipeText).isNullOrEmpty()) {
             val keyLabel = (swipeUpKeyLabel ?: swipeText)!!
-            val displayText = if (keyLabel.length <= 2) keyLabel else keyLabel.take(2)
+            val displayText = if (keyLabel.length <= 4) keyLabel else keyLabel.take(4)
             Text(
                 text = displayText,
                 color = textColor.copy(alpha = 0.6f),
@@ -604,7 +604,7 @@ fun SwipeableKeyButton(
         }
         
         if (!swipeDownKeyLabel.isNullOrEmpty()) {
-            val displayText = if (swipeDownKeyLabel.length <= 2) swipeDownKeyLabel else swipeDownKeyLabel.take(2)
+            val displayText = if (swipeDownKeyLabel.length <= 4) swipeDownKeyLabel else swipeDownKeyLabel.take(4)
             Text(
                 text = displayText,
                 color = textColor.copy(alpha = 0.5f),


### PR DESCRIPTION
将滑动按键的文本显示长度从2个字符增加到4个字符，
以提供更好的用户体验和更完整的文本展示。

同时更新了相关子项目依赖的提交记录。