### PR TITLE
fix(T9KeyboardLayout): 修复T9键盘删除键上滑清空功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -670,7 +670,10 @@ private fun T9KeyboardContent(
                 onPress = { onKeyPressDown?.invoke("delete") },
                 swipeUpLabel = if (compactMode) null else "上滑清空",
                 swipeDownLabel = if (compactMode) null else "下滑撤回",
-                onSwipeUp = { onKeyPress("clear_all") },
+                onSwipeUp = {
+                    controller.clearAll()
+                    onKeyPress("clear_all")
+                },
                 onSwipeDown = { onKeyPress("undo_clear") },
                 onSwipeLeft = { onKeyPress("clear_composition") },
                 onSwipeStateChange = { state, bounds ->


### PR DESCRIPTION
当用户在T9键盘的删除键上滑时，现在会先调用controller.clearAll()方法，
然后再执行原有的清空所有操作，确保输入状态能够正确重置。

更新了librime和librime-lua-deps子模块的脏状态标记。