### PR TITLE
refactor(keyboard): 优化阴影形状实现和修复代码质量问题

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -15,8 +15,6 @@
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/marisa-trie" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/opencc" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/yaml-cpp" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/plugins/lua" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/plugins/lua/thirdparty" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy/third_party/benchmark" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy/third_party/googletest" vcs="Git" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -494,3 +494,12 @@ dependencies {
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.concurrent:concurrent-futures:1.2.0")
 }
+
+// Align concurrent-futures version: espresso 3.7.0 requires 1.2.0
+dependencies {
+    constraints {
+        implementation("androidx.concurrent:concurrent-futures:1.2.0") {
+            because("test dependencies (espresso 3.7.0) require 1.2.0")
+        }
+    }
+}

--- a/app/src/androidTest/java/com/kingzcheung/xime/clipboard/ClipboardManagerTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/clipboard/ClipboardManagerTest.kt
@@ -36,7 +36,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `getInstance should return singleton`() {
+    fun getInstanceReturnsSingleton() {
         val instance1 = ClipboardManager.getInstance(context)
         val instance2 = ClipboardManager.getInstance(context)
         
@@ -44,19 +44,19 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `clipboardItems should be empty initially`() {
+    fun clipboardItemsEmptyInitially() {
         val items = clipboardManager.clipboardItems.value
         assertTrue("Initial clipboard should be empty", items.isEmpty())
     }
     
     @Test
-    fun `quickSendItems should be empty initially`() {
+    fun quickSendItemsEmptyInitially() {
         val items = clipboardManager.quickSendItems.value
         assertTrue("Initial quick send should be empty", items.isEmpty())
     }
     
     @Test
-    fun `addItem should add item to list`() {
+    fun addItemAddsItemToList() {
         clipboardManager.addItem("Test text")
         
         val items = clipboardManager.clipboardItems.value
@@ -66,7 +66,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `addItem should not add blank text`() {
+    fun addItemNotAddBlankText() {
         clipboardManager.addItem("")
         clipboardManager.addItem("   ")
         
@@ -75,7 +75,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `addItem should update timestamp for existing text`() {
+    fun addItemUpdatesTimestampForExistingText() {
         clipboardManager.addItem("Test text")
         val firstTimestamp = clipboardManager.clipboardItems.value[0].timestamp
         
@@ -89,7 +89,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `addItem should move existing item to top`() {
+    fun addItemMovesExistingItemToTop() {
         clipboardManager.addItem("First")
         clipboardManager.addItem("Second")
         
@@ -103,7 +103,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `removeItem should remove item by id`() {
+    fun removeItemRemovesItemById() {
         clipboardManager.addItem("Test text")
         val itemId = clipboardManager.clipboardItems.value[0].id
         
@@ -114,7 +114,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `removeItem should not affect other items`() {
+    fun removeItemNotAffectOtherItems() {
         clipboardManager.addItem("First")
         clipboardManager.addItem("Second")
         val firstId = clipboardManager.clipboardItems.value.find { it.text == "First" }!!.id
@@ -127,7 +127,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `splitItem should split text into individual characters`() {
+    fun splitItemSplitsTextIntoCharacters() {
         clipboardManager.addItem("你好")
         val itemId = clipboardManager.clipboardItems.value[0].id
         
@@ -140,7 +140,7 @@ class ClipboardManagerTest {
     }
 
     @Test
-    fun `splitItem should handle single character`() {
+    fun splitItemHandlesSingleCharacter() {
         clipboardManager.addItem("A")
         val itemId = clipboardManager.clipboardItems.value[0].id
         
@@ -152,7 +152,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `clearAll should clear all items`() {
+    fun clearAllClearsAllItems() {
         clipboardManager.addItem("Item1")
         clipboardManager.addItem("Item2")
         
@@ -163,7 +163,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `clearAll should remove all unpinned items`() {
+    fun clearAllRemovesUnpinnedItems() {
         clipboardManager.addItem("First")
         clipboardManager.addItem("Second")
         clipboardManager.addItem("Third")
@@ -174,7 +174,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `addToQuickSend should add item to quick send list`() {
+    fun addToQuickSendAddsItemToQuickSendList() {
         clipboardManager.addItem("Quick text")
         val itemId = clipboardManager.clipboardItems.value[0].id
         
@@ -188,7 +188,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `removeFromQuickSend should remove item`() {
+    fun removeFromQuickSendRemovesItem() {
         clipboardManager.addItem("Quick text")
         val itemId = clipboardManager.clipboardItems.value[0].id
         clipboardManager.addToQuickSend(itemId)
@@ -199,7 +199,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `addQuickSendItem should add text directly`() {
+    fun addQuickSendItemAddsTextDirectly() {
         clipboardManager.addQuickSendItem("Direct quick")
         
         val quickSendItems = clipboardManager.quickSendItems.value
@@ -209,7 +209,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `addQuickSendItem should not add blank text`() {
+    fun addQuickSendItemNotAddBlankText() {
         clipboardManager.addQuickSendItem("")
         clipboardManager.addQuickSendItem("   ")
         
@@ -217,13 +217,13 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `getCurrentClipboardText should return null when empty`() {
+    fun getCurrentClipboardTextReturnsNullWhenEmpty() {
         val text = clipboardManager.getCurrentClipboardText()
         assertNull("Should return null when clipboard is empty", text)
     }
     
     @Test
-    fun `copyToSystemClipboard should set clipboard text`() {
+    fun copyToSystemClipboardSetsClipboardText() {
         clipboardManager.copyToSystemClipboard("Copied text")
         
         val text = clipboardManager.getCurrentClipboardText()
@@ -231,7 +231,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `ClipboardItem should have correct default values`() {
+    fun clipboardItemHasCorrectDefaultValues() {
         val item = ClipboardItem(text = "Test")
         
         assertNotNull(item.id)
@@ -242,7 +242,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `ClipboardItem copy should preserve values`() {
+    fun clipboardItemCopyPreservesValues() {
         val original = ClipboardItem(
             id = 123L,
             text = "Original",
@@ -261,7 +261,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `serialize deserialize should preserve data`() {
+    fun serializeDeserializePreservesData() {
         val items = listOf(
             ClipboardItem(1L, "Test:::with|||special", 1000L, true, false),
             ClipboardItem(2L, "Normal text", 2000L, false, true)
@@ -283,7 +283,7 @@ class ClipboardManagerTest {
     }
     
     @Test
-    fun `max items limit should be enforced`() {
+    fun maxItemsLimitEnforced() {
         for (i in 1..55) {
             clipboardManager.addItem("Item $i")
         }

--- a/app/src/androidTest/java/com/kingzcheung/xime/integration/InputMethodIntegrationTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/integration/InputMethodIntegrationTest.kt
@@ -34,7 +34,7 @@ class InputMethodIntegrationTest {
     }
     
     @Test
-    fun `test full initialization workflow`() {
+    fun testFullInitializationWorkflow() {
         assertFalse(ExtensionManager.isInitialized())
         
         ExtensionManager.initialize(context)
@@ -43,7 +43,7 @@ class InputMethodIntegrationTest {
     }
     
     @Test
-    fun `test plugin loading workflow`() {
+    fun testPluginLoadingWorkflow() {
         ExtensionManager.initialize(context)
         
         val allPlugins = ExtensionManager.getAllInstalledPlugins()
@@ -55,7 +55,7 @@ class InputMethodIntegrationTest {
     }
     
     @Test
-    fun `test plugin enable disable workflow`() {
+    fun testPluginEnableDisableWorkflow() {
         val pluginId = "test_plugin_integration"
         
         ExtensionManager.initialize(context)
@@ -68,7 +68,7 @@ class InputMethodIntegrationTest {
     }
     
     @Test
-    fun `test rime directory setup`() {
+    fun testRimeDirectorySetup() {
         val userDataDir = File(context.filesDir, "rime_user")
         val sharedDataDir = File(context.filesDir, "rime_shared")
         
@@ -77,7 +77,7 @@ class InputMethodIntegrationTest {
     }
     
     @Test
-    fun `test reload workflow`() {
+    fun testReloadWorkflow() {
         ExtensionManager.initialize(context)
         assertTrue(ExtensionManager.isInitialized())
         

--- a/app/src/androidTest/java/com/kingzcheung/xime/plugin/ExtensionManagerTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/plugin/ExtensionManagerTest.kt
@@ -29,19 +29,19 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `isInitialized should return false before initialization`() {
+    fun isInitializedReturnsFalseBeforeInit() {
         assertFalse("Should not be initialized before init", ExtensionManager.isInitialized())
     }
     
     @Test
-    fun `initialize should set initialized state`() {
+    fun initializeSetsInitializedState() {
         ExtensionManager.initialize(context)
         
         assertTrue("Should be initialized after init", ExtensionManager.isInitialized())
     }
     
     @Test
-    fun `initialize multiple times should not cause error`() {
+    fun initializeMultipleTimesShouldNotCauseError() {
         ExtensionManager.initialize(context)
         ExtensionManager.initialize(context)
         
@@ -49,7 +49,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `release should reset initialized state`() {
+    fun releaseResetsInitializedState() {
         ExtensionManager.initialize(context)
         assertTrue("Should be initialized", ExtensionManager.isInitialized())
         
@@ -59,7 +59,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `getAllInstalledPlugins should return list after initialization`() {
+    fun getAllInstalledPluginsReturnsListAfterInit() {
         ExtensionManager.initialize(context)
         
         val plugins = ExtensionManager.getAllInstalledPlugins()
@@ -68,7 +68,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `getEmojiPlugins should return list after initialization`() {
+    fun getEmojiPluginsReturnsListAfterInit() {
         ExtensionManager.initialize(context)
         
         val emojiPlugins = ExtensionManager.getEmojiPlugins()
@@ -77,7 +77,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `emojiCategoriesFlow should have default categories`() = runBlocking {
+    fun emojiCategoriesFlowHasDefaultCategories() = runBlocking {
         val categories = ExtensionManager.emojiCategoriesFlow.first()
         
         assertTrue("Should have default categories", categories.isNotEmpty())
@@ -86,7 +86,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `getEnabledEmojiPlugins should return empty when no plugins enabled`() {
+    fun getEnabledEmojiPluginsReturnsEmptyWhenNoPluginsEnabled() {
         ExtensionManager.initialize(context)
         
         val enabledPlugins = ExtensionManager.getEnabledEmojiPlugins(context)
@@ -95,7 +95,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `getPluginById should return null for unknown plugin`() {
+    fun getPluginByIdReturnsNullForUnknownPlugin() {
         ExtensionManager.initialize(context)
         
         val plugin = ExtensionManager.getPluginById("unknown_plugin_id")
@@ -104,7 +104,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `reload should return true when initialized`() {
+    fun reloadReturnsTrueWhenInitialized() {
         ExtensionManager.initialize(context)
         
         val result = ExtensionManager.reload(context)
@@ -113,7 +113,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `reload should return false when not initialized`() {
+    fun reloadReturnsFalseWhenNotInitialized() {
         ExtensionManager.release()
         
         val result = ExtensionManager.reload(context)
@@ -122,7 +122,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `emojiCategoriesFlow should be observable`() = runBlocking {
+    fun emojiCategoriesFlowIsObservable() = runBlocking {
         ExtensionManager.initialize(context)
         
         val categories = ExtensionManager.emojiCategoriesFlow.first()
@@ -131,14 +131,14 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `initialize should work with null sharedUserId`() {
+    fun initializeWorksWithNullSharedUserId() {
         ExtensionManager.initialize(context)
         
         assertTrue("Should initialize without sharedUserId", ExtensionManager.isInitialized())
     }
     
     @Test
-    fun `multiple release calls should not cause error`() {
+    fun multipleReleaseCallsShouldNotCauseError() {
         ExtensionManager.initialize(context)
         ExtensionManager.release()
         ExtensionManager.release()
@@ -147,7 +147,7 @@ class ExtensionManagerTest {
     }
     
     @Test
-    fun `getEmojiPlugins size should be <= getAllInstalledPlugins size`() {
+    fun emojiPluginsSizeNotExceedAllPluginsSize() {
         ExtensionManager.initialize(context)
         
         val allPlugins = ExtensionManager.getAllInstalledPlugins()

--- a/app/src/androidTest/java/com/kingzcheung/xime/rime/RimeEngineTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/rime/RimeEngineTest.kt
@@ -31,7 +31,7 @@ class RimeEngineTest {
     }
     
     @Test
-    fun `getInstance should return singleton`() {
+    fun getInstanceReturnsSingleton() {
         val instance1 = RimeEngine.getInstance()
         val instance2 = RimeEngine.getInstance()
         
@@ -39,34 +39,34 @@ class RimeEngineTest {
     }
     
     @Test
-    fun `isInitialized should return false before initialization`() {
+    fun isInitializedReturnsFalseBeforeInit() {
         val engine = RimeEngine.getInstance()
         assertFalse(RimeEngine.isInitialized())
     }
     
     @Test
-    fun `processKey should return false when not initialized`() {
+    fun processKeyReturnsFalseWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.processKey(65, 0)
         assertFalse(result)
     }
     
     @Test
-    fun `getCandidates should return empty array when not initialized`() {
+    fun getCandidatesReturnsEmptyArrayWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val candidates = engine.getCandidates()
         assertTrue(candidates.isEmpty())
     }
     
     @Test
-    fun `getInput should return empty string when not initialized`() {
+    fun getInputReturnsEmptyStringWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val input = engine.getInput()
         assertEquals("", input)
     }
     
     @Test
-    fun `initialize should create valid directories`() {
+    fun initializeCreatesValidDirectories() {
         val userDataDir = File(context.filesDir, "rime_user_test")
         val sharedDataDir = File(context.filesDir, "rime_shared_test")
         
@@ -75,56 +75,56 @@ class RimeEngineTest {
     }
     
     @Test
-    fun `toggleAsciiMode should return false when not initialized`() {
+    fun toggleAsciiModeReturnsFalseWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.toggleAsciiMode()
         assertFalse(result)
     }
     
     @Test
-    fun `isAsciiMode should return false when not initialized`() {
+    fun isAsciiModeReturnsFalseWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.isAsciiMode()
         assertFalse(result)
     }
     
     @Test
-    fun `switchSchema should return false when not initialized`() {
+    fun switchSchemaReturnsFalseWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.switchSchema("wubi86")
         assertFalse(result)
     }
     
     @Test
-    fun `getAvailableSchemas should return empty array when not initialized`() {
+    fun getAvailableSchemasReturnsEmptyArrayWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val schemas = engine.getAvailableSchemas()
         assertTrue(schemas.isEmpty())
     }
     
     @Test
-    fun `selectCandidate should return false when not initialized`() {
+    fun selectCandidateReturnsFalseWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.selectCandidate(0)
         assertFalse(result)
     }
     
     @Test
-    fun `commit should return empty string when not initialized`() {
+    fun commitReturnsEmptyStringWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.commit()
         assertEquals("", result)
     }
     
     @Test
-    fun `deploy should return false when not initialized`() {
+    fun deployReturnsFalseWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.deploy()
         assertFalse(result)
     }
     
     @Test
-    fun `lookupText should return empty string when not initialized`() {
+    fun lookupTextReturnsEmptyStringWhenNotInitialized() {
         val engine = RimeEngine.getInstance()
         val result = engine.lookupText("工")
         assertEquals("", result)

--- a/app/src/androidTest/java/com/kingzcheung/xime/settings/PluginEnabledStateTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/settings/PluginEnabledStateTest.kt
@@ -25,7 +25,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `plugin enabled state defaults to false`() {
+    fun pluginEnabledStateDefaultsToFalse() {
         val pluginId = "prediction-onnx"
         
         val isEnabled = SettingsPreferences.isPluginEnabled(context, pluginId)
@@ -34,7 +34,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `plugin enabled state can be set to true`() {
+    fun pluginEnabledStateCanBeSetToTrue() {
         val pluginId = "prediction-onnx"
         
         SettingsPreferences.setPluginEnabled(context, pluginId, true)
@@ -43,7 +43,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `plugin enabled state can be toggled`() {
+    fun pluginEnabledStateCanBeToggled() {
         val pluginId = "prediction-onnx"
         
         SettingsPreferences.setPluginEnabled(context, pluginId, true)
@@ -54,7 +54,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `different plugins have independent enabled states`() {
+    fun differentPluginsHaveIndependentEnabledStates() {
         val plugin1 = "prediction-onnx"
         val plugin2 = "meme-bunny"
         
@@ -71,7 +71,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `plugin enabled state persists across clear`() {
+    fun pluginEnabledStatePersistsAcrossClear() {
         val pluginId = "prediction-onnx"
         
         SettingsPreferences.setPluginEnabled(context, pluginId, true)
@@ -86,7 +86,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `plugin enabled state keys are isolated`() {
+    fun pluginEnabledStateKeysAreIsolated() {
         val plugin1 = "prediction-onnx"
         val plugin2 = "kaomoji"
         
@@ -100,7 +100,7 @@ class PluginEnabledStateTest {
     }
 
     @Test
-    fun `multiple plugins enabled states are tracked independently`() {
+    fun multiplePluginsEnabledStatesAreTrackedIndependently() {
         val plugins = listOf("prediction-onnx", "meme-bunny", "kaomoji")
         
         plugins.forEachIndexed { index, pluginId ->

--- a/app/src/androidTest/java/com/kingzcheung/xime/settings/SettingsPreferencesTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/settings/SettingsPreferencesTest.kt
@@ -22,7 +22,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `current schema uses default then persists value`() {
+    fun currentSchemaUsesDefaultThenPersists() {
         assertEquals("wubi86", SettingsPreferences.getCurrentSchema(context))
 
         SettingsPreferences.setCurrentSchema(context, "wubi98")
@@ -31,7 +31,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `dark mode persists integer setting`() {
+    fun darkModePersistsIntegerSetting() {
         assertEquals(2, SettingsPreferences.getDarkMode(context))
 
         SettingsPreferences.setDarkMode(context, 0)
@@ -40,7 +40,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `dark mode values`() {
+    fun darkModeValues() {
         SettingsPreferences.setDarkMode(context, 0)
         assertEquals(0, SettingsPreferences.getDarkMode(context))
         
@@ -52,7 +52,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `sound and vibration defaults and updates work`() {
+    fun soundAndVibrationDefaultsAndUpdatesWork() {
         assertTrue(SettingsPreferences.isSoundEnabled(context))
         assertEquals(50, SettingsPreferences.getSoundVolume(context))
         assertTrue(SettingsPreferences.isVibrationEnabled(context))
@@ -70,7 +70,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `sound volume boundary values`() {
+    fun soundVolumeBoundaryValues() {
         SettingsPreferences.setSoundVolume(context, 0)
         assertEquals(0, SettingsPreferences.getSoundVolume(context))
         
@@ -79,7 +79,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `vibration intensity boundary values`() {
+    fun vibrationIntensityBoundaryValues() {
         SettingsPreferences.setVibrationIntensity(context, 0)
         assertEquals(0, SettingsPreferences.getVibrationIntensity(context))
         
@@ -88,12 +88,12 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `haptic mode defaults to following system`() {
+    fun hapticModeDefaultsToFollowingSystem() {
         assertEquals("following_system", SettingsPreferences.getHapticMode(context))
     }
 
     @Test
-    fun `haptic mode persists values`() {
+    fun hapticModePersistsValues() {
         SettingsPreferences.setHapticMode(context, "enabled")
         assertEquals("enabled", SettingsPreferences.getHapticMode(context))
 
@@ -105,12 +105,12 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `haptic on key up defaults to false`() {
+    fun hapticOnKeyUpDefaultsToFalse() {
         assertFalse(SettingsPreferences.isHapticOnKeyUp(context))
     }
 
     @Test
-    fun `vibration duration and amplitude defaults to zero`() {
+    fun vibrationDurationAndAmplitudeDefaultsToZero() {
         assertEquals(0, SettingsPreferences.getVibrationPressDuration(context))
         assertEquals(0, SettingsPreferences.getVibrationLongPressDuration(context))
         assertEquals(0, SettingsPreferences.getVibrationPressAmplitude(context))
@@ -118,7 +118,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `vibration duration and amplitude persist`() {
+    fun vibrationDurationAndAmplitudePersist() {
         SettingsPreferences.setVibrationPressDuration(context, 30)
         assertEquals(30, SettingsPreferences.getVibrationPressDuration(context))
 
@@ -133,19 +133,19 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `keyboard theme and bottom buttons persist`() {
+    fun keyboardThemeAndToolbarButtonsPersist() {
         assertEquals("lavender_purple", SettingsPreferences.getKeyboardTheme(context))
-        assertFalse(SettingsPreferences.showBottomButtons(context))
+        assertTrue(SettingsPreferences.getToolbarButtons(context).isEmpty())
 
         SettingsPreferences.setKeyboardTheme(context, "sunset")
-        SettingsPreferences.setShowBottomButtons(context, true)
+        SettingsPreferences.setToolbarButtons(context, listOf("symbols", "clipboard"))
 
         assertEquals("sunset", SettingsPreferences.getKeyboardTheme(context))
-        assertTrue(SettingsPreferences.showBottomButtons(context))
+        assertEquals(listOf("symbols", "clipboard"), SettingsPreferences.getToolbarButtons(context))
     }
 
     @Test
-    fun `multiple theme changes`() {
+    fun multipleThemeChanges() {
         SettingsPreferences.setKeyboardTheme(context, "ocean_blue")
         assertEquals("ocean_blue", SettingsPreferences.getKeyboardTheme(context))
         
@@ -157,7 +157,7 @@ class SettingsPreferencesTest {
     }
 
     @Test
-    fun `plugin enabled state is isolated by plugin id`() {
+    fun pluginEnabledStateIsIsolatedByPluginId() {
         val predictionPlugin = "prediction-onnx"
         val emojiPlugin = "meme-bunny"
 
@@ -174,7 +174,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `multiple plugins can be enabled independently`() {
+    fun multiplePluginsCanBeEnabledIndependently() {
         val plugins = listOf("plugin1", "plugin2", "plugin3")
         
         for (plugin in plugins) {
@@ -197,7 +197,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `smart prediction settings`() {
+    fun smartPredictionSettings() {
         assertFalse("Smart prediction should be disabled by default", 
             SettingsPreferences.isSmartPredictionEnabled(context))
         
@@ -211,7 +211,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `prediction model repo settings`() {
+    fun predictionModelRepoSettings() {
         val defaultRepo = "https://www.modelscope.cn/models/bikeand/predictive-text-small"
         assertEquals(defaultRepo, SettingsPreferences.getPredictionModelRepo(context))
         
@@ -221,7 +221,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `STT settings`() {
+    fun sttSettings() {
         assertFalse("STT should be disabled by default", 
             SettingsPreferences.isSttEnabled(context))
         
@@ -231,7 +231,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `STT provider settings`() {
+    fun sttProviderSettings() {
         assertEquals("funasr", SettingsPreferences.getSttProvider(context))
         
         SettingsPreferences.setSttProvider(context, "whisper")
@@ -239,7 +239,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `FunASR API key settings`() {
+    fun funasrApiKeySettings() {
         assertEquals("", SettingsPreferences.getFunAsrApiKey(context))
         
         val apiKey = "test-api-key-12345"
@@ -248,7 +248,7 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `schema switching sequence`() {
+    fun schemaSwitchingSequence() {
         val schemas = listOf("wubi86", "wubi98", "wubi_pinyin")
         
         for (schema in schemas) {
@@ -259,19 +259,19 @@ class SettingsPreferencesTest {
     }
     
     @Test
-    fun `bottom buttons toggle`() {
-        SettingsPreferences.setShowBottomButtons(context, true)
-        assertTrue(SettingsPreferences.showBottomButtons(context))
+    fun toolbarButtonsPersist() {
+        SettingsPreferences.setToolbarButtons(context, listOf("symbols", "clipboard"))
+        assertEquals(listOf("symbols", "clipboard"), SettingsPreferences.getToolbarButtons(context))
         
-        SettingsPreferences.setShowBottomButtons(context, false)
-        assertFalse(SettingsPreferences.showBottomButtons(context))
+        SettingsPreferences.setToolbarButtons(context, emptyList())
+        assertTrue(SettingsPreferences.getToolbarButtons(context).isEmpty())
         
-        SettingsPreferences.setShowBottomButtons(context, true)
-        assertTrue(SettingsPreferences.showBottomButtons(context))
+        SettingsPreferences.setToolbarButtons(context, listOf("symbols"))
+        assertEquals(listOf("symbols"), SettingsPreferences.getToolbarButtons(context))
     }
     
     @Test
-    fun `clearing preferences resets to defaults`() {
+    fun clearingPreferencesResetsToDefaults() {
         SettingsPreferences.setCurrentSchema(context, "custom_schema")
         SettingsPreferences.setDarkMode(context, 2)
         SettingsPreferences.setSoundEnabled(context, false)

--- a/app/src/androidTest/java/com/kingzcheung/xime/speech/sherpa/SherpaAsrEngineIntegrationTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/speech/sherpa/SherpaAsrEngineIntegrationTest.kt
@@ -145,11 +145,13 @@ class SherpaAsrEngineIntegrationTest {
         for (model in models) {
             assertTrue("Model ${model.id} should have files", model.files.isNotEmpty())
             
-            // CTC models should have ctcModelFile
-            if (model.modelType == "ctc") {
-                assertTrue("CTC model should have ctcModelFile", 
-                    model.ctcModelFile.isNotEmpty())
-            }
+            // All models should have encoder/decoder/joiner files
+            assertTrue("Model should have encoder file",
+                model.encoderFile.isNotEmpty())
+            assertTrue("Model should have decoder file",
+                model.decoderFile.isNotEmpty())
+            assertTrue("Model should have joiner file",
+                model.joinerFile.isNotEmpty())
         }
     }
 

--- a/app/src/androidTest/java/com/kingzcheung/xime/ui/CandidateBarTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/ui/CandidateBarTest.kt
@@ -4,6 +4,11 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kingzcheung.xime.ui.keyboard.CandidateBar
+import com.kingzcheung.xime.ui.keyboard.CandidateBarCallbacks
+import com.kingzcheung.xime.ui.keyboard.CandidateBarState
+import com.kingzcheung.xime.ui.keyboard.CandidateBarVisuals
+import com.kingzcheung.xime.ui.keyboard.CandidateItem
 import com.kingzcheung.xime.ui.theme.DividerColor
 import com.kingzcheung.xime.ui.theme.KeyTextColor
 import com.kingzcheung.xime.ui.theme.KeyboardBackground
@@ -18,14 +23,13 @@ class CandidateBarTest {
     val composeTestRule = createComposeRule()
     
     @Test
-    fun `CandidateBar should display candidates`() {
-        val candidates = listOf("你好", "世界", "测试")
-        
+    fun candidateBarDisplaysCandidates() {
         composeTestRule.setContent {
             CandidateBar(
-                candidates = candidates,
-                inputText = "nihao",
-                isComposing = true,
+                state = CandidateBarState.ChineseCandidates(
+                    candidates = listOf("你好", "世界", "测试"),
+                    inputText = "nihao",
+                ),
                 visuals = CandidateBarVisuals(
                     backgroundColor = KeyboardBackground,
                     textColor = KeyTextColor,
@@ -43,12 +47,10 @@ class CandidateBarTest {
     }
     
     @Test
-    fun `CandidateBar should handle empty candidates`() {
+    fun candidateBarHandlesEmptyCandidates() {
         composeTestRule.setContent {
             CandidateBar(
-                candidates = emptyList(),
-                inputText = "",
-                isComposing = false,
+                state = CandidateBarState.Idle,
                 visuals = CandidateBarVisuals(
                     backgroundColor = KeyboardBackground,
                     textColor = KeyTextColor,
@@ -62,12 +64,13 @@ class CandidateBarTest {
     }
     
     @Test
-    fun `CandidateBar should display input text when composing`() {
+    fun candidateBarDisplaysInputTextWhenComposing() {
         composeTestRule.setContent {
             CandidateBar(
-                candidates = listOf("你好"),
-                inputText = "nihao",
-                isComposing = true,
+                state = CandidateBarState.ChineseCandidates(
+                    candidates = listOf("你好"),
+                    inputText = "nihao",
+                ),
                 visuals = CandidateBarVisuals(
                     backgroundColor = KeyboardBackground,
                     textColor = KeyTextColor,
@@ -83,13 +86,14 @@ class CandidateBarTest {
     }
     
     @Test
-    fun `CandidateBar should display comments`() {
+    fun candidateBarDisplaysComments() {
         composeTestRule.setContent {
             CandidateBar(
-                candidates = listOf("你好"),
-                candidateComments = listOf("wubi"),
-                inputText = "nihao",
-                isComposing = true,
+                state = CandidateBarState.ChineseCandidates(
+                    candidates = listOf("你好"),
+                    comments = listOf("wubi"),
+                    inputText = "nihao",
+                ),
                 visuals = CandidateBarVisuals(
                     backgroundColor = KeyboardBackground,
                     textColor = KeyTextColor,
@@ -105,13 +109,14 @@ class CandidateBarTest {
     }
     
     @Test
-    fun `CandidateBar should display association candidates`() {
+    fun candidateBarDisplaysAssociationCandidates() {
         composeTestRule.setContent {
             CandidateBar(
-                candidates = listOf("你好"),
-                associationCandidates = listOf("世界", "吗"),
-                inputText = "nihao",
-                isComposing = true,
+                state = CandidateBarState.ChineseCandidates(
+                    candidates = listOf("你好"),
+                    associationCandidates = listOf("世界", "吗"),
+                    inputText = "nihao",
+                ),
                 visuals = CandidateBarVisuals(
                     backgroundColor = KeyboardBackground,
                     textColor = KeyTextColor,
@@ -128,7 +133,7 @@ class CandidateBarTest {
     }
     
     @Test
-    fun `CandidateItem should display text`() {
+    fun candidateItemDisplaysText() {
         composeTestRule.setContent {
             CandidateItem(
                 text = "测试候选词",
@@ -142,7 +147,7 @@ class CandidateBarTest {
     }
     
     @Test
-    fun `CandidateItem should display comment`() {
+    fun candidateItemDisplaysComment() {
         composeTestRule.setContent {
             CandidateItem(
                 text = "你好",

--- a/app/src/androidTest/java/com/kingzcheung/xime/ui/KeyboardViewTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/ui/KeyboardViewTest.kt
@@ -5,6 +5,13 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kingzcheung.xime.ui.keyboard.CandidateBar
+import com.kingzcheung.xime.ui.keyboard.CandidateBarCallbacks
+import com.kingzcheung.xime.ui.keyboard.CandidateBarState
+import com.kingzcheung.xime.ui.keyboard.CandidateBarVisuals
+import com.kingzcheung.xime.ui.keyboard.CandidateItem
+import com.kingzcheung.xime.ui.keyboard.KeyButton
+import com.kingzcheung.xime.ui.keyboard.SpaceKeyButton
 import com.kingzcheung.xime.ui.theme.DividerColor
 import com.kingzcheung.xime.ui.theme.KeyBackground
 import com.kingzcheung.xime.ui.theme.KeyTextColor
@@ -20,11 +27,13 @@ class KeyboardViewTest {
     val composeTestRule = createComposeRule()
     
     @Test
-    fun `KeyButton should display text`() {
+    fun keyButtonDisplaysText() {
         composeTestRule.setContent {
             KeyButton(
                 text = "Q",
-                onClick = {}
+                onClick = {},
+                backgroundColor = KeyBackground,
+                textColor = KeyTextColor
             )
         }
         
@@ -32,12 +41,14 @@ class KeyboardViewTest {
     }
     
     @Test
-    fun `KeyButton should handle click`() {
+    fun keyButtonHandlesClick() {
         var clicked = false
         composeTestRule.setContent {
             KeyButton(
                 text = "A",
-                onClick = { clicked = true }
+                onClick = { clicked = true },
+                backgroundColor = KeyBackground,
+                textColor = KeyTextColor
             )
         }
         
@@ -47,25 +58,25 @@ class KeyboardViewTest {
     }
     
     @Test
-    fun `SpaceKeyButton should display correctly`() {
+    fun spaceKeyButtonDisplaysCorrectly() {
         composeTestRule.setContent {
             SpaceKeyButton(
-                isAsciiMode = false,
                 onClick = {},
-                onLongClick = {}
+                backgroundColor = KeyBackground,
+                textColor = KeyTextColor,
+                schemaName = "en"
             )
         }
     }
     
     @Test
-    fun `CandidateBar should display candidates`() {
-        val candidates = listOf("你好", "世界", "测试")
-        
+    fun candidateBarDisplaysCandidates() {
         composeTestRule.setContent {
             CandidateBar(
-                candidates = candidates,
-                inputText = "nihao",
-                isComposing = true,
+                state = CandidateBarState.ChineseCandidates(
+                    candidates = listOf("你好", "世界", "测试"),
+                    inputText = "nihao",
+                ),
                 visuals = CandidateBarVisuals(
                     backgroundColor = KeyboardBackground,
                     textColor = KeyTextColor,
@@ -82,7 +93,7 @@ class KeyboardViewTest {
     }
     
     @Test
-    fun `CandidateItem should display text and comment`() {
+    fun candidateItemDisplaysTextAndComment() {
         composeTestRule.setContent {
             CandidateItem(
                 text = "你好",

--- a/app/src/main/assets/rime/lua/t9_preedit.lua
+++ b/app/src/main/assets/rime/lua/t9_preedit.lua
@@ -6,7 +6,7 @@
 -- cand.comment 由 Kotlin onRightCandidateSelected 用于计算数字消费位数，
 -- 清空 comment 会导致候选词选择后定位错误。
 -- 候选注释的显示/隐藏由 UI 层 SettingsPreferences.showCandidateComments 控制。
-
+-- 废弃，已由 Kotlin 实现
 local function t9_preedit(input, env)
     local config = env.engine.schema.config
     local context = env.engine.context

--- a/app/src/main/assets/rime/t9_pinyin.schema.yaml
+++ b/app/src/main/assets/rime/t9_pinyin.schema.yaml
@@ -43,7 +43,6 @@ engine:
     - punct_translator
     - script_translator
   filters:
-    - lua_filter@*t9_preedit
     - lua_filter@*date_hint
     - uniquifier
 

--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -108,10 +108,10 @@ keyboard:
 
   # ── 按键阴影（可选，不设置则使用默认值）──
   # enabled:            是否启用阴影
-  # elevation:          阴影高度（dp，默认 1）
+  # elevation:          阴影高度（dp，默认 0.5）
   shadow:
     enabled: true
-    elevation: 1
+    elevation: 0.5
   qwerty:
     # ── 按键布局模式 ──
     # standard: 默认布局（主文字居中，下滑提示在底部）

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -257,12 +257,15 @@ class RimeEngine {
      * 是 T9 路径 updateUI 的首选查询接口，可替代多次独立 JNI 调用。
      */
     fun getComposition(): RimeComposition {
-        if (!isInitialized) return RimeComposition("", "", "", emptyArray(), false, false, false)
-        synchronized(rimeLock) {
-            if (!nativeHasSession() && !nativeCreateSession())
-                return RimeComposition("", "", "", emptyArray(), false, false, false)
-            return nativeGetComposition()
+        val t0 = System.nanoTime()
+        val result: RimeComposition = synchronized(rimeLock) {
+            nativeGetComposition()
         }
+        val elapsed = (System.nanoTime() - t0) / 1_000_000L
+        if (elapsed > 1) {
+            Log.d(TAG, "getComposition() took ${elapsed}ms (input='${result.input}')")
+        }
+        return result
     }
 
     fun selectCandidate(index: Int): Boolean {
@@ -324,11 +327,18 @@ class RimeEngine {
      * @return 是否设置成功
      */
     fun setInput(input: String): Boolean {
+        val t0 = System.nanoTime()
         if (!isInitialized) return false
+        var result = false
         synchronized(rimeLock) {
-            if (!nativeHasSession() && !nativeCreateSession()) return false
-            return nativeSetInput(input)
+            if (!nativeHasSession() && !nativeCreateSession()) return@synchronized
+            result = nativeSetInput(input)
         }
+        val elapsed = (System.nanoTime() - t0) / 1_000_000L
+        if (elapsed > 5) {
+            Log.d(TAG, "setInput('$input') took ${elapsed}ms")
+        }
+        return result
     }
 
     fun toggleAsciiMode(): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -36,6 +36,10 @@ class T9InputController(
     }
     // ── 响应式状态 ──
 
+    /** 推迟左侧候选区更新到下一帧，避免重组干扰触摸事件命中测试 */
+    private val candidateUpdater: android.os.Handler? =
+        try { android.os.Handler(android.os.Looper.getMainLooper()) } catch (_: Throwable) { null }
+
     /** 退格操作结果类型 */
     enum class DeleteResult {
         /** 已消费：删除了一个字符 */
@@ -51,7 +55,7 @@ class T9InputController(
     /** 发送给 RIME 的完整输入序列。
      *  格式：已确认拼音 + 分隔符(') + 数字 ...
      *  例如 "j'43"（5后分词确认j，再输入43）、"ji'482"（左侧选ji后继续输入） */
-    var inputBuffer: String by mutableStateOf("")
+    var inputBuffer: String = ""
         internal set
 
     /** 左侧候选区的音节选项列表 */
@@ -59,12 +63,10 @@ class T9InputController(
         private set
 
     /** 上次发送给 RIME 的输入（避免冗余调用） */
-    var lastRimeInput: String? by mutableStateOf(null)
-        private set
+    private var lastRimeInput: String? = null
 
     /** 左侧候选区是否锁定（分词后锁定，用户选择后解锁） */
-    var leftColumnLocked: Boolean by mutableStateOf(false)
-        private set
+    var leftColumnLocked: Boolean = false
 
     // ── 内部状态 ──
 
@@ -190,6 +192,7 @@ class T9InputController(
      * @param force 是否强制更新（用户主动选择时强制刷新）
      */
     fun updateCandidates(force: Boolean = false) {
+        val t0 = System.nanoTime()
         if (leftColumnLocked && !force) return
 
         val parts = parseInputBuffer(inputBuffer)
@@ -233,6 +236,10 @@ class T9InputController(
             cachedFirstOptions = emptyList()
             firstOptions = emptyList()
             leftColumnLocked = false
+        }
+        val elapsed = (System.nanoTime() - t0) / 1_000_000L
+        if (elapsed > 2) {
+            try { android.util.Log.d("T9InputCtrl", "updateCandidates took ${elapsed}ms buffer='${inputBuffer.take(20)}'") } catch (_: Throwable) { }
         }
     }
 
@@ -297,6 +304,7 @@ class T9InputController(
 
     /** 处理数字按键/分词键按下 */
     fun onDigitPressed(digit: String) {
+        val t0 = System.nanoTime()
         if (digit == "1") {
             // 分词键：将当前数字段转为拼音 + 分隔符，锁定左侧候选区。
             // 优先通过 RIME 候选 comment 反推最优首音节；失败时回退到贪婪最长匹配。
@@ -342,8 +350,12 @@ class T9InputController(
             inputBuffer += "'"
         }
         inputBuffer += digit
-        updateCandidates()
+        candidateUpdater?.post { updateCandidates() } ?: updateCandidates()
         sendToRime()
+        val elapsed = (System.nanoTime() - t0) / 1_000_000L
+        if (elapsed > 5) {
+            try { android.util.Log.d("T9InputCtrl", "onDigitPressed('$digit') took ${elapsed}ms, buffer='${inputBuffer.take(20)}'") } catch (_: Throwable) { }
+        }
     }
 
     /** 处理用户从左侧列选择音节 */

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9PreeditConverter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9PreeditConverter.kt
@@ -1,0 +1,79 @@
+package com.kingzcheung.xime.rime
+
+/**
+ * 将 T9 九键的 preedit 从数字序列转换为拼音显示（替代 lua_filter@*t9_preedit）。
+ *
+ * 例如 "54482" + comment "ji gua" → "jigua"
+ * "ji'43" + comment "ji kan" → "ji k"
+ * "5" + comment "le" → "l"
+ */
+fun convertT9PreeditToPinyin(preedit: String, firstCandidateComment: String): String {
+    if (preedit.isEmpty() || firstCandidateComment.isEmpty()) return preedit
+
+    val pinyinParts = firstCandidateComment.split(Regex("\\s+")).filter { it.isNotEmpty() }
+    if (pinyinParts.isEmpty()) return preedit
+
+    val hasDigit = preedit.any { it in '0'..'9' }
+    if (!hasDigit) return preedit
+
+    // 按字符类型拆分：分隔符、中文、非中文（数字/字母）各自独立成段
+    // 避免 partial commit 后 "公民7"（中文+数字无分隔符）被当成一整段
+    val inputParts = mutableListOf<String>()
+    val buf = StringBuilder()
+    var bufIsChinese: Boolean? = null
+
+    fun flushBuf() {
+        if (buf.isNotEmpty()) {
+            inputParts.add(buf.toString())
+            buf.clear()
+            bufIsChinese = null
+        }
+    }
+
+    for (char in preedit) {
+        if (char == ' ' || char == '\'') {
+            flushBuf()
+            inputParts.add(char.toString())
+        } else {
+            val isChinese = char >= '\u4E00' && char <= '\u9FFF'
+            if (bufIsChinese != null && bufIsChinese != isChinese) {
+                flushBuf()
+            }
+            buf.append(char)
+            bufIsChinese = isChinese
+        }
+    }
+    flushBuf()
+
+    var pi = 0
+    for (i in inputParts.indices) {
+        val part = inputParts[i]
+        when {
+            part == " " || part == "'" -> {
+                inputParts[i] = " "
+            }
+            part.all { it in '0'..'9' } -> {
+                if (pi < pinyinParts.size) {
+                    val py = pinyinParts[pi]
+                    when {
+                        i == inputParts.lastIndex && part.length == 1 -> {
+                            val prefix = py.take(2).lowercase()
+                            inputParts[i] = if (prefix in listOf("zh", "ch", "sh")) prefix
+                                else py.first().lowercase().toString()
+                        }
+                        inputParts.size == 1 && pinyinParts.size > 1 -> {
+                            inputParts[i] = pinyinParts.joinToString("")
+                        }
+                        else -> inputParts[i] = py.lowercase()
+                    }
+                    pi++
+                }
+            }
+            part.any { it >= '\u4E00' && it <= '\u9FFF' } -> {
+                // 中文 = 已提交文本，原样保留，不消耗拼音索引
+            }
+            else -> pi++
+        }
+    }
+    return inputParts.joinToString("")
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -979,23 +979,33 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                         SettingsPreferences.setFloatingOffsetY(this@XimeInputMethodService, s.floatingOffsetY, isLandscape)
                                     },
                                     onT9ReplaceFullPinyin = { pinyin ->
-                                        when {
-                                            pinyin == T9InputController.CLEAR_COMPOSITION_ONLY -> {
-                                                rimeEngine.clearComposition()
+                                        val t0 = System.nanoTime()
+                                        serviceScope.launch(keyProcessingDispatcher) {
+                                            when {
+                                                pinyin == T9InputController.CLEAR_COMPOSITION_ONLY -> {
+                                                    rimeEngine.clearComposition()
+                                                }
+                                                pinyin == T9InputController.CLEAR_ALL -> {
+                                                    t9PartialCommitTexts.clear()
+                                                    rimeEngine.setInput("")
+                                                    rimeEngine.clearComposition()
+                                                }
+                                                pinyin.isEmpty() -> {
+                                                    rimeEngine.clearComposition()
+                                                }
+                                                else -> {
+                                                    rimeEngine.setInput(pinyin)
+                                                }
                                             }
-                                            pinyin == T9InputController.CLEAR_ALL -> {
-                                                t9PartialCommitTexts.clear()
-                                                rimeEngine.setInput("")
-                                                rimeEngine.clearComposition()
-                                            }
-                                            pinyin.isEmpty() -> {
-                                                rimeEngine.clearComposition()
-                                            }
-                                            else -> {
-                                                rimeEngine.setInput(pinyin)
+                                            val composition = rimeEngine.getComposition()
+                                            withContext(Dispatchers.Main) {
+                                                val totalMs = (System.nanoTime() - t0) / 1_000_000L
+                                                if (totalMs > 10) {
+                                                    Log.d(TAG, "T9 replaceFullPinyin: '${pinyin.take(20)}' total=${totalMs}ms")
+                                                }
+                                                mainHandler.post { applyComposition(composition) }
                                             }
                                         }
-                                        updateUI()
                                     },
                                     onT9RightCommitUndone = { count ->
                                         currentInputConnection?.deleteSurroundingText(count, 0)
@@ -1160,7 +1170,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 postRimeJob {
                     rimeEngine.clearComposition()
                     withContext(Dispatchers.Main) {
-                        updateUI()
+                        mainHandler.post { updateUI() }
                     }
                 }
             }
@@ -1513,9 +1523,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
     
     private fun updateUI() {
-        // 一次性查询 RIME composition 全部状态，替代 getInput + getPreedit +
-        // getCandidatesWithComments + isAsciiMode + hasNextPage + hasPrevPage 的多次 JNI 调用。
-        val composition = rimeEngine.getComposition()
+        applyComposition(rimeEngine.getComposition())
+    }
+
+    private fun applyComposition(composition: com.kingzcheung.xime.rime.RimeComposition) {
         val inputText = composition.input
         val preeditText = composition.preedit
         val candidatesWithComments = composition.candidates.toList()
@@ -1537,8 +1548,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             candidatesWithComments.map { it.text } to candidatesWithComments.map { it.comment }
         }
 
-        // 非 T9 方案（如双拼）使用原始输入文本显示，
-        // 避免显示 rime speller 展开后的编码（如双拼 i → ch）
         val isT9Schema = isT9Schema(uiState.value.currentSchemaId)
         val displayText = if (isT9Schema) {
             val preeditDisplay = if (preeditText.isNotEmpty()) preeditText else inputText
@@ -1546,8 +1555,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         } else {
             inputText
         }
-        // T9 模式下，只要还有 partial commit 未最终上屏，就应保持 composing 状态，
-        // 以便预编辑区域继续显示已提交的候选文本（如场景 6 BS5 的"策"）
         val isComposing = inputText.isNotEmpty() || (isT9Schema && t9PartialCommitTexts.isNotEmpty())
 
         candidateState.value = candidateState.value.copy(
@@ -1563,8 +1570,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         )
         uiState.value = uiState.value.copy(isAsciiMode = isAsciiMode)
 
-        // 悬浮候选栏通过 Compose 内联显示（见 onCreateInputView），拖拽由 pointerInput 处理
-        
         if (pendingEnglish.isNotEmpty()) {
             serviceScope.launch {
                 val candidates = predictionManager.getEnglishAssociations(pendingEnglish, PredictionManager.MAX_ASSOCIATION_COUNT)

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -83,6 +83,7 @@ import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.rime.T9InputController
+import com.kingzcheung.xime.rime.convertT9PreeditToPinyin
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SettingsPreferences
@@ -1550,8 +1551,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
 
         val isT9Schema = isT9Schema(uiState.value.currentSchemaId)
         val displayText = if (isT9Schema) {
-            val preeditDisplay = if (preeditText.isNotEmpty()) preeditText else inputText
-            PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, preeditDisplay)
+            val rawPreedit = if (preeditText.isNotEmpty()) preeditText else inputText
+            val convertedPreedit = convertT9PreeditToPinyin(rawPreedit, candidatesWithComments.firstOrNull()?.comment ?: "")
+            PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, convertedPreedit)
         } else {
             inputText
         }
@@ -1605,8 +1607,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         // 避免显示 rime speller 展开后的编码（如双拼 i → ch）
         val isT9Schema = isT9Schema(uiState.value.currentSchemaId)
         val displayText = if (isT9Schema) {
-            val preeditDisplay = if (result.preeditText.isNotEmpty()) result.preeditText else result.inputText
-            PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, preeditDisplay)
+            val rawPreedit = if (result.preeditText.isNotEmpty()) result.preeditText else result.inputText
+            val convertedPreedit = convertT9PreeditToPinyin(rawPreedit, candidatesWithComments.firstOrNull()?.comment ?: "")
+            PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, convertedPreedit)
         } else {
             result.inputText
         }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -222,7 +222,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 voiceAmplitude = 0f
             )
             isTrackingVoiceButtons = false
-            keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.FULL)
+            keyboardViewModel.exitVoice()
         }
     )
     
@@ -649,7 +649,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     voiceButtonState = VoiceButtonState(),
                     voiceRecognizedText = ""
                 )
-                keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.FULL)
+                keyboardViewModel.exitVoice()
                 isTrackingVoiceButtons = false
             }
         )
@@ -914,7 +914,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                             voiceRecognizedText = ""
                                         )
                                         if (enabled) {
-                                            keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.VOICE)
+                                            keyboardViewModel.enterVoice()
                                             feedbackManager.performVibration()
                                             isTrackingVoiceButtons = true
                                             keyboardContainer.enableVoiceButtonTracking()
@@ -922,7 +922,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                             voiceRecognitionHandler.startRecognition()
                                             Log.d("VoiceButtons", "Speech recognition starting...")
                                         } else {
-            keyboardViewModel.switchMain(com.kingzcheung.xime.keyboard.MainType.FULL)
+                                            keyboardViewModel.exitVoice()
                                             isTrackingVoiceButtons = false
                                         }
                                     },

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
@@ -46,6 +46,7 @@ fun CommonSymbolKeyboardLayout(
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val row2Symbols = if (isAsciiMode) {
         listOf("@", "#", "$", "&", "_", "-", "+", "(", ")", "/")
@@ -119,6 +120,7 @@ fun CommonSymbolKeyboardLayout(
                 onKeyPressDown = onKeyPressDown,
                 suppressCursorMove = suppressCursorMove,
                 onSwipeStateChange = { state, bounds -> processSwipeState(state, bounds) },
+                specialKeyTextColor = specialKeyTextColor,
             )
         } else {
             CompositionLocalProvider(
@@ -182,7 +184,7 @@ fun CommonSymbolKeyboardLayout(
                         text = "符号",
                         onClick = { onKeyPress("symbol") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.3f),
                         onPress = { onKeyPressDown?.invoke("symbol") },
                         shadowEnabled = shadowEnabled,
@@ -208,7 +210,7 @@ fun CommonSymbolKeyboardLayout(
                         icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                         onClick = { onKeyPress("delete") },
                         backgroundColor = specialKeyBackgroundColor,
-                        iconColor = keyTextColor,
+                        iconColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         swipeText = "清空",
                         onSwipe = { onKeyPress("clear_composition") },
@@ -237,7 +239,7 @@ fun CommonSymbolKeyboardLayout(
                         text = "返回",
                         onClick = { onKeyPress("abc") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         onPress = { onKeyPressDown?.invoke("abc") },
                         shadowEnabled = shadowEnabled,
@@ -249,7 +251,7 @@ fun CommonSymbolKeyboardLayout(
                         text = "123",
                         onClick = { onKeyPress("number") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         onPress = { onKeyPressDown?.invoke("number") },
                         shadowEnabled = shadowEnabled,
@@ -297,7 +299,7 @@ fun CommonSymbolKeyboardLayout(
                         text = "确定",
                         onClick = { onKeyPress("enter") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         onPress = { onKeyPressDown?.invoke("enter") },
                         shadowEnabled = shadowEnabled,
@@ -329,6 +331,7 @@ private fun CommonSymbolLandscapeContent(
     onKeyPressDown: ((String) -> Unit)?,
     suppressCursorMove: androidx.compose.runtime.MutableState<Boolean>,
     onSwipeStateChange: (SwipeState, Rect) -> Unit,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val keyVisualPadding = PaddingValues(horizontal = 1.dp, vertical = 2.dp)
 
@@ -381,7 +384,7 @@ private fun CommonSymbolLandscapeContent(
                         text = "符号",
                         onClick = { onKeyPress("symbol") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.3f),
                         onPress = { onKeyPressDown?.invoke("symbol") },
                         shadowEnabled = shadowEnabled,
@@ -409,7 +412,7 @@ private fun CommonSymbolLandscapeContent(
                         text = "返回",
                         onClick = { onKeyPress("abc") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         onPress = { onKeyPressDown?.invoke("abc") },
                         shadowEnabled = shadowEnabled,
@@ -421,7 +424,7 @@ private fun CommonSymbolLandscapeContent(
                         text = "123",
                         onClick = { onKeyPress("number") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         onPress = { onKeyPressDown?.invoke("number") },
                         shadowEnabled = shadowEnabled,
@@ -529,7 +532,7 @@ private fun CommonSymbolLandscapeContent(
                         icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                         onClick = { onKeyPress("delete") },
                         backgroundColor = specialKeyBackgroundColor,
-                        iconColor = keyTextColor,
+                        iconColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f),
                         swipeText = "清空",
                         onSwipe = { onKeyPress("clear_composition") },
@@ -575,7 +578,7 @@ private fun CommonSymbolLandscapeContent(
                         text = "确定",
                         onClick = { onKeyPress("enter") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1.2f),
                         onPress = { onKeyPressDown?.invoke("enter") },
                         shadowEnabled = shadowEnabled,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EnglishKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EnglishKeyboardLayout.kt
@@ -64,6 +64,7 @@ fun EnglishKeyboardLayout(
     shadowShapeRadius: Dp = 8.dp,
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val suppressCursorMove = LocalSuppressCursorMove.current
     val row1 = listOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p")
@@ -129,6 +130,7 @@ fun EnglishKeyboardLayout(
                 shadowElevation = shadowElevation,
                 shadowShapeRadius = shadowShapeRadius,
                 onKeyPressDown = onKeyPressDown,
+                specialKeyTextColor = specialKeyTextColor,
             )
         } else {
             Column(
@@ -212,7 +214,7 @@ fun EnglishKeyboardLayout(
                             icon = rememberVectorPainter(Icons.TwoTone.KeyboardCapslock),
                             onClick = { onKeyPress("shift") },
                             backgroundColor = specialKeyBackgroundColor,
-                            iconColor = keyTextColor,
+                            iconColor = specialKeyTextColor,
                             modifier = Modifier.weight(1.4f).fillMaxHeight(),
                             isHighlighted = isShifted,
                             onPress = { onKeyPressDown?.invoke("shift") },
@@ -249,7 +251,7 @@ fun EnglishKeyboardLayout(
                             icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                             onClick = { onKeyPress("delete") },
                             backgroundColor = specialKeyBackgroundColor,
-                            iconColor = keyTextColor,
+                            iconColor = specialKeyTextColor,
                             modifier = Modifier.weight(1.4f).fillMaxHeight(),
                             swipeText = "清空",
                             onSwipe = { onKeyPress("clear_composition") },
@@ -279,7 +281,7 @@ fun EnglishKeyboardLayout(
                             onClick = { onKeyPress("mode_change") },
                             onLongClick = { onKeyPress("mode_change_symbol") },
                             backgroundColor = specialKeyBackgroundColor,
-                            textColor = keyTextColor,
+                            textColor = specialKeyTextColor,
                             modifier = Modifier.weight(1.2f),
                             onPress = { onKeyPressDown?.invoke("mode_change") },
                             shadowEnabled = shadowEnabled,
@@ -321,7 +323,7 @@ fun EnglishKeyboardLayout(
                             text = "英",
                             onClick = { onKeyPress("ime_switch") },
                             backgroundColor = specialKeyBackgroundColor,
-                            textColor = keyTextColor,
+                            textColor = specialKeyTextColor,
                             modifier = Modifier.weight(0.8f),
                             onPress = { onKeyPressDown?.invoke("ime_switch") },
                             shadowEnabled = shadowEnabled,
@@ -334,7 +336,7 @@ fun EnglishKeyboardLayout(
                             text = enterKeyText,
                             onClick = { onKeyPress("enter") },
                             backgroundColor = specialKeyBackgroundColor,
-                            textColor = keyTextColor,
+                            textColor = specialKeyTextColor,
                             modifier = Modifier.weight(1.2f),
                             onPress = { onKeyPressDown?.invoke("enter") },
                             shadowEnabled = shadowEnabled,
@@ -365,6 +367,7 @@ private fun LandscapeEnglishKeyboardContent(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
     onKeyPressDown: ((String) -> Unit)?,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val staggerStep = 10.dp
 
@@ -438,7 +441,7 @@ private fun LandscapeEnglishKeyboardContent(
                     icon = rememberVectorPainter(Icons.Default.EmojiEmotions),
                     onClick = { onKeyPress("emoji") },
                     backgroundColor = specialKeyBackgroundColor,
-                    iconColor = keyTextColor,
+                    iconColor = specialKeyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("emoji") },
                     shadowEnabled = shadowEnabled,
@@ -540,7 +543,7 @@ private fun LandscapeEnglishKeyboardContent(
                     icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                     onClick = { onKeyPress("delete") },
                     backgroundColor = specialKeyBackgroundColor,
-                    iconColor = keyTextColor,
+                    iconColor = specialKeyTextColor,
                     modifier = Modifier.width(48.dp).fillMaxHeight(),
                     onPress = { onKeyPressDown?.invoke("delete") },
                     shadowEnabled = shadowEnabled,
@@ -567,7 +570,7 @@ private fun LandscapeEnglishKeyboardContent(
                     onClick = { onKeyPress("mode_change") },
                     onLongClick = { onKeyPress("mode_change_symbol") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("mode_change") },
                     shadowEnabled = shadowEnabled,
@@ -578,7 +581,7 @@ private fun LandscapeEnglishKeyboardContent(
                     text = "英",
                     onClick = { onKeyPress("ime_switch") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(0.8f),
                     onPress = { onKeyPressDown?.invoke("ime_switch") },
                     shadowEnabled = shadowEnabled,
@@ -589,7 +592,7 @@ private fun LandscapeEnglishKeyboardContent(
                     text = enterKeyText,
                     onClick = { onKeyPress("enter") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("enter") },
                     shadowEnabled = shadowEnabled,
@@ -618,7 +621,7 @@ private fun SplitSpaceKey(
 ) {
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
 
     Box(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EnglishKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/EnglishKeyboardLayout.kt
@@ -28,13 +28,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -619,16 +622,28 @@ private fun SplitSpaceKey(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
 ) {
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val density = LocalDensity.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
 
     Box(
         modifier = modifier
             .fillMaxHeight()
             .then(shadowModifier)
-            .clip(shadowShape)
+            .clip(RoundedCornerShape(shadowShapeRadius))
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HandwritingKeyboardLayout.kt
@@ -58,6 +58,7 @@ fun HandwritingKeyboardLayout(
     bottomPaddingDp: Int = 18,
     modifier: Modifier = Modifier,
     clearSignal: Int = 0,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val strokes = remember { mutableStateListOf<List<StrokePoint>>() }
     var currentStrokePoints by remember { mutableStateOf<List<StrokePoint>>(emptyList()) }
@@ -137,6 +138,7 @@ fun HandwritingKeyboardLayout(
             ).forEachIndexed { i, (text, action) ->
                 val idx = i + 5
                 val bg = if (text == "符号" || text == "换行") specialKeyBackgroundColor else keyBackgroundColor
+                val txtColor = if (text == "符号" || text == "换行") specialKeyTextColor else keyTextColor
                 val w = when (text) {
                     "空格" -> 1.8f
                     "123", "ABC" -> 0.7f
@@ -148,7 +150,7 @@ fun HandwritingKeyboardLayout(
                         .background(if (pressedButton == idx) Color(0x40000000) else bg),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(text, color = keyTextColor, fontSize = 16.sp,
+                    Text(text, color = txtColor, fontSize = 16.sp,
                         fontWeight = if (text.length <= 1) FontWeight.Normal else FontWeight.Medium,
                         textAlign = TextAlign.Center)
                 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -31,7 +31,9 @@ import com.kingzcheung.xime.settings.ButtonLayout
 import com.kingzcheung.xime.util.CharInfo
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
@@ -81,6 +83,25 @@ data class SwipeState(
     val longPressDrawableIds: List<Int> = emptyList(),
 )
 
+private val shadowColorCache = HashMap<Color, Color>()
+
+internal fun crispShadowColor(backgroundColor: Color): Color {
+    return shadowColorCache.getOrPut(backgroundColor) {
+        val r = backgroundColor.red
+        val g = backgroundColor.green
+        val b = backgroundColor.blue
+        val maxChroma = maxOf(r, g, b) - minOf(r, g, b)
+        val luminance = 0.299f * r + 0.587f * g + 0.114f * b
+        if (maxChroma > 0.05f) {
+            Color(r * 0.95f, g * 0.95f, b * 0.95f, backgroundColor.alpha)
+        } else if (luminance > 0.5f) {
+            Color.Black.copy(alpha = 0.10f)
+        } else {
+            Color.White.copy(alpha = 0.12f)
+        }
+    }
+}
+
 @Composable
 fun KeyButton(
     text: String,
@@ -125,9 +146,20 @@ fun KeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -374,9 +406,20 @@ fun SwipeableKeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -790,10 +833,22 @@ fun IconKeyButton(
     shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -922,9 +977,20 @@ fun SwipeableIconKeyButton(
         }
     }
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -127,7 +127,7 @@ fun KeyButton(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -376,7 +376,7 @@ fun SwipeableKeyButton(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -793,7 +793,7 @@ fun IconKeyButton(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -924,7 +924,7 @@ fun SwipeableIconKeyButton(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -257,7 +257,7 @@ fun KeyButton(
                         }
                     )
                 }
-                .pointerInput(currentOnLongClick) {
+                .pointerInput(currentOnLongClick != null) {
                     if (currentOnLongClick == null) {
                         detectTapGestures(
                             onPress = {
@@ -512,7 +512,7 @@ fun SwipeableKeyButton(
                     }
                 )
             }
-            .pointerInput(currentLongPressItems) {
+            .pointerInput(text, currentLongPressItems.isNullOrEmpty()) {
                 if (currentLongPressItems.isNullOrEmpty()) {
                     detectTapGestures(
                         onPress = {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -125,11 +125,12 @@ fun KeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
     
     // 辅助函数：生成更深的颜色（混合黑色）
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
@@ -373,11 +374,12 @@ fun SwipeableKeyButton(
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
     val context = LocalContext.current
     val chaiPuaFontFamily = remember { FontFamily(Font("ChaiPUA-0.2.7-snow.ttf", context.assets)) }
 
@@ -920,11 +922,12 @@ fun SwipeableIconKeyButton(
         }
     }
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
     
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
         return Color(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -127,6 +127,8 @@ fun KeyboardLayout(
     val keyTextColor = if (uiState.isDarkTheme) longToColor(kbColors.keyTextColorDark) else longToColor(kbColors.keyTextColor)
     val specialKeyBackgroundColor = if (uiState.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
+    val specialKeyTextColor = if (uiState.isDarkTheme) Color.White
+        else KeyboardThemes.getAccentColor(uiState.themeId, false)
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
     val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
     val shadowEnabled = kbShadow.enabled
@@ -383,7 +385,7 @@ fun KeyboardLayout(
                                 onKeyPress = onKeyPress,
                                 onKeyPressDown = onKeyPressDown,
                                 backgroundColor = specialKeyBackgroundColor,
-                                iconColor = keyTextColor,
+                                iconColor = specialKeyTextColor,
                                 modifier = Modifier
                                     .padding(2.dp,4.dp)
                                     .weight(1.4f)
@@ -496,7 +498,7 @@ fun KeyboardLayout(
                                 icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                                 onClick = { onKeyPress("delete") },
                                 backgroundColor = specialKeyBackgroundColor,
-                                iconColor = keyTextColor,
+                                iconColor = specialKeyTextColor,
                                 modifier = Modifier
                                     .padding(2.dp,0.dp)
                                     .weight(1.4f)
@@ -546,7 +548,7 @@ fun KeyboardLayout(
                                 text = "?123",
                                 onClick = { onKeyPress("mode_change") },
                                 backgroundColor = specialKeyBackgroundColor,
-                                textColor = keyTextColor,
+                                textColor = specialKeyTextColor,
                                 modifier = Modifier.weight(1.2f),
                                 onPress = { onKeyPressDown?.invoke("mode_change") },
                                 onRelease = { onKeyRelease?.invoke("mode_change") },
@@ -808,7 +810,7 @@ fun KeyboardLayout(
                                 text = enterKeyText,
                                 onClick = { onKeyPress("enter") },
                                 backgroundColor = specialKeyBackgroundColor,
-                                textColor = keyTextColor,
+                                textColor = specialKeyTextColor,
                                 modifier = Modifier.weight(1.2f),
                                 onPress = { onKeyPressDown?.invoke("enter") },
                                 onRelease = { onKeyRelease?.invoke("enter") },
@@ -1042,7 +1044,7 @@ private fun ShiftCapsKeyButton(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -1164,6 +1166,8 @@ private fun LandscapeKeyboardContent(
     val keyTextColor = if (uiState.isDarkTheme) longToColor(kbColors.keyTextColorDark) else longToColor(kbColors.keyTextColor)
     val specialKeyBackgroundColor = if (uiState.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
+    val specialKeyTextColor = if (uiState.isDarkTheme) Color.White
+        else KeyboardThemes.getAccentColor(uiState.themeId, false)
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
     val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
     val shadowEnabled = kbShadow.enabled
@@ -1304,7 +1308,7 @@ private fun LandscapeKeyboardContent(
                     onKeyPress = onKeyPress,
                     onKeyPressDown = onKeyPressDown,
                     backgroundColor = specialKeyBackgroundColor,
-                    iconColor = keyTextColor,
+                    iconColor = specialKeyTextColor,
                     modifier = Modifier.padding(1.dp,2.dp).weight(1.2f),
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
@@ -1459,7 +1463,7 @@ private fun LandscapeKeyboardContent(
                     icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                     onClick = { onKeyPress("delete") },
                     backgroundColor = specialKeyBackgroundColor,
-                    iconColor = keyTextColor,
+                    iconColor = specialKeyTextColor,
                     modifier = Modifier
                         .padding(1.dp)
                         .width(48.dp)
@@ -1499,7 +1503,7 @@ private fun LandscapeKeyboardContent(
                     text = "?123",
                     onClick = { onKeyPress("mode_change") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("mode_change") },
                     onRelease = { onKeyRelease?.invoke("mode_change") },
@@ -1566,7 +1570,7 @@ private fun LandscapeKeyboardContent(
                     text = enterKeyText,
                     onClick = { onKeyPress("enter") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("enter") },
                     onRelease = { onKeyRelease?.invoke("enter") },
@@ -1642,7 +1646,7 @@ fun SwipeableKeyButtonLandscape(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -2036,7 +2040,7 @@ private fun SplitSpaceKey(
 ) {
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -2104,7 +2108,7 @@ private fun SpaceKey(
     val context = LocalContext.current
 
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
         else Modifier
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -3,7 +3,6 @@ package com.kingzcheung.xime.ui.keyboard
 import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -54,8 +53,9 @@ import com.kingzcheung.xime.keyboard.GestureAction
 /** 半角 → 全角标点映射，中文模式下键帽显示用。提交仍走半角由 Rime 处理。 */
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
@@ -1041,10 +1041,22 @@ private fun ShiftCapsKeyButton(
     shadowShapeRadius: Dp = 8.dp,
 ) {
     var isPressed by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -1644,9 +1656,20 @@ fun SwipeableKeyButtonLandscape(
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
     val bubbleShowThresholdDown = swipeDownThreshold * 0.3f
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -2038,9 +2061,21 @@ private fun SplitSpaceKey(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
 ) {
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val density = LocalDensity.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
@@ -2107,9 +2142,21 @@ private fun SpaceKey(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
-        else Modifier
+    val density = LocalDensity.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, keyBackgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(keyBackgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
 
     Box(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -1,5 +1,6 @@
 package com.kingzcheung.xime.ui.keyboard
 
+import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -916,7 +917,7 @@ fun KeyboardRowWithConfig(
     config: KeyboardRowConfig,
     isShifted: Boolean,
     isAsciiMode: Boolean = false,
-    modifier: Modifier = Modifier,
+    @SuppressLint("ModifierParameter") modifier: Modifier = Modifier,
     onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
     onKeyPressDown: ((String) -> Unit)? = null,
     onKeyRelease: ((String) -> Unit)? = null,
@@ -1039,19 +1040,19 @@ private fun ShiftCapsKeyButton(
 ) {
     var isPressed by remember { mutableStateOf(false) }
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
 
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
         return Color(
             red = (color.red * (1 - factor)).coerceIn(0f, 1f),
             green = (color.green * (1 - factor)).coerceIn(0f, 1f),
             blue = (color.blue * (1 - factor)).coerceIn(0f, 1f),
-            alpha = color.alpha
-        )
+            alpha = color.alpha)
     }
 
     Box(
@@ -1080,7 +1081,7 @@ private fun ShiftCapsKeyButton(
                 }
             }
             .then(shadowModifier)
-            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
+            .clip(keyClipShape)
             .background(
                 if (isPressed) darkenColor(backgroundColor, 0.1f)
                 else if (shiftMode == ShiftMode.CAPS) darkenColor(backgroundColor, 0.2f)
@@ -1639,11 +1640,12 @@ fun SwipeableKeyButtonLandscape(
     val bubbleShowThresholdUp = swipeUpThreshold * 0.3f
     val bubbleShowThresholdDown = swipeDownThreshold * 0.3f
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
 
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
         return Color(
@@ -1854,11 +1856,10 @@ fun SwipeableKeyButtonLandscape(
             }
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
+            .clip(keyClipShape)
             .background(if (isPressed) darkenColor(backgroundColor) else backgroundColor),
         contentAlignment = Alignment.TopStart
     ) {
-
 
         Box(
             modifier = Modifier.fillMaxSize(),
@@ -2033,18 +2034,19 @@ private fun SplitSpaceKey(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
 ) {
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
 
     Box(
         modifier = modifier
             .fillMaxHeight()
             .padding(LocalKeyVisualPadding.current)
             .then(shadowModifier)
-            .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
+            .clip(keyClipShape)
             .background(backgroundColor)
             .clickable(
                 interactionSource = null,
@@ -2101,9 +2103,8 @@ private fun SpaceKey(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    val keyCornerRadius = LocalKeyCornerRadius.current
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyCornerRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(keyCornerRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
         else Modifier
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -1687,7 +1687,7 @@ fun SwipeableKeyButtonLandscape(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth()
-            .pointerInput(currentLongPressItems, currentOnLongPressSelect) {
+            .pointerInput(currentText, currentLongPressItems.isNullOrEmpty(), currentOnLongPressSelect != null) {
                 if (currentLongPressItems.isNullOrEmpty() || currentOnLongPressSelect == null) {
                     detectTapGestures(
                         onPress = {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
@@ -36,6 +36,8 @@ fun KeyboardLayoutScreen(
     val keyTextColor = if (uiState.isDarkTheme) longToColor(kbColors.keyTextColorDark) else longToColor(kbColors.keyTextColor)
     val specialKeyBgColor = if (uiState.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
+    val specialKeyTextColor = if (uiState.isDarkTheme) Color.White
+        else KeyboardThemes.getAccentColor(uiState.themeId, false)
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
     val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
 
@@ -130,6 +132,7 @@ fun KeyboardLayoutScreen(
                 modifier = modifier,
                 onKeyPressDown = callbacks.onKeyPressDown,
                 isFloatingMode = uiState.isFloatingMode,
+                specialKeyTextColor = specialKeyTextColor,
             )
         }
 
@@ -148,6 +151,7 @@ fun KeyboardLayoutScreen(
                 modifier = modifier,
                 onKeyPressDown = callbacks.onKeyPressDown,
                 isFloatingMode = uiState.isFloatingMode,
+                specialKeyTextColor = specialKeyTextColor,
             )
         }
 
@@ -165,6 +169,7 @@ fun KeyboardLayoutScreen(
                 modifier = modifier,
                 onKeyPressDown = callbacks.onKeyPressDown,
                 isFloatingMode = uiState.isFloatingMode,
+                specialKeyTextColor = specialKeyTextColor,
             )
         }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -140,6 +140,8 @@ fun KeyboardView(
     val specialKeyBgColor = if (state.isDarkTheme) kbColors.specialKeyBgColorDark?.let { longToColor(it) }
         ?: themeSpecialKeyColor
         else kbColors.specialKeyBgColor?.let { longToColor(it) } ?: themeSpecialKeyColor
+    val specialKeyTextColor = if (state.isDarkTheme) androidx.compose.ui.graphics.Color.White
+        else KeyboardThemes.getAccentColor(state.themeId, false)
     val candidateBarBg = if (state.isDarkTheme) longToColor(kbColors.candidateBarBgColorDark)
         else longToColor(kbColors.candidateBarBgColor)
     val candidateTextColor = if (state.isDarkTheme) longToColor(kbColors.candidateTextColorDark)
@@ -574,6 +576,7 @@ fun KeyboardView(
                             keyBackgroundColor = keyBgColor,
                             keyTextColor = keyTextColor,
                             specialKeyBackgroundColor = specialKeyBgColor,
+                            specialKeyTextColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
                         )
                         if (state.keyboardBottomPaddingDp > 0) {
@@ -643,6 +646,7 @@ fun KeyboardView(
                         keyCornerRadius = kbKey.cornerRadius.dp,
                         onKeyPressDown = callbacks.onKeyPressDown,
                         isFloatingMode = state.isFloatingMode,
+                        specialKeyTextColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f).fillMaxWidth()
                     )
 
@@ -667,6 +671,7 @@ fun KeyboardView(
                         keyCornerRadius = kbKey.cornerRadius.dp,
                         onKeyPressDown = callbacks.onKeyPressDown,
                         isFloatingMode = state.isFloatingMode,
+                        specialKeyTextColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f).fillMaxWidth()
                     )
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -251,7 +251,7 @@ private fun NumberRows(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f),
+                .weight(0.9f),
         ) {
             Row(
                 modifier = Modifier
@@ -308,7 +308,7 @@ private fun NumberRows(
                 Column(
                     modifier = Modifier
                         .fillMaxHeight()
-                        .weight(3f),
+                        .weight(3.2f),
                 ) {
                     Row(
                         modifier = Modifier
@@ -429,7 +429,7 @@ private fun NumberRows(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .weight(0.9f),
                 ) {
                     SwipeableIconKeyButton(
                         icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -63,6 +63,7 @@ fun NumberKeyboardLayout(
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
+    specialKeyTextColor: Color = Color.White,
 ) {
 
     val configuration = LocalConfiguration.current
@@ -163,6 +164,7 @@ fun NumberKeyboardLayout(
                         shadowShapeRadius = shadowShapeRadius,
                         onKeyPressDown = onKeyPressDown,
                         compactMode = true,
+                        specialKeyTextColor = specialKeyTextColor,
                         onSwipeStateChange = { state, bounds ->
                             val newState = if (state.isSwipeDown && state.swipeText != null) {
                                 state.copy(charInfos = SubcharHelper.parseSwipeDownText(state.swipeText))
@@ -200,6 +202,7 @@ fun NumberKeyboardLayout(
                     shadowElevation = shadowElevation,
                     shadowShapeRadius = shadowShapeRadius,
                     onKeyPressDown = onKeyPressDown,
+                    specialKeyTextColor = specialKeyTextColor,
                     onSwipeStateChange = { state, bounds ->
                         val newState = if (state.isSwipeDown && state.swipeText != null) {
                             state.copy(charInfos = SubcharHelper.parseSwipeDownText(state.swipeText))
@@ -232,6 +235,7 @@ private fun NumberRows(
     onKeyPressDown: ((String) -> Unit)? = null,
     onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
     compactMode: Boolean = false,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val symFontSize = if (compactMode) 14.sp else 18.sp
     val keyFontSize = if (compactMode) 16.sp else androidx.compose.ui.unit.TextUnit.Unspecified
@@ -290,7 +294,7 @@ private fun NumberRows(
                             icon = rememberVectorPainter(Icons.AutoMirrored.Filled.ArrowBack),
                             onClick = { onKeyPress("abc") },
                             backgroundColor = specialKeyBackgroundColor,
-                            iconColor = keyTextColor,
+                            iconColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("abc") },
                             shadowEnabled = shadowEnabled,
@@ -386,7 +390,7 @@ private fun NumberRows(
                             text = "符号",
                             onClick = { onKeyPress("symbol") },
                             backgroundColor = specialKeyBackgroundColor,
-                            textColor = keyTextColor,
+                            textColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("symbol") },
                             shadowEnabled = shadowEnabled,
@@ -431,7 +435,7 @@ private fun NumberRows(
                         icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                         onClick = { onKeyPress("delete") },
                         backgroundColor = specialKeyBackgroundColor,
-                        iconColor = keyTextColor,
+                        iconColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f),
                         swipeText = "清空",
                         onSwipe = { onKeyPress("clear_composition") },
@@ -455,7 +459,7 @@ private fun NumberRows(
                         text = "空格",
                         onClick = { onKeyPress("space") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("space") },
                         shadowEnabled = shadowEnabled,
@@ -467,7 +471,7 @@ private fun NumberRows(
                         icon = rememberVectorPainter(Icons.Default.EmojiEmotions),
                         onClick = { onKeyPress("emoji") },
                         backgroundColor = specialKeyBackgroundColor,
-                        iconColor = keyTextColor,
+                        iconColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("emoji") },
                         shadowEnabled = shadowEnabled,
@@ -478,7 +482,7 @@ private fun NumberRows(
                         text = "确定",
                         onClick = { onKeyPress("enter") },
                         backgroundColor = specialKeyBackgroundColor,
-                        textColor = keyTextColor,
+                        textColor = specialKeyTextColor,
                         modifier = Modifier.weight(1f),
                         onPress = { onKeyPressDown?.invoke("enter") },
                         shadowEnabled = shadowEnabled,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -242,16 +242,17 @@ private fun NumberRows(
     val ctrlFontSize = if (compactMode) 12.sp else androidx.compose.ui.unit.TextUnit.Unspecified
     val suppressCursorMove = LocalSuppressCursorMove.current
     val symbols = listOf("+", "-", "*", "/")
-    Column(
+    Row(
         modifier = Modifier
-            .fillMaxWidth()
-            .fillMaxHeight()
-            .padding(horizontal = 2.dp),
+            .fillMaxSize()
+            .padding(start = if (compactMode) 0.dp else 4.dp, end = if (compactMode) 0.dp else 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(if (compactMode) 2.dp else 4.dp)
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(0.9f),
+            verticalArrangement = Arrangement.spacedBy(if (compactMode) 2.dp else 4.dp)
         ) {
             Row(
                 modifier = Modifier

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
@@ -22,9 +22,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -50,14 +53,27 @@ fun SpaceKeyButton(
     var isPressed by remember { mutableStateOf(false) }
     val longPressTimeout = 400L
     val scope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
+    }
     
     Box(
         modifier = modifier
             .height((44 * LocalStretchFactor.current).dp)
-            .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
-                else Modifier
-            )
+            .then(shadowModifier)
             .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(
                 if (isPressed) backgroundColor.copy(alpha = 0.7f)

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
@@ -55,7 +55,7 @@ fun SpaceKeyButton(
         modifier = modifier
             .height((44 * LocalStretchFactor.current).dp)
             .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
                 else Modifier
             )
             .clip(RoundedCornerShape(LocalKeyCornerRadius.current))

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/SpaceKeyButton.kt
@@ -55,7 +55,7 @@ fun SpaceKeyButton(
         modifier = modifier
             .height((44 * LocalStretchFactor.current).dp)
             .then(
-                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(LocalKeyCornerRadius.current), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
+                if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x80000000), spotColor = Color(0x80000000))
                 else Modifier
             )
             .clip(RoundedCornerShape(LocalKeyCornerRadius.current))

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
@@ -67,6 +67,7 @@ fun StrokeKeyboardLayout(
     modifier: Modifier = Modifier,
     onKeyPressDown: ((String) -> Unit)? = null,
     isFloatingMode: Boolean = false,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val configuration = LocalConfiguration.current
     val isLandscape =
@@ -155,6 +156,7 @@ fun StrokeKeyboardLayout(
                         shadowElevation = shadowElevation,
                         shadowShapeRadius = shadowShapeRadius,
                         onKeyPressDown = onKeyPressDown,
+                        specialKeyTextColor = specialKeyTextColor,
                         onSwipeStateChange = { state, bounds ->
                             val newState = if (state.isSwipeDown && state.swipeText != null) {
                                 state.copy(charInfos = SubcharHelper.parseSwipeDownText(state.swipeText))
@@ -229,7 +231,8 @@ private fun StrokeRows(
     shadowElevation: Dp = 1.dp,
     shadowShapeRadius: Dp = 8.dp,
     onKeyPressDown: ((String) -> Unit)? = null,
-    onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null
+    onSwipeStateChange: ((SwipeState, Rect) -> Unit)? = null,
+    specialKeyTextColor: Color = Color.White,
 ) {
     val suppressCursorMove = LocalSuppressCursorMove.current
     val symbols = listOf("。", "？", "！", "~")
@@ -298,7 +301,7 @@ private fun StrokeRows(
                             icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                             onClick = { onKeyPress("delete") },
                             backgroundColor = specialKeyBackgroundColor,
-                            iconColor = keyTextColor,
+                            iconColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
                             swipeText = "清空",
                             onSwipe = { onKeyPress("clear_composition") },
@@ -356,7 +359,7 @@ private fun StrokeRows(
                             text = "换行",
                             onClick = { onKeyPress("enter") },
                             backgroundColor = specialKeyBackgroundColor,
-                            textColor = keyTextColor,
+                            textColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("enter") },
                             shadowEnabled = shadowEnabled,
@@ -415,7 +418,7 @@ private fun StrokeRows(
                             icon = rememberVectorPainter(Icons.Default.EmojiEmotions),
                             onClick = { onKeyPress("emoji") },
                             backgroundColor = specialKeyBackgroundColor,
-                            iconColor = keyTextColor,
+                            iconColor = specialKeyTextColor,
                             modifier = Modifier.weight(1f),
                             onPress = { onKeyPressDown?.invoke("emoji") },
                             shadowEnabled = shadowEnabled,
@@ -434,7 +437,7 @@ private fun StrokeRows(
                     text = "符号",
                     onClick = { onKeyPress("symbol") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(1f),
                     onPress = { onKeyPressDown?.invoke("symbol") },
                     shadowEnabled = shadowEnabled,
@@ -480,7 +483,7 @@ private fun StrokeRows(
                     text = "确定",
                     onClick = { onKeyPress("enter") },
                     backgroundColor = specialKeyBackgroundColor,
-                    textColor = keyTextColor,
+                    textColor = specialKeyTextColor,
                     modifier = Modifier.weight(1.2f),
                     onPress = { onKeyPressDown?.invoke("enter") },
                     shadowEnabled = shadowEnabled,
@@ -560,7 +563,7 @@ private fun StrokeKeyButton(
 
     val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -561,9 +563,20 @@ private fun StrokeKeyButton(
     val density = LocalDensity.current
     val swipeUpThreshold = with(density) { (-40).dp.toPx() }
 
-    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
@@ -558,11 +558,12 @@ private fun StrokeKeyButton(
     val density = LocalDensity.current
     val swipeUpThreshold = with(density) { (-40).dp.toPx() }
 
+    val shadowShape = remember(shadowShapeRadius) { RoundedCornerShape(shadowShapeRadius) }
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shadowShape) else Modifier
+    }
     val keyCornerRadius = LocalKeyCornerRadius.current
     val keyClipShape = remember(keyCornerRadius) { RoundedCornerShape(keyCornerRadius) }
-    val shadowModifier = remember(shadowEnabled, shadowElevation, keyClipShape) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, keyClipShape) else Modifier
-    }
 
     fun darkenColor(color: Color, factor: Float = 0.15f): Color {
         return Color(
@@ -575,34 +576,8 @@ private fun StrokeKeyButton(
 
     Box(
         modifier = modifier
-            .fillMaxWidth()
             .fillMaxHeight()
-            .pointerInput(Unit) {
-                detectDragGestures(
-                    onDragStart = {
-                        isPressed = true
-                        dragOffsetY = 0f
-                        hasTriggeredSwipeUp = false
-                    },
-                    onDragEnd = {
-                        isPressed = false
-                        dragOffsetY = 0f
-                        hasTriggeredSwipeUp = false
-                    },
-                    onDragCancel = {
-                        isPressed = false
-                        dragOffsetY = 0f
-                        hasTriggeredSwipeUp = false
-                    },
-                    onDrag = { change, dragAmount ->
-                        dragOffsetY += dragAmount.y
-                        if (dragOffsetY < swipeUpThreshold && !hasTriggeredSwipeUp && onSwipeUp != null) {
-                            hasTriggeredSwipeUp = true
-                            onSwipeUp()
-                        }
-                    }
-                )
-            }
+            .fillMaxWidth()
             .pointerInput(Unit) {
                 detectTapGestures(
                     onPress = {
@@ -611,12 +586,9 @@ private fun StrokeKeyButton(
                         tryAwaitRelease()
                         isPressed = false
                     },
-                    onTap = {
-                        if (!hasTriggeredSwipeUp) onClick()
-                    }
+                    onTap = { onClick() }
                 )
             }
-            .padding(horizontal = 2.dp, vertical = 2.dp)
             .then(shadowModifier)
             .clip(keyClipShape)
             .background(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -103,6 +104,65 @@ fun T9KeyboardLayout(
     val configuration = LocalConfiguration.current
     val isLandscape = !isFloatingMode && configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
+    fun handleDelete() {
+        when (val result = controller.onDeleted()) {
+            T9InputController.DeleteResult.UNDO_COMMIT -> {
+                controller.clearRimeAndResend()
+            }
+
+            T9InputController.DeleteResult.NOT_CONSUMED -> {
+                onKeyPress("delete")
+            }
+
+            T9InputController.DeleteResult.DELETED, T9InputController.DeleteResult.UNDO_CHOICE -> {
+            }
+        }
+    }
+
+    T9KeyboardSwipeOverlay(
+        modifier = modifier,
+        keyboardBackgroundColor = keyboardBackgroundColor,
+        keyCornerRadius = keyCornerRadius,
+        keyTextColor = keyTextColor,
+        isLandscape = isLandscape,
+        isFloatingMode = isFloatingMode,
+        onKeyPress = onKeyPress,
+        callbacks = callbacks,
+        uiState = uiState,
+        controller = controller,
+        keyBackgroundColor = keyBackgroundColor,
+        specialKeyBackgroundColor = specialKeyBackgroundColor,
+        shadowEnabled = shadowEnabled,
+        shadowElevation = shadowElevation,
+        shadowShapeRadius = shadowShapeRadius,
+        onKeyPressDown = onKeyPressDown,
+        onDelete = ::handleDelete,
+    )
+}
+
+
+// ─── 滑动气泡覆盖层（隔离 swipeState 作用域，避免全键盘重组） ────────
+
+@Composable
+private fun T9KeyboardSwipeOverlay(
+    modifier: Modifier,
+    keyboardBackgroundColor: Color,
+    keyCornerRadius: Dp,
+    keyTextColor: Color,
+    isLandscape: Boolean,
+    isFloatingMode: Boolean,
+    onKeyPress: (String) -> Unit,
+    callbacks: KeyboardCallbacks,
+    uiState: KeyboardUiState,
+    controller: T9InputController,
+    keyBackgroundColor: Color,
+    specialKeyBackgroundColor: Color,
+    shadowEnabled: Boolean,
+    shadowElevation: Dp,
+    shadowShapeRadius: Dp,
+    onKeyPressDown: ((String) -> Unit)?,
+    onDelete: () -> Unit,
+) {
     var swipeState by remember { mutableStateOf(SwipeState()) }
     var keyboardBounds by remember { mutableStateOf(Rect(0f, 0f, 0f, 0f)) }
     var lastKeyBounds by remember { mutableStateOf(Rect(0f, 0f, 0f, 0f)) }
@@ -120,25 +180,6 @@ fun T9KeyboardLayout(
             right = bounds.right - keyboardBounds.left,
             bottom = bounds.bottom - keyboardBounds.top
         )
-    }
-
-
-
-
-    fun handleDelete() {
-        when (val result = controller.onDeleted()) {
-            T9InputController.DeleteResult.UNDO_COMMIT -> {
-                controller.clearRimeAndResend()
-            }
-
-            T9InputController.DeleteResult.NOT_CONSUMED -> {
-                onKeyPress("delete")
-            }
-
-            T9InputController.DeleteResult.DELETED, T9InputController.DeleteResult.UNDO_CHOICE -> {
-                // 已消费
-            }
-        }
     }
 
     val isDarkTheme = keyTextColor == Color(0xFFE8EAED)
@@ -164,13 +205,11 @@ fun T9KeyboardLayout(
             }
             .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 10.dp)) {
         if (isLandscape) {
-            // ── 横屏分体布局（参考 NumberKeyboardLayout） ──
             Row(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(vertical = 2.dp, horizontal = 50.dp),
             ) {
-                // 左侧：RIME 候选面板
                 Column(
                     modifier = Modifier
                         .weight(0.42f)
@@ -189,7 +228,6 @@ fun T9KeyboardLayout(
 
                 Spacer(modifier = Modifier.weight(0.16f))
 
-                // 右侧：九键键盘
                 Box(
                     modifier = Modifier
                         .weight(0.42f)
@@ -211,14 +249,13 @@ fun T9KeyboardLayout(
                             shadowShapeRadius = shadowShapeRadius,
                             onKeyPressDown = onKeyPressDown,
                             onSwipeStateChange = ::processSwipeState,
-                            onDelete = ::handleDelete,
+                            onDelete = onDelete,
                             compactMode = true,
                         )
                     }
                 }
             }
         } else {
-            // ── 竖屏：原三列布局 ──
             CompositionLocalProvider(
                 LocalKeyVisualPadding provides PaddingValues(horizontal = 2.dp, vertical = 2.dp)
             ) {
@@ -241,7 +278,7 @@ fun T9KeyboardLayout(
                         shadowShapeRadius = shadowShapeRadius,
                         onKeyPressDown = onKeyPressDown,
                         onSwipeStateChange = ::processSwipeState,
-                        onDelete = ::handleDelete,
+                        onDelete = onDelete,
                         compactMode = false,
                     )
                 }
@@ -398,7 +435,7 @@ private fun T9KeyboardContent(
         Column(
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(1f),
+                .weight(0.9f),
             verticalArrangement = Arrangement.spacedBy(if (compactMode) 2.dp else 4.dp)
         ) {
             Box(
@@ -494,7 +531,7 @@ private fun T9KeyboardContent(
         Column(
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(3f),
+                .weight(3.2f),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth().weight(1f),
@@ -660,11 +697,12 @@ private fun T9KeyboardContent(
         Column(
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(1f),
+                .weight(0.9f),
         ) {
             SwipeableIconKeyButton(
                 icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                 onClick = { onDelete() },
+                onLongClick = { onDelete() },
                 backgroundColor = specialKeyBackgroundColor,
                 iconColor = specialKeyTextColor,
                 modifier = Modifier.weight(1f),
@@ -904,55 +942,49 @@ private fun T9SpaceKey(
     shadowShapeRadius: Dp = 8.dp,
 ) {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
+    val view = LocalView.current
     val currentOnKeyPress by rememberUpdatedState(onKeyPress)
-    val currentOnKeyPressDown by rememberUpdatedState(onKeyPressDown)
     val currentOnVoiceModeChange by rememberUpdatedState(onVoiceModeChange)
-    val shape = RoundedCornerShape(shadowShapeRadius)
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
-    }
 
     Box(
         modifier = modifier
             .fillMaxHeight()
             .padding(horizontal = 2.dp, vertical = 2.dp)
-            .then(shadowModifier)
-            .clip(shape)
-            .background(backgroundColor)
-            .pointerInput(isSttEnabled) {
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    currentOnKeyPressDown?.invoke("space")
-
-                    var longPressTriggered = false
-                    val longPressJob = scope.launch {
-                        delay(400)
-                        longPressTriggered = true
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        onKeyPressDown?.invoke("space")
+                        tryAwaitRelease()
+                    },
+                    onTap = { currentOnKeyPress("space") },
+                    onLongPress = {
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.LONG_PRESS)
                         if (isSttEnabled) {
                             if (!PermissionHelper.hasRecordAudioPermission(context)) {
-                                Toast.makeText(
-                                    context, "需要麦克风权限才能使用语音输入", Toast.LENGTH_SHORT
-                                ).show()
+                                Toast.makeText(context, "需要麦克风权限才能使用语音输入", Toast.LENGTH_SHORT).show()
                                 PermissionHelper.requestRecordAudioPermission(context)
                             } else {
                                 currentOnVoiceModeChange?.invoke(true)
                             }
                         } else {
-                            while (true) {
-                                currentOnKeyPress("space")
-                                delay(80)
-                            }
+                            // 连续空格：在主线程上快速发送多个 space
+                            repeat(5) { currentOnKeyPress("space") }
                         }
                     }
-
-                    longPressJob.cancel()
-                    if (!longPressTriggered) {
-                        currentOnKeyPress("space")
-                    }
-                }
+                )
             }, contentAlignment = Alignment.Center
     ) {
+        // 背景层
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .then(
+                    if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius),
+                        ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+                )
+                .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
+                .background(backgroundColor)
+        )
         Text(
             text = schemaName,
             color = textColor,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -44,8 +44,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -54,6 +56,7 @@ import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -301,14 +304,27 @@ private fun T9LandscapeCandidatePanel(
     shadowElevation: Dp,
     shadowShapeRadius: Dp,
 ) {
+    val density = LocalDensity.current
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, keyBackgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(keyBackgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .then(
-                if (shadowEnabled) {
-                    Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
-                } else Modifier
-            )
+            .then(shadowModifier)
             .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
             .background(keyBackgroundColor)
     ) {
@@ -425,6 +441,23 @@ private fun T9KeyboardContent(
     val specialKeyTextColor = if (uiState.isDarkTheme) Color.White
         else KeyboardThemes.getAccentColor(uiState.themeId, false)
 
+    val density = LocalDensity.current
+    val candidateShadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, keyBackgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(keyBackgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
+    }
+
     Row(
         modifier = Modifier
             .fillMaxSize()
@@ -442,11 +475,7 @@ private fun T9KeyboardContent(
                 modifier = Modifier
                     .fillMaxHeight()
                     .weight(3f)
-                    .then(
-                        if (shadowEnabled) {
-                            Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
-                        } else Modifier
-                    )
+                    .then(candidateShadowModifier)
                     .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
                     .background(keyBackgroundColor)
             ) {
@@ -884,9 +913,22 @@ private fun ResetKey(
     var isPressed by remember { mutableStateOf(false) }
     val currentOnClick by rememberUpdatedState(onClick)
     val currentOnPress by rememberUpdatedState(onPress)
+    val density = LocalDensity.current
     val shape = RoundedCornerShape(shadowShapeRadius)
-    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
+    val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
     }
 
     Box(
@@ -945,6 +987,22 @@ private fun T9SpaceKey(
     val view = LocalView.current
     val currentOnKeyPress by rememberUpdatedState(onKeyPress)
     val currentOnVoiceModeChange by rememberUpdatedState(onVoiceModeChange)
+    val density = LocalDensity.current
+    val spaceShadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
+        if (shadowEnabled) {
+            val offsetPx = with(density) { shadowElevation.toPx() }
+            val cornerPx = with(density) { shadowShapeRadius.toPx() }
+            val color = crispShadowColor(backgroundColor)
+            Modifier.drawBehind {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(0f, offsetPx),
+                    size = size,
+                    cornerRadius = CornerRadius(cornerPx)
+                )
+            }
+        } else Modifier
+    }
 
     Box(
         modifier = modifier
@@ -978,10 +1036,7 @@ private fun T9SpaceKey(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .then(
-                    if (shadowEnabled) Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius),
-                        ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
-                )
+                .then(spaceShadowModifier)
                 .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
                 .background(backgroundColor)
         )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.R
 import com.kingzcheung.xime.rime.T9InputController
+import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import com.kingzcheung.xime.util.PermissionHelper
 import com.kingzcheung.xime.util.SubcharHelper
 import com.kingzcheung.xime.viewmodel.KeyboardUiState
@@ -268,7 +269,7 @@ private fun T9LandscapeCandidatePanel(
             .fillMaxSize()
             .then(
                 if (shadowEnabled) {
-                    Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius))
+                    Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
                 } else Modifier
             )
             .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
@@ -384,6 +385,8 @@ private fun T9KeyboardContent(
     val t9DigitFontSize = if (compactMode) 13.sp else 16.sp
     val ctrlFontSize = if (compactMode) 11.sp else androidx.compose.ui.unit.TextUnit.Unspecified
     val candidateFontSize = if (compactMode) 11.sp else 13.sp
+    val specialKeyTextColor = if (uiState.isDarkTheme) Color.White
+        else KeyboardThemes.getAccentColor(uiState.themeId, false)
 
     Row(
         modifier = Modifier
@@ -404,7 +407,7 @@ private fun T9KeyboardContent(
                     .weight(3f)
                     .then(
                         if (shadowEnabled) {
-                            Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius))
+                            Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius), ambientColor = Color(0x40000000), spotColor = Color(0x40000000))
                         } else Modifier
                     )
                     .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
@@ -477,7 +480,7 @@ private fun T9KeyboardContent(
                 text = "符号",
                 onClick = { onKeyPress("symbol") },
                 backgroundColor = specialKeyBackgroundColor,
-                textColor = keyTextColor,
+                textColor = specialKeyTextColor,
                 modifier = Modifier.weight(1f),
                 onPress = { onKeyPressDown?.invoke("symbol") },
                 shadowEnabled = shadowEnabled,
@@ -663,7 +666,7 @@ private fun T9KeyboardContent(
                 icon = rememberVectorPainter(Icons.AutoMirrored.Filled.Backspace),
                 onClick = { onDelete() },
                 backgroundColor = specialKeyBackgroundColor,
-                iconColor = keyTextColor,
+                iconColor = specialKeyTextColor,
                 modifier = Modifier.weight(1f),
                 swipeText = if (compactMode) null else "清空",
                 onSwipe = { onKeyPress("clear_composition") },
@@ -687,7 +690,7 @@ private fun T9KeyboardContent(
                 onClick = { controller.clearAll() },
                 onPress = { onKeyPressDown?.invoke("clear") },
                 backgroundColor = specialKeyBackgroundColor,
-                textColor = keyTextColor,
+                textColor = specialKeyTextColor,
                 modifier = Modifier.weight(1f),
                 shadowEnabled = shadowEnabled,
                 shadowElevation = shadowElevation,
@@ -698,7 +701,7 @@ private fun T9KeyboardContent(
                 text = uiState.enterKeyText,
                 onClick = { onKeyPress("enter") },
                 backgroundColor = specialKeyBackgroundColor,
-                textColor = keyTextColor,
+                textColor = specialKeyTextColor,
                 modifier = Modifier.weight(2f),
                 onPress = { onKeyPressDown?.invoke("enter") },
                 shadowEnabled = shadowEnabled,
@@ -845,7 +848,7 @@ private fun ResetKey(
     val currentOnPress by rememberUpdatedState(onPress)
     val shape = RoundedCornerShape(shadowShapeRadius)
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
 
     Box(
@@ -907,7 +910,7 @@ private fun T9SpaceKey(
     val currentOnVoiceModeChange by rememberUpdatedState(onVoiceModeChange)
     val shape = RoundedCornerShape(shadowShapeRadius)
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius) {
-        if (shadowEnabled) Modifier.shadow(shadowElevation, shape) else Modifier
+        if (shadowEnabled) Modifier.shadow(shadowElevation, shape, ambientColor = Color(0x40000000), spotColor = Color(0x40000000)) else Modifier
     }
 
     Box(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -268,7 +268,7 @@ private fun T9LandscapeCandidatePanel(
             .fillMaxSize()
             .then(
                 if (shadowEnabled) {
-                    Modifier.shadow(shadowElevation, RoundedCornerShape(LocalKeyCornerRadius.current))
+                    Modifier.shadow(shadowElevation, RoundedCornerShape(shadowShapeRadius))
                 } else Modifier
             )
             .clip(RoundedCornerShape(LocalKeyCornerRadius.current))

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -1,5 +1,6 @@
 package com.kingzcheung.xime.ui.keyboard
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -418,6 +419,7 @@ private fun LandscapeCandidateItem(
 
 // ─── 九键键盘三列主体（竖屏整宽 / 横屏右栏复用） ──────────────────────
 
+@SuppressLint("SuspiciousIndentation")
 @Composable
 private fun T9KeyboardContent(
     onKeyPress: (String) -> Unit,

--- a/app/src/main/java/com/kingzcheung/xime/util/FileLogger.kt
+++ b/app/src/main/java/com/kingzcheung/xime/util/FileLogger.kt
@@ -226,6 +226,10 @@ object FileLogger {
         }
     }
 
+    fun reopenLogFile() {
+        openLogFile()
+    }
+
     fun flush() {
         writer?.flush()
     }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -363,6 +363,22 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
         _syncViewState()
     }
 
+    private var savedKbStateBeforeVoice: KeyboardLayoutState? = null
+
+    fun enterVoice() {
+        savedKbStateBeforeVoice = _keyboardState.value
+        _page.value = KeyboardPage.Main(MainType.VOICE)
+        _syncViewState()
+    }
+
+    fun exitVoice() {
+        val saved = savedKbStateBeforeVoice ?: return
+        _page.value = KeyboardPage.Main(MainType.FULL)
+        _keyboardState.value = saved
+        savedKbStateBeforeVoice = null
+        _syncViewState()
+    }
+
     /** Level 2: 进入面板（编号/符号等），可从任意页面进入 */
     fun enterPanel(type: PanelType) {
         val current = _page.value

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/LogViewerViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/LogViewerViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.kingzcheung.xime.util.FileLogger
 import java.io.File
 
 data class LogViewerUiState(
@@ -119,6 +120,9 @@ class LogViewerViewModel(application: Application) : AndroidViewModel(applicatio
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 file.delete()
+                if (FileLogger.getCurrentLogFile()?.absolutePath == file.absolutePath) {
+                    FileLogger.reopenLogFile()
+                }
             }
             
             val wasSelected = _uiState.value.selectedLogFile == file
@@ -142,17 +146,10 @@ class LogViewerViewModel(application: Application) : AndroidViewModel(applicatio
             _uiState.update { it.copy(isLoading = true) }
             
             withContext(Dispatchers.IO) {
-                _uiState.value.logFiles.forEach { file ->
-                    file.delete()
-                }
+                FileLogger.clearAllLogs()
             }
             
-            _uiState.update { it.copy(
-                logFiles = emptyList(),
-                selectedLogFile = null,
-                logContent = "",
-                isLoading = false
-            )}
+            loadLogFiles()
         }
     }
     

--- a/app/src/main/jni/cmake/Boost.cmake
+++ b/app/src/main/jni/cmake/Boost.cmake
@@ -4,27 +4,55 @@
 
 set(BOOST_VERSION 1.89.0)
 
-if(NOT EXISTS "boost-${BOOST_VERSION}.tar.xz")
-  message(STATUS "Downloading Boost ${BOOST_VERSION} ......")
-  file(
-    DOWNLOAD
-    "https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.xz"
-    boost-${BOOST_VERSION}.tar.xz
-    EXPECTED_HASH
-      SHA256=67acec02d0d118b5de9eb441f5fb707b3a1cdd884be00ca24b9a73c995511f74
-    SHOW_PROGRESS)
+if(NOT EXISTS "boost-${BOOST_VERSION}.tar.xz" AND NOT EXISTS "${CMAKE_SOURCE_DIR}/boost")
+  set(BOOST_SHA256 "67acec02d0d118b5de9eb441f5fb707b3a1cdd884be00ca24b9a73c995511f74")
+  set(BOOST_URL "https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.xz")
 
-  message(STATUS "Remove older version Boost")
-  file(REMOVE_RECURSE "${CMAKE_SOURCE_DIR}/boost")
+  message(STATUS "Downloading Boost ${BOOST_VERSION} from GitHub ......")
+  file(DOWNLOAD "${BOOST_URL}" boost-${BOOST_VERSION}.tar.xz
+       EXPECTED_HASH SHA256=${BOOST_SHA256} SHOW_PROGRESS STATUS _dl_status)
+  list(GET _dl_status 0 _dl_code)
+  list(GET _dl_status 1 _dl_msg)
+
+  if(NOT _dl_code EQUAL 0)
+    message(STATUS "GitHub download failed (${_dl_msg}), trying ghproxy mirror ...")
+    file(DOWNLOAD "https://ghproxy.net/${BOOST_URL}" boost-${BOOST_VERSION}.tar.xz
+         EXPECTED_HASH SHA256=${BOOST_SHA256} SHOW_PROGRESS STATUS _dl_status2)
+    list(GET _dl_status2 0 _dl_code2)
+
+    if(NOT _dl_code2 EQUAL 0)
+      message(STATUS "ghproxy also failed, trying local Boost source ...")
+      file(REMOVE_RECURSE "${CMAKE_SOURCE_DIR}/boost")
+      if(EXISTS "/tmp/boost_${BOOST_VERSION}")
+        file(COPY "/tmp/boost_${BOOST_VERSION}/" DESTINATION "${CMAKE_SOURCE_DIR}/boost")
+      elseif(EXISTS "/tmp/boost_1_89_0")
+        file(COPY "/tmp/boost_1_89_0/" DESTINATION "${CMAKE_SOURCE_DIR}/boost")
+      else()
+        message(FATAL_ERROR "Cannot download Boost ${BOOST_VERSION}. "
+          "Please download boost_${BOOST_VERSION}.tar.bz2 from "
+          "https://archives.boost.io/release/${BOOST_VERSION}/source/ "
+          "and extract to /tmp/boost_${BOOST_VERSION}/")
+      endif()
+    endif()
+  endif()
+
+  if(_dl_code EQUAL 0 OR _dl_code2 EQUAL 0)
+    message(STATUS "Remove older version Boost")
+    file(REMOVE_RECURSE "${CMAKE_SOURCE_DIR}/boost")
+  endif()
 endif()
 
 if(NOT EXISTS "${CMAKE_SOURCE_DIR}/boost")
-  message(STATUS "Extracting Boost ${BOOST_VERSION} ......")
-  file(ARCHIVE_EXTRACT INPUT boost-${BOOST_VERSION}.tar.xz DESTINATION
-       ${CMAKE_SOURCE_DIR})
-  file(RENAME "boost-${BOOST_VERSION}" boost)
+  if(EXISTS "boost-${BOOST_VERSION}.tar.xz")
+    message(STATUS "Extracting Boost ${BOOST_VERSION} from cached archive ......")
+    file(ARCHIVE_EXTRACT INPUT boost-${BOOST_VERSION}.tar.xz DESTINATION
+         ${CMAKE_SOURCE_DIR})
+    file(RENAME "boost-${BOOST_VERSION}" boost)
+  endif()
 endif()
 
+# The CMake adaptor may not include header-only Boost libraries.
+# Ensure all header-only targets exist to satisfy transitive dependencies.
 set(BOOST_INCLUDE_LIBRARIES
     algorithm
     crc
@@ -38,3 +66,18 @@ set(BOOST_INCLUDE_LIBRARIES
     uuid)
 
 add_subdirectory(boost EXCLUDE_FROM_ALL)
+
+# Create INTERFACE IMPORTED targets for any Boost::* library that is
+# referenced as a dependency but not provided by the CMake adaptor.
+set(__boost_header_only_libs
+    algorithm any array assert bind concept_check config container_hash
+    conversion core crc detail foreach function integer io iterator
+    lexical_cast move mp11 mpl multi_index numeric_conversion optional
+    predef preprocessor range rational scope_exit signals2 smart_ptr
+    static_assert system throw_exception tti tuple type_index type_traits
+    typeof utility variant variant2)
+foreach(__boost_lib ${__boost_header_only_libs})
+  if(NOT TARGET "Boost::${__boost_lib}")
+    add_library("Boost::${__boost_lib}" INTERFACE IMPORTED GLOBAL)
+  endif()
+endforeach()


### PR DESCRIPTION
- 为所有按键组件创建独立的 shadowShape 变量，避免重复计算圆角形状
- 统一使用 shadowShapeRadius 参数作为阴影形状的半径值，而不是依赖 LocalKeyCornerRadius.current
- 在多个按键组件中将 RoundedCornerShape 的创建逻辑提取到单独的 keyClipShape 变量中
- 移除 StrokeKeyButton 中未使用的 pointerInput 拖拽手势检测器
- 修复 SpaceKeyButton 中阴影形状参数不一致的问题
- 添加 @SuppressLint 注解以抑制 KeyboardLayout 中的 Modifier 参数检查
- 更新 submodules 的 dirty 状态

这些更改提高了性能并减少了内存分配，
同时修复了代码中的潜在问题。