### PR TITLE
feat(keyboard): 添加按键圆角半径配置功能

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -101,14 +101,17 @@ keyboard:
     candidate_text_color: 0x202124
     candidate_text_color_dark: 0xE8EAED
   
-  # ── 按键阴影配置（可选，不设置则使用默认值）──
-  # enabled:            是否启用阴影（true/false）
+  # ── 按键配置（可选，不设置则使用默认值）──
+  # corner_radius:      按键圆角半径（dp，默认 8），独立于 shadow.shape_radius
+  key:
+    corner_radius: 8
+
+  # ── 按键阴影（可选，不设置则使用默认值）──
+  # enabled:            是否启用阴影
   # elevation:          阴影高度（dp，默认 1）
-  # shape_radius:       阴影圆角半径（dp，默认 8）
   shadow:
     enabled: true
     elevation: 1
-    shape_radius: 8
   qwerty:
     # ── 按键布局模式 ──
     # standard: 默认布局（主文字居中，下滑提示在底部）

--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -77,6 +77,13 @@ data class KeyboardShadowConfig(
 )
 
 /**
+ * 键盘按键配置，从 xime.yaml keyboard.key 加载。
+ */
+data class KeyboardKeyConfig(
+    val cornerRadius: Int = 8,
+)
+
+/**
  * 键盘颜色配置，从 xime.yaml keyboard.colors 加载。
  * 所有颜色值为 0xRRGGBB 格式（不含 alpha）。
  */
