### PR TITLE
feat(keyboard): 添加图标支持并重命名中英切换键

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -155,8 +155,8 @@ keyboard:
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } , long_press: { display: "bubble", values: [ ",","."] }}
       # 中/英切换键，label 为按键显示文字
-      shift_l: { tap: { label: "英", action: "toggle_ascii" } }
-   
+      earth: { tap: { label: "@language", action: "toggle_ascii" }, long_press: { display: "bubble", values: [ { label: "选择输入法", action: "command", value: "show_ime_picker" } ] } }
+    
   # 英文键盘布局
   qwerty_en:
     # ── 按键布局模式 ──
@@ -197,4 +197,4 @@ keyboard:
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: ",", value: "," }, swipe_up: { label: ".", value: "." } }
       # 中/英切换键，label 为按键显示文字
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "@language", action: "toggle_ascii" }, long_press: { display: "bubble", values: [ { label: "选择输入法", action: "command", value: "show_ime_picker" } ] } }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -11,6 +11,7 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.CursorAnchorInfo
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
 import android.widget.FrameLayout
@@ -1162,6 +1163,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         updateUI()
                     }
                 }
+            }
+            "show_ime_picker" -> {
+                val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                @Suppress("DEPRECATION")
+                imm.showInputMethodPicker()
             }
             else -> Log.w(TAG, "Unknown command: $name")
         }

--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -48,6 +48,7 @@ data class GestureDef(
     val labels: List<String> = emptyList(),
     val action: GestureAction? = GestureAction.COMMIT,
     val value: String = "",
+    val icon: String = "",
     val display: DisplayMode = DisplayMode.BOTH,
 )
 
@@ -169,7 +170,9 @@ private fun parseGestureNode(node: com.charleskorn.kaml.YamlNode): GestureDef {
     // 字符串 → commit
     if (node is com.charleskorn.kaml.YamlScalar) {
         val text = node.content
-        return GestureDef(label = text, action = GestureAction.COMMIT, value = text)
+        val icon = if (text.startsWith("@")) text.removePrefix("@") else ""
+        val cleanLabel = if (icon.isNotEmpty()) "" else text
+        return GestureDef(label = cleanLabel, action = GestureAction.COMMIT, value = text, icon = icon)
     }
     // 映射 → 完整定义
     if (node is com.charleskorn.kaml.YamlMap) {
@@ -204,7 +207,9 @@ private fun parseGestureNode(node: com.charleskorn.kaml.YamlNode): GestureDef {
                 }
             }
         }
