### PR TITLE
fix(XimeInputMethodService): 修复T9模式下全提交判断逻辑错误

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -254,8 +254,6 @@ class T9InputController(
         if (input.isEmpty()) {
             if (lastRimeInput != null) {
                 lastRimeInput = null
-                // 当 buffer 为空但仍有 RightCommit 未撤销时，只清除 RIME composition
-                // 但不清空 partial commit 累积文本（预编辑区域仍需显示已提交的候选词）
                 val hasPendingRightCommit = snapshots.any { it.isRightCommit }
                 onReplaceFullPinyin(if (hasPendingRightCommit) CLEAR_COMPOSITION_ONLY else CLEAR_ALL)
             }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -2224,7 +2224,15 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
 
         if (rimeEngine.selectCandidate(index)) {
             val committedText = rimeEngine.commit()
-            if (committedText.isNotEmpty() || (isT9 && fullyConsumed && selectedCandidate != null)) {
+            val isFullCommit = if (isT9 && committedText.isEmpty() && fullyConsumed) {
+                // committedText 为空说明 RIME 未实际提交，但 T9 控制器消费了全部数字。
+                // 此时需检查 RIME 是否还有活动 composition，若有则是 partial commit 误判。
+                val comp = rimeEngine.getComposition()
+                comp.input.isEmpty()
+            } else {
+                committedText.isNotEmpty() || (isT9 && fullyConsumed && selectedCandidate != null)
+            }
+            if (isFullCommit) {
                 if (SettingsPreferences.isSmartPredictionEnabled(this) && selectedCandidate != null && AssociationManager.isInitialized()) {
                     if (predictionManager.lastCommittedText.isNotEmpty()) {
                         val lastChar = predictionManager.lastCommittedText.last().toString()


### PR DESCRIPTION
当 committedText 为空但 T9 控制器消费了全部数字时，
需要检查 RIME 是否还有活动 composition 来避免 partial commit 误判， 确保提交行为的准确性。