### PR TITLE
fix(keyboard): 修复ASCII模式切换时覆盖层状态处理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -196,7 +196,9 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
                 Triple(KeyboardViewState.Handwriting, KeyboardPage.Main(MainType.HANDWRITING), KeyboardLayoutState.Chinese)
             }
             is KeyboardDispatchAction.AsciiModeChanged -> {
-                if (current is KeyboardViewState.NumberPanel || current is KeyboardViewState.CommonSymbolPanel) {
+                if (current is KeyboardViewState.Overlay) {
+                    Triple(current, _page.value, _keyboardState.value)
+                } else if (current is KeyboardViewState.NumberPanel || current is KeyboardViewState.CommonSymbolPanel) {
                     Triple(current, _page.value, _keyboardState.value)
                 } else if (!action.isAsciiMode && action.schemaId == "handwriting") {
                     Triple(KeyboardViewState.Handwriting, KeyboardPage.Main(MainType.HANDWRITING), KeyboardLayoutState.Chinese)


### PR DESCRIPTION
当键盘处于覆盖层状态时，ASCII模式切换不应重置当前视图状态，
保持原有的覆盖层、页面和键盘布局状态不变，避免用户输入中断。