-        return GestureDef(label = label, labels = labels, action = action, value = value, display = DisplayMode.fromValue(display))
+        val icon = if (label.startsWith("@")) label.removePrefix("@") else ""
+        val cleanLabel = if (icon.isNotEmpty()) "" else label
+        return GestureDef(label = cleanLabel, labels = labels, action = action, value = value, icon = icon, display = DisplayMode.fromValue(display))
     }
     return GestureDef()
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -319,6 +319,7 @@ fun SwipeableKeyButton(
     modifier: Modifier = Modifier,
     isHighlighted: Boolean = false,
     layoutMode: ButtonLayout = ButtonLayout.STANDARD,
+    icon: Painter? = null,
     swipeText: String? = null,
     swipeDownText: String? = null,
     /** 下滑文本显示在按键上（气泡为空，用于 display:key） */
@@ -593,18 +594,30 @@ fun SwipeableKeyButton(
     ) {
         if (layoutMode == ButtonLayout.COMPACT) {
             Box(modifier = Modifier.fillMaxSize()) {
-                Text(
-                    text = text,
-                    color = textColor,
-                    fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else if (text.length > 2) 13.sp else 16.sp,
-                    fontWeight = if (text.length > 2) FontWeight.Medium else FontWeight.Normal,
-                    textAlign = TextAlign.Start,
-                    maxLines = 1,
-                    lineHeight = 1.sp,
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(top = 2.dp, start = 4.dp)
-                )
+                if (icon != null) {
+                    Icon(
+                        painter = icon,
+                        contentDescription = text,
+                        tint = textColor,
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(top = 2.dp, start = 4.dp)
+                            .size(16.dp)
+                    )
+                } else {
+                    Text(
+                        text = text,
+                        color = textColor,
+                        fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else if (text.length > 2) 13.sp else 16.sp,
+                        fontWeight = if (text.length > 2) FontWeight.Medium else FontWeight.Normal,
+                        textAlign = TextAlign.Start,
+                        maxLines = 1,
+                        lineHeight = 1.sp,
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(top = 2.dp, start = 4.dp)
+                    )
+                }
 
                 Column(
                     modifier = Modifier
@@ -653,14 +666,23 @@ fun SwipeableKeyButton(
                 }
             }
         } else {
-            Text(
-                text = text,
-                color = textColor,
-                fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else if (text.length > 2) 14.sp else 18.sp,
-                fontWeight = if (text.length > 2) FontWeight.Medium else FontWeight.Normal,
-                textAlign = TextAlign.Center,
-                maxLines = 1
-            )
+            if (icon != null) {
+                Icon(
+                    painter = icon,
+                    contentDescription = text,
+                    tint = textColor,
+                    modifier = Modifier.size(20.dp)
+                )
+            } else {
+                Text(
+                    text = text,
+                    color = textColor,
+                    fontSize = if (fontSize != androidx.compose.ui.unit.TextUnit.Unspecified) fontSize else if (text.length > 2) 14.sp else 18.sp,
+                    fontWeight = if (text.length > 2) FontWeight.Medium else FontWeight.Normal,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1
+                )
+            }
 
             if (!(swipeUpKeyLabel ?: swipeText).isNullOrEmpty()) {
                 val keyLabel = (swipeUpKeyLabel ?: swipeText)!!

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -692,14 +692,18 @@ fun KeyboardLayout(
                                 modifier = Modifier.weight(1.2f)
                             )
                         } else {
-                            // shift_l — 从配置读取
-                            val k4KeyGesture = KeysConfigHelper.getKeyGesture("shift_l", isAsciiMode)
+                            // earth — 从配置读取
+                            val k4KeyGesture = KeysConfigHelper.getKeyGesture("earth", isAsciiMode)
                             val k4TapAction = k4KeyGesture?.tap?.action
-                            val k4TapValue = k4KeyGesture?.tap?.value?.takeIf { it.isNotEmpty() }
-                                ?: k4KeyGesture?.tap?.label?.takeIf { it.isNotEmpty() }
-                                ?: "ime_switch"
-                            val k4TapLabel = k4KeyGesture?.tap?.label?.takeIf { it.isNotEmpty() }
-                                ?: if (isAsciiMode) "中" else "英"
+                            val k4TapValue = k4KeyGesture?.tap?.value?.takeIf { it.isNotEmpty() } ?: ""
+                            val k4TapLabel = k4KeyGesture?.tap?.label?.takeIf { it.isNotEmpty() } ?: ""
+                            val k4Icon: Painter? = k4KeyGesture?.tap?.icon?.takeIf { it.isNotEmpty() }?.let { iconName ->
+                                val iv = when (iconName) {
+                                    "language", "globe" -> Icons.Default.Language
+                                    else -> null
+                                }
+                                iv?.let { rememberVectorPainter(it) }
+                            }
                             val k4SwipeUpRaw = k4KeyGesture?.swipeUp
                             val k4SwipeUpLabel = if (isAsciiMode)
                                 (k4SwipeUpRaw?.value?.takeIf { it.isNotEmpty() } ?: "")
@@ -758,9 +762,9 @@ fun KeyboardLayout(
                                     Unit
                                 }
                             }
-                            if (k4TapAction == GestureAction.TOGGLE_ASCII) {
+                            if (k4TapAction == GestureAction.TOGGLE_ASCII && k4LongPressLabels == null && k4Icon != null) {
                                 IconKeyButton(
-                                    icon = rememberVectorPainter(Icons.Default.Language),
+                                    icon = k4Icon,
                                     onClick = k4OnClick,
                                     backgroundColor = keyBackgroundColor,
                                     iconColor = keyTextColor,
@@ -779,7 +783,8 @@ fun KeyboardLayout(
                                     backgroundColor = keyBackgroundColor,
                                     textColor = keyTextColor,
                                     modifier = Modifier.weight(0.8f),
-                                    swipeText = k4SwipeUpLabel,
+                                    icon = k4Icon,
+                                    swipeText = k4SwipeUpLabel.takeIf { it.isNotEmpty() },
                                     swipeDownText = k4SwipeDownBubbleText,
                                     swipeDownKeyLabel = if (!isAsciiMode && (k4SwipeDownDisplay == DisplayMode.KEY || k4SwipeDownDisplay == DisplayMode.BOTH)) k4SwipeDownLabel else null,
                                     onSwipe = k4OnSwipe,
@@ -1508,7 +1513,7 @@ private fun LandscapeKeyboardContent(
                     shadowElevation = shadowElevation,
                     shadowShapeRadius = shadowShapeRadius,
                 )
-                val k4Gesture = KeysConfigHelper.getKeyGesture("shift_l")
+                val k4Gesture = KeysConfigHelper.getKeyGesture("earth")
                 val k4Action = k4Gesture?.tap?.action
                 val k4Value = k4Gesture?.tap?.value?.takeIf { it.isNotEmpty() } ?: k4Gesture?.tap?.label?.takeIf { it.isNotEmpty() } ?: "ime_switch"
                 val k4Label = k4Gesture?.tap?.label?.takeIf { it.isNotEmpty() } ?: "中"

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SwipeBubble.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SwipeBubble.kt
@@ -76,7 +76,7 @@ fun rememberSwipeBubbleDrawData(
     val displayText = if (isLongPressMode) null
         else if (swipeState.isPressed) swipeState.pressedText
         else swipeState.swipeText
-    if (!isLongPressMode && displayText == null) return null
+    if (!isLongPressMode && displayText.isNullOrEmpty()) return null
 
     val density = LocalDensity.current
     val bodyHeightPx = with(density) { BubbleBodyHeight.toPx() }

--- a/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
@@ -470,7 +470,9 @@ class KeyboardGestureConfigTest {
     private fun parseGestureNode(node: com.charleskorn.kaml.YamlNode): GestureDef {
         if (node is com.charleskorn.kaml.YamlScalar) {
             val text = node.content
-            return GestureDef(label = text, action = GestureAction.COMMIT, value = text)
+            val icon = if (text.startsWith("@")) text.removePrefix("@") else ""
+            val cleanLabel = if (icon.isNotEmpty()) "" else text
+            return GestureDef(label = cleanLabel, action = GestureAction.COMMIT, value = text, icon = icon)
         }
         if (node is com.charleskorn.kaml.YamlMap) {
             var label = ""
@@ -487,7 +489,9 @@ class KeyboardGestureConfigTest {
                     "display" -> if (vStr != null) display = vStr
                 }
             }
-            return GestureDef(label = label, action = action, value = value, display = DisplayMode.fromValue(display))
+            val icon = if (label.startsWith("@")) label.removePrefix("@") else ""
+            val cleanLabel = if (icon.isNotEmpty()) "" else label
+            return GestureDef(label = cleanLabel, action = action, value = value, icon = icon, display = DisplayMode.fromValue(display))
         }
         return GestureDef()
     }
@@ -514,19 +518,59 @@ class KeyboardGestureConfigTest {
     // ── qwerty / qwerty_en 双布局解析 ──
 
     @Test
-    fun `qwerty 和 qwerty_en 独立解析`() {
+    fun `标签以 @ 开头时自动提取 icon label 置空`() {
+        val keys = parseKeys("""
+            k: { tap: { label: "@language", action: "toggle_ascii" } }
+        """.trimIndent())
+        val tap = keys["k"]!!.tap!!
+        assertEquals("", tap.label)
+        assertEquals("language", tap.icon)
+    }
+
+    @Test
+    fun `标签以 @ 开头时 value 不 fallback 到 label`() {
+        val keys = parseKeys("""
+            k: { tap: { label: "@language", action: "toggle_ascii" } }
+        """.trimIndent())
+        val tap = keys["k"]!!.tap!!
+        assertEquals("", tap.value)
+    }
+
+    @Test
+    fun `字符串简写 @label 也提取 icon`() {
+        val keys = parseKeys("""
+            k: { tap: "@language" }
+        """.trimIndent())
+        val tap = keys["k"]!!.tap!!
+        assertEquals("", tap.label)
+        assertEquals("language", tap.icon)
+        assertEquals("@language", tap.value)
+    }
+
+    @Test
+    fun `普通标签不受 @ 影响`() {
+        val keys = parseKeys("""
+            k: { tap: { label: "英", action: "toggle_ascii" } }
+        """.trimIndent())
+        val tap = keys["k"]!!.tap!!
+        assertEquals("英", tap.label)
+        assertEquals("", tap.icon)
+    }
+
+    @Test
+    fun `qwerty_en 与 qwerty 独立读取`() {
         val yaml = """
 keyboard:
   qwerty:
     keys:
       "'": { tap: { label: "，", value: "," } }
-      shift_l: { tap: { label: "英", action: "toggle_ascii" } }
+      earth: { tap: { label: "英", action: "toggle_ascii" } }
       space: { tap: { label: "空格", value: " " } }
       return: { tap: { label: "回车", value: "\\n" } }
   qwerty_en:
     keys:
       "'": { tap: { label: ",", value: "," } }
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "中", action: "toggle_ascii" } }
       space: { tap: { label: "English", value: " " } }
       return: { tap: { label: "Enter", value: "\\n" } }
         """.trimIndent()
@@ -534,12 +578,12 @@ keyboard:
         val en = parseSection(yaml, "qwerty_en")
         // 中文布局
         assertEquals("，", zh["'"]!!.tap!!.label)
-        assertEquals("英", zh["shift_l"]!!.tap!!.label)
+        assertEquals("英", zh["earth"]!!.tap!!.label)
         assertEquals("空格", zh["space"]!!.tap!!.label)
         assertEquals("回车", zh["return"]!!.tap!!.label)
         // 英文布局
         assertEquals(",", en["'"]!!.tap!!.label)
-        assertEquals("中", en["shift_l"]!!.tap!!.label)
+        assertEquals("中", en["earth"]!!.tap!!.label)
         assertEquals("English", en["space"]!!.tap!!.label)
         assertEquals("Enter", en["return"]!!.tap!!.label)
     }
@@ -580,22 +624,22 @@ keyboard:
   qwerty:
     keys:
       "'": { tap: { label: "，", value: "," } }
-      shift_l: { tap: { label: "英", action: "toggle_ascii" } }
+      earth: { tap: { label: "英", action: "toggle_ascii" } }
   qwerty_en:
     keys:
       "'": { tap: { label: ",", value: "," } }
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "中", action: "toggle_ascii" } }
         """.trimIndent()
         val zh = parseSection(yaml, "qwerty")
         val en = parseSection(yaml, "qwerty_en")
         
         // 中文模式 (isAsciiMode = false)
         assertEquals("，", zh["'"]!!.tap!!.label)
-        assertEquals("英", zh["shift_l"]!!.tap!!.label)
+        assertEquals("英", zh["earth"]!!.tap!!.label)
         
         // 英文模式 (isAsciiMode = true)
         assertEquals(",", en["'"]!!.tap!!.label)
-        assertEquals("中", en["shift_l"]!!.tap!!.label)
+        assertEquals("中", en["earth"]!!.tap!!.label)
         
         // 验证中英文不同
         assertNotEquals(zh["'"]!!.tap!!.label, en["'"]!!.tap!!.label)

--- a/docs/config_examples/xime.cangjie.yaml
+++ b/docs/config_examples/xime.cangjie.yaml
@@ -154,4 +154,4 @@ keyboard:
       # 逗号键
       "'": { tap: { label: ",", value: "," }, swipe_up: { label: ".", value: "." } }
       # 中/英切换键
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "@language", action: "toggle_ascii" } }

--- a/docs/config_examples/xime.flypy.yaml
+++ b/docs/config_examples/xime.flypy.yaml
@@ -153,7 +153,7 @@ keyboard:
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } , long_press: { display: "bubble", values: [ ",","."] }}
       # 中/英切换键，label 为按键显示文字
-      shift_l: { tap: { label: "英", action: "toggle_ascii" } }
+      earth: { tap: { label: "@language", action: "toggle_ascii" } }
    
   # 英文键盘布局
   qwerty_en:
@@ -191,4 +191,4 @@ keyboard:
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: ",", value: "," }, swipe_up: { label: ".", value: "." } }
       # 中/英切换键，label 为按键显示文字
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "@language", action: "toggle_ascii" } }

--- a/docs/config_examples/xime.full_example.yaml
+++ b/docs/config_examples/xime.full_example.yaml
@@ -183,4 +183,4 @@ keyboard:
       # 逗号键
       "'": { tap: { label: ",", value: "," }, swipe_up: { label: ".", value: "." } }
       # 中/英切换键，英文键盘下显示"中"
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "中", action: "toggle_ascii" } }

--- a/docs/config_examples/xime.shortcut.yaml
+++ b/docs/config_examples/xime.shortcut.yaml
@@ -36,4 +36,4 @@ keyboard:
       # 逗号键
       "'": { tap: { label: ",", value: "," }, swipe_up: { label: ".", value: "." } }
       # 中/英切换键
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "中", action: "toggle_ascii" } }

--- a/docs/config_examples/xime.wubi_compact.yaml
+++ b/docs/config_examples/xime.wubi_compact.yaml
@@ -152,7 +152,7 @@ keyboard:
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } , long_press: { display: "bubble", values: [ ",","."] }}
       # 中/英切换键，label 为按键显示文字
-      shift_l: { tap: { label: "英", action: "toggle_ascii" } }
+      earth: { tap: { label: "英", action: "toggle_ascii" } }
    
   # 英文键盘布局
   qwerty_en:
@@ -190,4 +190,4 @@ keyboard:
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: ",", value: "," }, swipe_up: { label: ".", value: "." } }
       # 中/英切换键，label 为按键显示文字
-      shift_l: { tap: { label: "中", action: "toggle_ascii" } }
+      earth: { tap: { label: "中", action: "toggle_ascii" } }


### PR DESCRIPTION
- 将 shift_l 键重命名为 earth 键，支持图标显示
- 添加 @language 图标语法支持，以 @ 开头的标签会被识别为图标
- 实现长按地球键显示输入法选择器功能
- 支持在 YAML 配置中使用 @ 符号前缀定义图标
- 更新所有示例配置文件中的中英切换键配置

refactor(config): 提取图标配置到独立字段

- 在 GestureDef 数据类中添加 icon 字段
- 修改 YAML 解析逻辑以支持图标提取
- 当标签以 @ 开头时自动提取图标名称并清空标签文本

fix(bubble): 修复空字符串判断条件

- 将 swipe bubble 的空值检查从 null 改为 isNullOrEmpty
- 避免空字符串导致的显示异常

docs: 更新配置示例文件

- 同步更新所有文档中的示例配置
- 将 shift_l 替换为 earth 键配置