@@ -294,6 +301,9 @@ object KeysConfigHelper {
     
     // 键盘阴影配置缓存
     private var keyboardShadowConfig: KeyboardShadowConfig = KeyboardShadowConfig()
+
+    // 键盘按键配置缓存
+    private var keyboardKeyConfig: KeyboardKeyConfig = KeyboardKeyConfig()
     
     // 按键布局模式缓存（中文 qwerty / 英文 qwerty_en）
     private var _buttonLayoutZh: ButtonLayout = ButtonLayout.STANDARD
@@ -327,6 +337,8 @@ object KeysConfigHelper {
             keyboardColorsConfig = parseKeyboardColorsFromAssets(context)
             // 键盘阴影（从原始 YAML 手动解析）
             keyboardShadowConfig = parseKeyboardShadowFromAssets(context)
+            // 键盘按键（从原始 YAML 手动解析）
+            keyboardKeyConfig = parseKeyboardKeyFromAssets(context)
             // 按键布局（从原始 YAML 手动解析，中英文分开）
             val parsedLayouts = parseButtonLayoutFromAssets(context)
             _buttonLayoutZh = parsedLayouts.first
@@ -499,6 +511,50 @@ object KeysConfigHelper {
         return KeyboardShadowConfig(enabled = enabled, elevation = elevation, shapeRadius = shapeRadius)
     }
 
+    /** 从 xime.yaml + xime.custom.yaml 合并解析键盘按键配置。 */
+    private fun parseKeyboardKeyFromAssets(context: Context): KeyboardKeyConfig {
+        val defaultText = readAssetText(context, XIME_CONFIG_FILE) ?: return KeyboardKeyConfig()
+        val default = parseKeyboardKeyYamlText(defaultText) ?: return KeyboardKeyConfig()
+        val custom = readUserDataText(context, XIME_CUSTOM_CONFIG_FILE)
+            ?.let { parseKeyboardKeyYamlText(it) }
+            ?: readAssetText(context, XIME_CUSTOM_CONFIG_FILE)
+                ?.let { parseKeyboardKeyYamlText(it) }
+        return custom ?: default
+    }
+
+    /** 从 YAML 文本中提取 keyboard.key 段。
+     *  兼容旧版：若 key.corner_radius 未设置，回退读取 shadow.shape_radius。 */
+    private fun parseKeyboardKeyYamlText(yamlText: String): KeyboardKeyConfig? {
+        val root = yaml.parseToYamlNode(yamlText) as? YamlMap ?: return null
+        val keyboardNode = root["keyboard"] as? YamlMap ?: return null
+        var cornerRadius = 8
+        // 优先读取 key.corner_radius
+        val keyNode = keyboardNode["key"] as? YamlMap
+        if (keyNode != null) {
+            for ((kNode, vNode) in keyNode.entries) {
+                val key = (kNode as? YamlScalar)?.content ?: continue
+                val value = (vNode as? YamlScalar)?.content ?: continue
+                if (key == "corner_radius") {
+                    cornerRadius = value.toIntOrNull() ?: 8
+                }
+            }
+        }
+        // 未设置 key.corner_radius 时，回退读取 shadow.shape_radius
+        if (cornerRadius == 8) {
+            val shadowNode = keyboardNode["shadow"] as? YamlMap
+            if (shadowNode != null) {
+                for ((kNode, vNode) in shadowNode.entries) {
+                    val key = (kNode as? YamlScalar)?.content ?: continue
+                    val value = (vNode as? YamlScalar)?.content ?: continue
+                    if (key == "shape_radius") {
+                        cornerRadius = value.toIntOrNull() ?: 8
+                    }
+                }
+            }
+        }
+        return KeyboardKeyConfig(cornerRadius = cornerRadius)
+    }
+
     /** 从 xime.yaml + xime.custom.yaml 合并解析按键布局模式（中英文分开）。 */
     private fun parseButtonLayoutFromAssets(context: Context): Pair<ButtonLayout, ButtonLayout> {
         val defaultText = readAssetText(context, XIME_CONFIG_FILE) ?: return Pair(ButtonLayout.STANDARD, ButtonLayout.STANDARD)
@@ -634,6 +690,9 @@ object KeysConfigHelper {
 
     /** 获取键盘阴影配置（从 xime.yaml keyboard.shadow 加载）。 */
     fun getKeyboardShadow(): KeyboardShadowConfig = keyboardShadowConfig
+
+    /** 获取键盘按键配置（从 xime.yaml keyboard.key 加载）。 */
+    fun getKeyboardKeyConfig(): KeyboardKeyConfig = keyboardKeyConfig
 
     /** 获取某个按键的手势配置。 */
     fun getKeyGesture(key: String): KeyGestureConfig? = keyGestureConfig[key.lowercase()]

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
@@ -42,6 +42,7 @@ fun CommonSymbolKeyboardLayout(
     shadowEnabled: Boolean = true,
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
+    keyCornerRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
@@ -87,6 +88,7 @@ fun CommonSymbolKeyboardLayout(
         keyboardWidth = keyboardBounds.width,
     )
 
+    CompositionLocalProvider(LocalKeyCornerRadius provides keyCornerRadius) {
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -307,6 +309,7 @@ fun CommonSymbolKeyboardLayout(
             }
             }
         }
+    }
     }
 }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -62,6 +62,10 @@ val LocalKeyVisualPadding = staticCompositionLocalOf {
     PaddingValues(horizontal = 2.dp, vertical = 4.25.dp)
 }
 
+/** 按键圆角半径，由各布局在根层通过 CompositionLocalProvider 提供。
+ *  独立于 shadow.shape_radius，为统一配置化而设。 */
+val LocalKeyCornerRadius = staticCompositionLocalOf { 8.dp }
+
 data class SwipeState(
     val isSwiping: Boolean = false,
     val swipeText: String? = null,
@@ -121,9 +125,10 @@ fun KeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
     
     // 辅助函数：生成更深的颜色（混合黑色）
@@ -259,7 +264,7 @@ fun KeyButton(
                 }
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(keyClipShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)
@@ -367,9 +372,10 @@ fun SwipeableKeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
     val context = LocalContext.current
     val chaiPuaFontFamily = remember { FontFamily(Font("ChaiPUA-0.2.7-snow.ttf", context.assets)) }
@@ -577,7 +583,7 @@ fun SwipeableKeyButton(
             }
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(keyClipShape)
             .background(
                 if (isPressed) backgroundColor.copy(alpha = 0.7f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)
@@ -765,6 +771,8 @@ fun IconKeyButton(
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
         if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
     }
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
     
     // 辅助函数：生成更深的颜色（混合黑色）
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -796,7 +804,7 @@ fun IconKeyButton(
             }
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(keyClipShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.1f)
                 else if (isHighlighted) darkenColor(backgroundColor, 0.2f)
@@ -890,9 +898,10 @@ fun SwipeableIconKeyButton(
         }
     }
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
     
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -1061,7 +1070,7 @@ fun SwipeableIconKeyButton(
             }
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(keyClipShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else if (isHighlighted) backgroundColor.copy(alpha = 0.8f)

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -127,6 +127,7 @@ fun KeyboardLayout(
     val specialKeyBackgroundColor = if (uiState.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
+    val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
     val shadowEnabled = kbShadow.enabled
     val shadowElevation = kbShadow.elevation.dp
     val shadowShapeRadius = kbShadow.shapeRadius.dp
@@ -233,6 +234,7 @@ fun KeyboardLayout(
 
     val isLandscape = !uiState.isFloatingMode && LocalConfiguration.current.screenWidthDp > LocalConfiguration.current.screenHeightDp
 
+    CompositionLocalProvider(LocalKeyCornerRadius provides kbKey.cornerRadius.dp) {
     Box(
         modifier = modifier
             .background(keyboardBackgroundColor)
@@ -831,6 +833,7 @@ fun KeyboardLayout(
         }
     }
 
+    }
 }
 
 @Composable
@@ -896,7 +899,7 @@ private fun DummyKeyButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(backgroundColor)
     )
 }
@@ -1031,9 +1034,10 @@ private fun ShiftCapsKeyButton(
 ) {
     var isPressed by remember { mutableStateOf(false) }
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
 
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -1071,7 +1075,7 @@ private fun ShiftCapsKeyButton(
                 }
             }
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.1f)
                 else if (shiftMode == ShiftMode.CAPS) darkenColor(backgroundColor, 0.2f)
@@ -1155,6 +1159,7 @@ private fun LandscapeKeyboardContent(
     val specialKeyBackgroundColor = if (uiState.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
+    val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
     val shadowEnabled = kbShadow.enabled
     val shadowElevation = kbShadow.elevation.dp
     val shadowShapeRadius = kbShadow.shapeRadius.dp
@@ -1629,9 +1634,10 @@ fun SwipeableKeyButtonLandscape(
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
     val bubbleShowThresholdDown = swipeDownThreshold * 0.3f
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
 
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -1843,7 +1849,7 @@ fun SwipeableKeyButtonLandscape(
             }
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(if (isPressed) darkenColor(backgroundColor) else backgroundColor),
         contentAlignment = Alignment.TopStart
     ) {
@@ -2022,9 +2028,10 @@ private fun SplitSpaceKey(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
 ) {
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
 
     Box(
@@ -2032,7 +2039,7 @@ private fun SplitSpaceKey(
             .fillMaxHeight()
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,
@@ -2089,8 +2096,9 @@ private fun SpaceKey(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyCornerRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(keyCornerRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
         else Modifier
     }
 
@@ -2135,7 +2143,7 @@ private fun SpaceKey(
             .fillMaxWidth()
             .fillMaxHeight()
             .then(shadowModifier)
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(keyBackgroundColor),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
@@ -37,6 +37,7 @@ fun KeyboardLayoutScreen(
     val specialKeyBgColor = if (uiState.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
+    val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
 
     val onGestureAction: (GestureAction, String) -> Unit = { action, value ->
         when (action) {
@@ -125,6 +126,7 @@ fun KeyboardLayoutScreen(
                 shadowEnabled = kbShadow.enabled,
                 shadowElevation = kbShadow.elevation.dp,
                 shadowShapeRadius = kbShadow.shapeRadius.dp,
+                keyCornerRadius = kbKey.cornerRadius.dp,
                 modifier = modifier,
                 onKeyPressDown = callbacks.onKeyPressDown,
                 isFloatingMode = uiState.isFloatingMode,
@@ -142,6 +144,7 @@ fun KeyboardLayoutScreen(
                 shadowEnabled = kbShadow.enabled,
                 shadowElevation = kbShadow.elevation.dp,
                 shadowShapeRadius = kbShadow.shapeRadius.dp,
+                keyCornerRadius = kbKey.cornerRadius.dp,
                 modifier = modifier,
                 onKeyPressDown = callbacks.onKeyPressDown,
                 isFloatingMode = uiState.isFloatingMode,
@@ -158,6 +161,7 @@ fun KeyboardLayoutScreen(
                 shadowEnabled = kbShadow.enabled,
                 shadowElevation = kbShadow.elevation.dp,
                 shadowShapeRadius = kbShadow.shapeRadius.dp,
+                keyCornerRadius = kbKey.cornerRadius.dp,
                 modifier = modifier,
                 onKeyPressDown = callbacks.onKeyPressDown,
                 isFloatingMode = uiState.isFloatingMode,
@@ -178,6 +182,7 @@ fun KeyboardLayoutScreen(
                     shadowEnabled = kbShadow.enabled,
                     shadowElevation = kbShadow.elevation.dp,
                     shadowShapeRadius = kbShadow.shapeRadius.dp,
+                    keyCornerRadius = kbKey.cornerRadius.dp,
                     modifier = modifier,
                     onKeyPressDown = callbacks.onKeyPressDown,
                     isFloatingMode = uiState.isFloatingMode,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -127,6 +127,7 @@ fun KeyboardView(
 
     val kbColors = KeysConfigHelper.getKeyboardColors()
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
+    val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
     val longToColor: (Long) -> androidx.compose.ui.graphics.Color = { androidx.compose.ui.graphics.Color(0xFF000000 or it) }
     val keyboardBgColor = if (state.isDarkTheme) longToColor(kbColors.keyboardBgColorDark)
         else longToColor(kbColors.keyboardBgColor)
@@ -639,6 +640,7 @@ fun KeyboardView(
                         shadowEnabled = kbShadow.enabled,
                         shadowElevation = kbShadow.elevation.dp,
                         shadowShapeRadius = kbShadow.shapeRadius.dp,
+                        keyCornerRadius = kbKey.cornerRadius.dp,
                         onKeyPressDown = callbacks.onKeyPressDown,
                         isFloatingMode = state.isFloatingMode,
                         modifier = Modifier.weight(1f).fillMaxWidth()
@@ -662,6 +664,7 @@ fun KeyboardView(
                         shadowEnabled = kbShadow.enabled,
                         shadowElevation = kbShadow.elevation.dp,
                         shadowShapeRadius = kbShadow.shapeRadius.dp,
+                        keyCornerRadius = kbKey.cornerRadius.dp,
                         onKeyPressDown = callbacks.onKeyPressDown,
                         isFloatingMode = state.isFloatingMode,
                         modifier = Modifier.weight(1f).fillMaxWidth()

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -59,6 +59,7 @@ fun NumberKeyboardLayout(
     shadowEnabled: Boolean = true,
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
+    keyCornerRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
@@ -86,6 +87,7 @@ fun NumberKeyboardLayout(
         keyboardWidth = keyboardBounds.width
     )
 
+    CompositionLocalProvider(LocalKeyCornerRadius provides keyCornerRadius) {
     Box(
         modifier = modifier
             .background(keyboardBackgroundColor)
@@ -214,6 +216,7 @@ fun NumberKeyboardLayout(
             }
         }
 
+    }
     }
 }
 
@@ -504,11 +507,12 @@ private fun NumberSymbolKey(
     var isPressed by remember { mutableStateOf(false) }
     val currentOnClick by rememberUpdatedState(onClick)
     val currentOnPress by rememberUpdatedState(onPress)
+    val cornerRadius = LocalKeyCornerRadius.current
     val shape = RoundedCornerShape(
-        topStart = if (isFirst) 8.dp else 0.dp,
-        topEnd = if (isFirst) 8.dp else 0.dp,
-        bottomStart = if (isLast) 8.dp else 0.dp,
-        bottomEnd = if (isLast) 8.dp else 0.dp
+        topStart = if (isFirst) cornerRadius else 0.dp,
+        topEnd = if (isFirst) cornerRadius else 0.dp,
+        bottomStart = if (isLast) cornerRadius else 0.dp,
+        bottomEnd = if (isLast) cornerRadius else 0.dp
     )
     Box(
         modifier = modifier

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
@@ -55,10 +55,10 @@ fun SpaceKeyButton(
         modifier = modifier
             .height((44 * LocalStretchFactor.current).dp)
             .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(LocalKeyCornerRadius.current), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
                 else Modifier
             )
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(
                 if (isPressed) backgroundColor.copy(alpha = 0.7f)
                 else backgroundColor

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.automirrored.filled.Backspace
 import androidx.compose.material.icons.filled.EmojiEmotions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -62,6 +63,7 @@ fun StrokeKeyboardLayout(
     shadowEnabled: Boolean = true,
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
+    keyCornerRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
@@ -89,6 +91,7 @@ fun StrokeKeyboardLayout(
         keyboardWidth = keyboardBounds.width
     )
 
+    CompositionLocalProvider(LocalKeyCornerRadius provides keyCornerRadius) {
     Box(
         modifier = modifier
             .background(keyboardBackgroundColor)
@@ -199,6 +202,7 @@ fun StrokeKeyboardLayout(
             }
         }
     }
+    }
 }
 
 private data class StrokeKeyDef(
@@ -261,7 +265,7 @@ private fun StrokeRows(
                             modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke(symbol) },
                             isFirst = index == 0,
-                            isLast = index == symbols.lastIndex
+                            isLast = index == symbols.lastIndex,
                         )
                     }
                 }
@@ -497,16 +501,17 @@ private fun StrokeSymbolKey(
     modifier: Modifier = Modifier,
     onPress: (() -> Unit)? = null,
     isFirst: Boolean = false,
-    isLast: Boolean = false
+    isLast: Boolean = false,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     val currentOnClick by rememberUpdatedState(onClick)
     val currentOnPress by rememberUpdatedState(onPress)
+    val cornerRadius = LocalKeyCornerRadius.current
     val shape = RoundedCornerShape(
-        topStart = if (isFirst) 8.dp else 0.dp,
-        topEnd = if (isFirst) 8.dp else 0.dp,
-        bottomStart = if (isLast) 8.dp else 0.dp,
-        bottomEnd = if (isLast) 8.dp else 0.dp
+        topStart = if (isFirst) cornerRadius else 0.dp,
+        topEnd = if (isFirst) cornerRadius else 0.dp,
+        bottomStart = if (isLast) cornerRadius else 0.dp,
+        bottomEnd = if (isLast) cornerRadius else 0.dp
     )
     Box(
         modifier = modifier
@@ -553,9 +558,10 @@ private fun StrokeKeyButton(
     val density = LocalDensity.current
     val swipeUpThreshold = with(density) { (-40).dp.toPx() }
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    val keyCornerRadius = LocalKeyCornerRadius.current
+    val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
     }
 
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -612,7 +618,7 @@ private fun StrokeKeyButton(
             }
             .padding(horizontal = 2.dp, vertical = 2.dp)
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(keyClipShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.2f)
                 else backgroundColor

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -93,6 +93,7 @@ fun T9KeyboardLayout(
     shadowEnabled: Boolean = true,
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
+    keyCornerRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
@@ -149,6 +150,7 @@ fun T9KeyboardLayout(
         keyboardWidth = keyboardBounds.width
     )
 
+    CompositionLocalProvider(LocalKeyCornerRadius provides keyCornerRadius) {
     Box(
         modifier = modifier
             .background(keyboardBackgroundColor)
@@ -245,6 +247,7 @@ fun T9KeyboardLayout(
             }
         }
     }
+    }
 }
 
 // ─── 横屏候选面板 — 包装组件 ────────────────────────────────────────
@@ -265,10 +268,10 @@ private fun T9LandscapeCandidatePanel(
             .fillMaxSize()
             .then(
                 if (shadowEnabled) {
-                    Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius))
+                    Modifier.shadow(shadowElevation, RoundedCornerShape(LocalKeyCornerRadius.current))
                 } else Modifier
             )
-            .clip(RoundedCornerShape(shadowShapeRadius))
+            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(keyBackgroundColor)
     ) {
         val rimeCandidates = uiState.candidates
@@ -404,7 +407,7 @@ private fun T9KeyboardContent(
                             Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius))
                         } else Modifier
                     )
-                    .clip(RoundedCornerShape(shadowShapeRadius))
+                    .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
                     .background(keyBackgroundColor)
             ) {
                 val showCandidates = controller.firstOptions.isNotEmpty()

--- a/docs/config_examples/xime.flypy.yaml
+++ b/docs/config_examples/xime.flypy.yaml
@@ -102,14 +102,17 @@ keyboard:
     candidate_text_color: 0x202124
     candidate_text_color_dark: 0xE8EAED
   
-  # ── 按键阴影配置（可选，不设置则使用默认值）──
-  # enabled:            是否启用阴影（true/false）
+  # ── 按键配置（可选，不设置则使用默认值）──
+  # corner_radius:      按键圆角半径（dp，默认 8）
+  key:
+    corner_radius: 8
+
+  # ── 按键阴影（可选，不设置则使用默认值）──
+  # enabled:            是否启用阴影
   # elevation:          阴影高度（dp，默认 1）
-  # shape_radius:       阴影圆角半径（dp，默认 8）
   shadow:
     enabled: true
     elevation: 1
-    shape_radius: 8
   qwerty:
     button_layout: compact
     keys:

--- a/docs/config_examples/xime.full_example.yaml
+++ b/docs/config_examples/xime.full_example.yaml
@@ -97,11 +97,17 @@ keyboard:
     candidate_text_color: 0x202124
     candidate_text_color_dark: 0xE8EAED
 
-  # ── 按键阴影配置（可选，不设置则使用默认值）──
+  # ── 按键配置（可选，不设置则使用默认值）──
+  # corner_radius:      按键圆角半径（dp，默认 8）
+  key:
+    corner_radius: 8
+
+  # ── 按键阴影（可选，不设置则使用默认值）──
+  # enabled:            是否启用阴影
+  # elevation:          阴影高度（dp，默认 1）
   shadow:
     enabled: true
     elevation: 1
-    shape_radius: 8
 
   # ── 中文键盘 ──
   qwerty:

--- a/docs/config_examples/xime.wubi_compact.yaml
+++ b/docs/config_examples/xime.wubi_compact.yaml
@@ -101,14 +101,17 @@ keyboard:
     candidate_text_color: 0x202124
     candidate_text_color_dark: 0xE8EAED
   
-  # ── 按键阴影配置（可选，不设置则使用默认值）──
-  # enabled:            是否启用阴影（true/false）
+  # ── 按键配置（可选，不设置则使用默认值）──
+  # corner_radius:      按键圆角半径（dp，默认 8）
+  key:
+    corner_radius: 8
+
+  # ── 按键阴影（可选，不设置则使用默认值）──
+  # enabled:            是否启用阴影
   # elevation:          阴影高度（dp，默认 1）
-  # shape_radius:       阴影圆角半径（dp，默认 8）
   shadow:
     enabled: true
     elevation: 1
-    shape_radius: 8
   qwerty:
     button_layout: compact
     keys:


### PR DESCRIPTION
- 在 xime.yaml 中新增 keyboard.key 配置项，支持自定义按键圆角半径
- 新增 KeyboardKeyConfig 数据类处理按键配置
- 实现配置解析逻辑，支持从 xime.yaml 和 xime.custom.yaml 读取配置
- 添加向下兼容逻辑，未设置 corner_radius 时回退到 shadow.shape_radius
- 使用 CompositionLocalProvider 统一管理各键盘布局的圆角半径
- 更新所有按键组件使用新的圆角半径配置替代阴影形状半径