### PR TITLE
refactor(rime): 重构 T9 输入为三态状态机架构并修复右选候选词消费错误

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/T9BufferManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9BufferManager.kt
@@ -1,0 +1,340 @@
+package com.kingzcheung.xime.rime
+
+// ─────────────────────────────────────────────────────────
+// 设计文档 §2.2：T9Buffer — 结构化输入模型（替代纯字符串 buffer）
+//
+// 核心设计：
+//   - digitSequence: 用户输入的全部数字（如 "54482"）
+//   - selections:    已确认的拼音选择，按顺序排列
+//   - consumedCount: 已被 LeftSelect / RightCommit 消费的数字总数
+//
+// 字符串 buffer 变为导出属性 toBufferString()，
+// 不再需要 parseBuffer() / digitStreamFrom() 等逆向解析。
+//
+// 设计文档 §2.2 原 DigitStream 模型已合并到此模型中。
+// ─────────────────────────────────────────────────────────
+
+/**
+ * T9 输入的完整结构化模型。
+ *
+ * 解决设计文档 §1.1 的两个根因缺陷：
+ *   缺陷 1（Buffer 类型混杂）：digitSequence（数字）与 selections（字母）显式分离
+ *   缺陷 2（' 语义过载）：分隔符不再存储，仅在 toBufferString() 中按规则生成
+ *
+ * 使用示例：
+ *   T9Buffer("54482").addSelection("ji", 2) → digits=54482, sel=[ji(2)], consumed=2
+ *   .toBufferString() → "ji'482"
+ */
+data class T9Buffer(
+    /** 用户输入的全部数字序列，如 "54482" */
+    val digitSequence: String = "",
+    /** 已确认的拼音选择，按选择时间排序 */
+    val selections: List<Selection> = emptyList(),
+    /** 已被 LeftSelect / RightCommit 消费的数字总数 */
+    val consumedCount: Int = 0,
+    /** 累计输入的数字总数（退格不会减少），用于判断 digitSequence 是否被缩短过 */
+    val totalDigitsEntered: Int = digitSequence.length,
+) {
+    /** 单次拼音选择 */
+    data class Selection(
+        val pinyin: String,
+        val digitLen: Int,
+    ) {
+        val isAbbreviation: Boolean get() = pinyin.length == 1
+    }
+
+    // ── 导出属性 ──
+
+    /** 尚未被消费的数字段 */
+    val unassigned: String get() = digitSequence.drop(consumedCount)
+
+    val isFullyConsumed: Boolean get() = consumedCount >= digitSequence.length
+    val isEmpty: Boolean get() = digitSequence.isEmpty()
+
+    /** 所有已选拼音拼接（不含分隔符） */
+    val selectedPinyin: String get() = selections.joinToString("") { it.pinyin }
+
+    // ── 不可变突变方法 ──
+
+    /** 追加一位数字 */
+    fun addDigit(d: String) = copy(
+        digitSequence = digitSequence + d,
+        totalDigitsEntered = maxOf(totalDigitsEntered, digitSequence.length + 1),
+    )
+
+    /** 消费 n 位数字（不关联到具体拼音选择） */
+    fun consume(n: Int) = copy(consumedCount = consumedCount + n)
+
+    /** 添加拼音选择并消费对应位数 */
+    fun addSelection(pinyin: String, digitLen: Int) = copy(
+        selections = selections + Selection(pinyin, digitLen),
+        consumedCount = consumedCount + digitLen,
+    )
+
+    /** 替换最后一个选择（同位数替换时合并撤销） */
+    fun replaceLastSelection(pinyin: String, digitLen: Int): T9Buffer {
+        val prev = selections.lastOrNull() ?: return this
+        return copy(
+            selections = selections.dropLast(1) + Selection(pinyin, digitLen),
+            consumedCount = consumedCount - prev.digitLen + digitLen,
+        )
+    }
+
+    /** 添加选择但不增加消费计数（用于替换分词键已消费的数字） */
+    fun addSelectionNoConsume(pinyin: String, digitLen: Int) = copy(
+        selections = selections + Selection(pinyin, digitLen),
+    )
+
+    /** 撤销最后一个选择并回退消费 */
+    fun undoLastSelection(): T9Buffer {
+        val prev = selections.lastOrNull() ?: return this
+        return copy(
+            selections = selections.dropLast(1),
+            consumedCount = consumedCount - prev.digitLen,
+        )
+    }
+
+    /** 清空全部状态 */
+    fun clear() = T9Buffer()
+
+    /** 移除最后一位数字（退格删除）。若删除导致消费数超出，则裁剪选择 */
+    fun removeLastDigit(): T9Buffer {
+        if (digitSequence.isEmpty()) return this
+        val newSeq = digitSequence.dropLast(1)
+        val newConsumed = consumedCount.coerceAtMost(newSeq.length)
+        var acc = 0
+        val kept = selections.takeWhile { sel ->
+            acc += sel.digitLen
+            acc <= newConsumed
+        }
+        return copy(digitSequence = newSeq, selections = kept, consumedCount = newConsumed)
+    }
+
+    // ── 导出字符串（向后兼容） ──
+
+    /**
+     * 重建传统 inputBuffer 字符串。
+     *
+     * 分隔符插入规则：
+     *   - 每个选择后，若后续还有数字（已消费或未消费），则加 ' 分隔
+     *   - 连续简拼选择间不加 '（通过 toPreeditString 处理 RIME 端的分隔）
+     */
+    fun toBufferString(): String {
+        if (selections.isEmpty() && consumedCount == 0) return digitSequence
+        // 无选择时只展示剩余未分配数字（right-commit 已消费的数字不显示）
+        if (selections.isEmpty()) return unassigned
+        if (isFullyConsumed && selections.sumOf { it.digitLen } == consumedCount) {
+            // 仅当 digitSequence 被退格缩短过（有原始数字被删除）时才保留尾随 '
+            if (digitSequence.length < totalDigitsEntered) {
+                return selectedPinyin + "'"
+            }
+            return selectedPinyin
+        }
+
+        // offset: 被非 selection 方式（right-commit / 分词键）消费的前导数字数
+        // selections 在 digitSequence 中的实际起始位置 = offset
+        val offset = (consumedCount - selections.sumOf { it.digitLen }).coerceAtLeast(0)
+        val sb = StringBuilder()
+        var pos = offset
+        for (i in selections.indices) {
+            val sel = selections[i]
+            sb.append(sel.pinyin)
+            pos += sel.digitLen
+            // 仅当存在未分配数字（pos 已进入 unconsumed 区）时才添加分隔符
+            if (pos >= consumedCount && pos < digitSequence.length) {
+                val nextIsAbbrev = (i + 1 < selections.size) && selections[i + 1].isAbbreviation
+                if (!sel.isAbbreviation || !nextIsAbbrev) {
+                    sb.append("'")
+                }
+            }
+        }
+        // 未消费数字
+        sb.append(unassigned)
+        return sb.toString()
+    }
+
+    /**
+     * 计算发给 RIME 引擎的预编辑字符串。
+     *
+     * 与 [toBufferString] 的区别：
+     *   - 连续简拼选择间加 ' 分隔，避免 RIME 合并为全拼音节（如 "l'i'" vs "li"）
+     *   - 全拼选择后不加 '（RIME 自动识别音节边界）
+     */
+    fun toPreeditString(): String {
+        if (selections.isEmpty()) return unassigned
+
+        val sb = StringBuilder()
+        for (i in selections.indices) {
+            val cur = selections[i]
+            if (i > 0) sb.append("'")
+            sb.append(cur.pinyin)
+        }
+        if (!isFullyConsumed) {
+            if (selections.isNotEmpty()) sb.append("'")
+            sb.append(unassigned)
+        }
+        return sb.toString()
+    }
+
+    companion object {
+        /** 空 buffer */
+        val EMPTY = T9Buffer()
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// 设计文档 2.2 节：DigitStream — 数字流核心数据模型
+// ─────────────────────────────────────────────────────────
+
+/**
+ * 右侧提交模型（设计文档 2.4 节）。
+ *
+ * 描述右侧候选词选择后的消费结果：
+ *   consumedDigits: 被消费的数字段
+ *   remainingAfterCommit: 未被消费的数字段
+ *   committedText: 已上屏的汉字
+ *   isPartialCommit: 是否部分消费
+ */
+data class RightCommit(
+    val consumedDigits: String,
+    val remainingAfterCommit: String,
+    val committedText: String = "",
+    val isPartialCommit: Boolean = false,
+)
+
+// ─────────────────────────────────────────────────────────
+// 设计文档 2.5 节：导出计算（纯函数）
+// ─────────────────────────────────────────────────────────
+
+// ── preeditString（T9Buffer 版本） ──
+
+/**
+ * 计算预编辑文本（发给 RIME 的字符串），使用 [T9Buffer] 结构化模型。
+ *
+ * 设计文档 2.5 节。
+ */
+fun preeditString(buf: T9Buffer): String {
+    if (buf.isEmpty) return ""
+    return buf.toPreeditString()
+}
+
+/**
+ * 计算左侧候选区拼音列表（[T9Buffer] 版本）。
+ */
+fun leftCandidates(
+    buf: T9Buffer,
+    state: T9StateMachine.State,
+    selectionDigits: String?,
+): List<T9PinyinMap.SyllableOption> {
+    if (state == T9StateMachine.State.IDLE) return emptyList()
+    val digits = buf.unassigned.ifEmpty { selectionDigits ?: return emptyList() }
+    return T9PinyinMap.firstSyllableOptions(digits)
+}
+
+/**
+ * 候选词与选择历史的匹配级别。
+ *
+ * - [FULL]:     候选词的拼音注释匹配了 selectionHistory 中的全部音节
+ * - [PREFIX]:   候选词的拼音注释仅匹配了 selectionHistory 的前缀部分
+ * - [NONE]:     不匹配
+ */
+enum class MatchLevel { FULL, PREFIX, NONE }
+
+/**
+ * 根据左侧选择历史过滤候选词，分两层返回：全匹配 + 前缀匹配。
+ *
+ * 全匹配组（匹配所有 selectionHistory）排在前面，
+ * 前缀匹配组（仅匹配 selectionHistory 的某个前缀）排在后面，
+ * 确保精确匹配优先，同时不丢失单字候选。
+ *
+ * 例：selectionHistory=[jiu, jian] 时，
+ *   "就见(jiu jian)" 为 FULL 匹配，
+ *   "九(jiu)" 为 PREFIX 匹配（仅匹配了 jiu）。
+ */
+fun filterCandidatesBySelectionHistory(
+    candidates: List<String>,
+    comments: List<String>,
+    selectionHistory: List<T9PinyinMap.SyllableOption>,
+): Pair<List<String>, List<String>> {
+    if (selectionHistory.isEmpty()) return candidates to comments
+
+    // 预计算 selectionHistory 的数字码，避免对每个候选词重复计算
+    val selCodes = selectionHistory.map { T9PinyinMap.pinyinToDigitCode(it.pinyin) }
+
+    val fullTexts = mutableListOf<String>()
+    val fullComments = mutableListOf<String>()
+    val prefixTexts = mutableListOf<String>()
+    val prefixComments = mutableListOf<String>()
+
+    for (i in candidates.indices) {
+        val comment = comments.getOrElse(i) { "" }
+        when (matchCandidateComment(comment, selectionHistory, selCodes)) {
+            MatchLevel.FULL -> {
+                fullTexts.add(candidates[i])
+                fullComments.add(comment)
+            }
+            MatchLevel.PREFIX -> {
+                prefixTexts.add(candidates[i])
+                prefixComments.add(comment)
+            }
+            MatchLevel.NONE -> { /* 排除 */ }
+        }
+    }
+
+    val resultTexts = fullTexts + prefixTexts
+    val resultComments = fullComments + prefixComments
+    if (resultTexts.isEmpty()) return candidates to comments
+    return resultTexts to resultComments
+}
+
+/**
+ * 判断候选词的拼音注释与选择历史的匹配级别。
+ *
+ * 逐音节对齐校验：每个选择匹配到 comment 中对应位置的音节。
+ * 全拼要求数字码完全相等（允许 he 匹配 ge，因为同码 43），
+ * 简拼只求数字码前缀匹配。
+ *
+ * - FULL:   comment 中每个音节都能匹配 selectionHistory 中的对应选择，
+ *           且所有 selectionHistory 都被匹配
+ * - PREFIX: 仅匹配了 selectionHistory 的某个前缀（comment 音节数少于
+ *           selectionHistory 的匹配数，但已匹配部分全部正确）
+ * - NONE:   存在匹配失败的 selectionHistory 条目
+ *
+ * @param selCodes selectionHistory 对应的数字码列表（由调用方预计算复用）
+ */
+private fun matchCandidateComment(
+    comment: String,
+    selectionHistory: List<T9PinyinMap.SyllableOption>,
+    selCodes: List<String?>,
+): MatchLevel {
+    val syllables = comment.trim()
+        .split("[\\s']+".toRegex())
+        .filter { it.any { c -> c.isLetter() } }
+    if (syllables.isEmpty()) return MatchLevel.FULL
+
+    var syllableIdx = 0
+    var matchedCount = 0
+    for (idx in selectionHistory.indices) {
+        val sel = selectionHistory[idx]
+        val selCode = selCodes[idx] ?: return MatchLevel.FULL
+        var matched = false
+        while (syllableIdx < syllables.size) {
+            val sylCode = T9PinyinMap.pinyinToDigitCode(syllables[syllableIdx])
+                ?: run { syllableIdx++; continue }
+            if (sylCode.startsWith(selCode)) {
+                if (sel.pinyin.length > 1 && sylCode != selCode) return MatchLevel.NONE
+                syllableIdx++
+                matched = true
+                break
+            }
+            syllableIdx++
+        }
+        if (matched) {
+            matchedCount++
+        } else {
+            // selectionHistory 未全部匹配：前面有成功匹配 → PREFIX，否则 → NONE
+            return if (matchedCount > 0) MatchLevel.PREFIX else MatchLevel.NONE
+        }
+    }
+    return MatchLevel.FULL
+}

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9DisplayHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9DisplayHelper.kt
@@ -1,0 +1,54 @@
+package com.kingzcheung.xime.rime
+
+import com.kingzcheung.xime.util.PreeditMergeHelper
+
+/** T9 模式下 UI 展示状态：包含展示文本、候选列表和 composing 标志 */
+data class T9DisplayState(
+    val displayText: String,
+    val displayCandidates: List<String>,
+    val displayComments: List<String>,
+    val isComposing: Boolean,
+)
+
+/**
+ * 构建 T9 模式下的 UI 展示状态。
+ *
+ * 三种情形：
+ * 1. 无 partial commit：优先 preedit（t9_preedit.lua 处理后的拼音），回退 input
+ * 2. RightCommit 展示态（有 partial + preedit 为空）：
+ *    displayText=partialTexts 拼接，候选列表=最近一次已提交文本
+ * 3. 常规：mergePartialCommitText 合并
+ */
+fun buildT9DisplayState(
+    partialTexts: List<String>,
+    preeditText: String,
+    inputText: String,
+    candidates: List<String>,
+    comments: List<String>,
+): T9DisplayState {
+    if (partialTexts.isEmpty()) {
+        val text = if (preeditText.isNotEmpty()) preeditText else inputText
+        return T9DisplayState(
+            displayText = text,
+            displayCandidates = candidates,
+            displayComments = comments,
+            isComposing = inputText.isNotEmpty(),
+        )
+    }
+    // RightCommit 展示态：preedit 为空（composition 已清除），input 可能为残留值
+    if (preeditText.isEmpty()) {
+        val last = partialTexts.last()
+        return T9DisplayState(
+            displayText = partialTexts.joinToString(""),
+            displayCandidates = listOf(last),
+            displayComments = comments.firstOrNull()?.let { listOf(it) } ?: emptyList(),
+            isComposing = true,
+        )
+    }
+    return T9DisplayState(
+        displayText = PreeditMergeHelper.mergePartialCommitText(partialTexts, preeditText),
+        displayCandidates = candidates,
+        displayComments = comments,
+        isComposing = inputText.isNotEmpty() || partialTexts.isNotEmpty(),
+    )
+}

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -26,10 +26,6 @@ class T9InputController(
         const val CLEAR_ALL = T9RimeBridge.CLEAR_ALL
     }
 
-    /** 推迟左侧候选区更新到下一帧，避免重组干扰触摸事件命中测试 */
-    private val candidateUpdater: android.os.Handler? =
-        try { android.os.Handler(android.os.Looper.getMainLooper()) } catch (_: Throwable) { null }
-
     private val rimeBridge = T9RimeBridge(onReplaceFullPinyin, onQueryRimeComposition, onRightCommitUndone)
 
     enum class LeftPanelState { IDLE, INPUT, SELECTION }
@@ -243,7 +239,7 @@ class T9InputController(
         // T9Buffer 自动处理字母/数字间的分隔——不需要手动插入 '
         pushCommand(T9Command.DigitPressed(digit))
         inputBuffer = inputBuffer.addDigit(digit)
-        candidateUpdater?.post { updateCandidates() } ?: updateCandidates()
+        updateCandidates()
 
         sendToRime()
         val elapsed = (System.nanoTime() - t0) / 1_000_000L

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -266,8 +266,8 @@ class T9InputController(
                 inputBuffer = inputBuffer.addSelection(confirmed.pinyin, confirmed.digitLength)
             }
             // 无匹配音节：仅记录分词状态（separatorConsumedDigits 保持 null），不修改 inputBuffer
+            leftColumnLocked = true
         }
-        leftColumnLocked = true
         sendToRime()
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -167,7 +167,7 @@ class T9InputController(
         }
         val elapsed = (System.nanoTime() - t0) / 1_000_000L
         if (elapsed > 2) {
-            try { android.util.Log.d("T9InputCtrl", "updateCandidates took ${elapsed}ms buffer='${inputBuffer.toBufferString().take(20)}'") } catch (_: Throwable) { }
+            try { android.util.Log.d("T9InputCtrl", "updateCandidates took ${elapsed}ms buffer='${bufStr.take(20)}'") } catch (_: Throwable) { }
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -5,525 +5,492 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
 /**
- * 九键拼音输入控制器
+ * 九键拼音输入控制器。
  *
- * 封装九宫格拼音输入的状态机和所有业务逻辑。
- * 原内联于 NineKeyKeyboardLayout.kt 的左侧候选区逻辑提取至此。
- *
- * 职责：
- * - inputBuffer 管理（已确认拼音 + 分隔符 + 数字序列）
- * - 左侧候选区（firstOptions）的计算与锁定控制
- * - 分词、选词、删除、清空等操作
- * - 向 RIME 引擎发送输入（通过 onReplaceFullPinyin 回调）
- *
- * 使用示例（在 Compose 中）：
- *   val controller = remember { T9InputController(onReplaceFullPinyin) }
- *   LaunchedEffect(resetSignal) { controller.reset() }
- *   Text(controller.firstOptions.map { it.pinyin }.toString())
+ * 设计文档 13.1 节模块分工：
+ * - DigitStream（原 T9BufferManager）：数字流模型与 buffer 解析
+ * - T9StateMachine：三态状态机 + LeftSelection 模型
+ * - T9UndoManager：命令模式撤销管理（Phase 3）
+ * - T9RimeBridge：RIME 引擎通信桥接
+ * - T9RightCommitUtils：右侧选词消费计算
+ * - T9PinyinMap：拼音映射（无需改动）
+ * - T9DisplayHelper：UI 展示状态构建
  */
 class T9InputController(
-    private val onReplaceFullPinyin: (String) -> Unit,
-    private val onQueryRimeComposition: (() -> RimeComposition)? = null,
-    /** 可选回调：撤销一次右侧候选选词（partial commit）。服务层应同步删除已提交文本，
-     *  并从 partial commit 累积列表中移除最近一次提交的候选。 */
-    private val onRightCommitUndone: ((Int) -> Unit)? = null
+    onReplaceFullPinyin: (String) -> Unit,
+    onQueryRimeComposition: (() -> RimeComposition)? = null,
+    onRightCommitUndone: ((Int) -> Unit)? = null,
 ) {
     companion object {
-        /** sendToRime 的特殊标记：仅清除 RIME composition，保留 partial commit 累积文本 */
-        const val CLEAR_COMPOSITION_ONLY = "\u0000CLEAR_COMPOSITION_ONLY"
-        /** sendToRime 的特殊标记：清除 RIME composition 并清空 partial commit 累积文本 */
-        const val CLEAR_ALL = "\u0000CLEAR_ALL"
+        const val CLEAR_COMPOSITION_ONLY = T9RimeBridge.CLEAR_COMPOSITION_ONLY
+        const val CLEAR_ALL = T9RimeBridge.CLEAR_ALL
     }
-    // ── 响应式状态 ──
 
     /** 推迟左侧候选区更新到下一帧，避免重组干扰触摸事件命中测试 */
     private val candidateUpdater: android.os.Handler? =
         try { android.os.Handler(android.os.Looper.getMainLooper()) } catch (_: Throwable) { null }
 
-    /** 退格操作结果类型 */
+    private val rimeBridge = T9RimeBridge(onReplaceFullPinyin, onQueryRimeComposition, onRightCommitUndone)
+
+    enum class LeftPanelState { IDLE, INPUT, SELECTION }
+
     enum class DeleteResult {
-        /** 已消费：删除了一个字符 */
-        DELETED,
-        /** 已消费：撤销了左侧候选区选词操作（onChoiceSelected） */
-        UNDO_CHOICE,
-        /** 已消费：撤销了右侧候选列表选词操作（onRightCandidateSelected） */
-        UNDO_COMMIT,
-        /** 未消费：inputBuffer 已空 */
-        NOT_CONSUMED
+        DELETED, UNDO_CHOICE, UNDO_COMMIT, NOT_CONSUMED
     }
 
-    /** 发送给 RIME 的完整输入序列。
-     *  格式：已确认拼音 + 分隔符(') + 数字 ...
-     *  例如 "j'43"（5后分词确认j，再输入43）、"ji'482"（左侧选ji后继续输入） */
-    var inputBuffer: String = ""
+    /**
+     * T9 结构化输入缓冲区。
+     *
+     * 设计文档 §2.2：替换纯字符串 buffer，分离数字序列与拼音选择。
+     * 分隔符 ' 不再存储，仅在 toBufferString() / toPreeditString() 中按规则生成。
+     */
+    var inputBuffer: T9Buffer by mutableStateOf(T9Buffer.EMPTY)
+
         internal set
 
-    /** 左侧候选区的音节选项列表 */
+    /** inputBuffer 的字符串表示（供 UI 显示和外部查询）。
+     * 分词键确认的拼音已内化到 T9Buffer.selections，由 toBufferString() 自然生成。
+     * 此处仅处理 leftColumnLocked 时的尾随 ' 显示（锁定态视觉提示）。 */
+    val bufferString: String get() {
+        val buf = inputBuffer.toBufferString()
+        // 拼音选择完全消费且锁定：补尾随 '（显示锁定状态）
+        // 避免与 toBufferString 的退格缩短 ' 重复
+        if (leftColumnLocked && inputBuffer.selections.isNotEmpty() &&
+            inputBuffer.unassigned.isEmpty() && !buf.endsWith("'")) {
+            return buf + "'"
+        }
+        return buf
+    }
+
     var firstOptions: List<T9PinyinMap.SyllableOption> by mutableStateOf(emptyList())
         private set
 
-    /** 上次发送给 RIME 的输入（避免冗余调用） */
-    private var lastRimeInput: String? = null
+    private var lastRimeInput: String?
+        get() = rimeBridge.getLastRimeInput()
+        set(value) { rimeBridge.setLastRimeInput(value) }
 
-    /** 左侧候选区是否锁定（分词后锁定，用户选择后解锁） */
-    var leftColumnLocked: Boolean = false
+    var leftColumnLocked: Boolean by mutableStateOf(false)
+        private set
 
-    // ── 内部状态 ──
 
-    /**
-     * lastDigitSegment() 结果缓存，避免相同数字段重复调用 T9PinyinMap 计算。
-     * key = 数字段，value = 对应 firstOptions 结果。
-     * 当数字段变化或 force=true 时清空。
-     */
+    var leftPanelState: LeftPanelState by mutableStateOf(LeftPanelState.IDLE)
+        private set
+
+    var selectedOption: T9PinyinMap.SyllableOption? by mutableStateOf(null)
+        private set
+
+    var selectionCandidateDigits: String? by mutableStateOf(null)
+        private set
+
+    /** 当前输入会话中所有已确认的拼音选择历史（按选择顺序），供候选词过滤使用 */
+    val selectionHistory: List<T9PinyinMap.SyllableOption> get() = stateMachine.selectionHistory.toList()
+
+    /** 当前左侧选择上下文（设计文档 2.3 节 LeftSelection 模型） */
+    val leftSelection: T9StateMachine.LeftSelection? get() = stateMachine.leftSelection
+
+    private val stateMachine = T9StateMachine()
+
+    private fun syncStateFromMachine() {
+        leftPanelState = when (stateMachine.state) {
+            T9StateMachine.State.IDLE -> LeftPanelState.IDLE
+            T9StateMachine.State.INPUT -> LeftPanelState.INPUT
+            T9StateMachine.State.SELECTION -> LeftPanelState.SELECTION
+        }
+        selectedOption = stateMachine.selectedOption
+        selectionCandidateDigits = stateMachine.selectionCandidateDigits
+    }
+
+    /** 构建命令撤销上下文 */
+    private fun undoCtx() = T9Command.Ctx(
+        buffer = inputBuffer,
+        leftColumnLocked = leftColumnLocked,
+        separatorConsumedDigits = separatorConsumedDigits,
+        lastChoiceConsumedDigits = lastChoiceConsumedDigits,
+        stateMachine = stateMachine,
+        onRestored = {
+            syncStateFromMachine()
+            updateCandidates(force = true)
+            rimeBridge.setLastRimeInput(null)
+            sendToRime()
+        },
+    )
+
+    /** 推送命令前的状态快照辅助：记录当前状态以备撤销 */
+    private fun pushCommand(cmd: T9Command) {
+        undoManager.push(cmd)
+    }
+
     private var cachedDigitSegment: String? = null
     private var cachedFirstOptions: List<T9PinyinMap.SyllableOption> = emptyList()
 
-    /**
-     * 快照式撤销记录。
-     *
-     * 每次语义操作前保存快照，撤销时恢复到上一个快照。
-     * 相比增量撤销，逻辑更简单：
-     *   - 撤销逻辑从 O(n) 降为 O(1)
-     *   - 消除复杂的 UndoEntry 状态机
-     *   - 状态更可预测，测试路径更少
-     *
-     * 存储代价：在输入法场景中，每个 buffer 通常 < 20 字符，
-     * 存储 10 个快照 ≈ 200 bytes，可忽略。
-     *
-     * 回退优先级（[onDeleted]）：
-     *   1. RightCommit 后 remaining 未被修改 → 撤销 RightCommit
-     *   2. 当前 buffer 有数字段 → 逐位删除数字（不查阅快照）
-     *   3. 快照栈非空 → 撤销到上一个快照
-     *   4. buffer 非空 → 删除最后一个字符
-     */
-    private data class Snapshot(
-        val buffer: String,
-        val isRightCommit: Boolean,
-        /** RightCommit 使用：消费的数字段 */
-        val consumedDigits: String = "",
-        /** RightCommit 使用：commit 后剩余的数字段 */
-        val remainingAfterCommit: String = "",
-        /** 撤销后应恢复的辅助状态 */
-        val separatorConsumedDigits: String? = null,
-        val lastChoiceConsumedDigits: String? = null,
-        val leftColumnLocked: Boolean = false,
-    )
+    private val undoManager = T9UndoManager()
 
-    private val snapshots = mutableListOf<Snapshot>()
-
-    /**
-     * RightCommit 后，remainingAfterCommit 是否被修改过。
-     * 一旦修改，后续撤销 RightCommit 只恢复 consumedDigits，而非完整 prevBuffer。
-     */
-    private var rightCommitRemainingDirty: Boolean = false
-
-    /**
-     * 记录最近一次分词键消费的数字段。
-     * 用于在分词后显示候选，让用户能修改首字母。
-     * 当用户选择左侧候选或撤销时清空。
-     */
     private var separatorConsumedDigits: String? = null
 
-    /**
-     * 记录最近一次左侧候选选择消费的数字段。
-     * 用于在分隔符结尾时显示候选。
-     */
     private var lastChoiceConsumedDigits: String? = null
 
-    // ── 公开 API ──
+    fun reset() = resetState(clearCache = true, clearRime = false)
 
-    /** 重置所有状态（响应 resetSignal） */
-    fun reset() {
-        inputBuffer = ""
-        firstOptions = emptyList()
-        lastRimeInput = null
-        leftColumnLocked = false
-        snapshots.clear()
-        rightCommitRemainingDirty = false
-        separatorConsumedDigits = null
-        lastChoiceConsumedDigits = null
-        cachedDigitSegment = null
-        cachedFirstOptions = emptyList()
-    }
+    fun lastDigitSegment(): String = inputBuffer.unassigned
 
-    /** 从 inputBuffer 中提取最后一个纯数字段，用于左侧候选区展示 */
-    fun lastDigitSegment(): String = parseInputBuffer(inputBuffer).digitSegment
-
-    /**
-     * inputBuffer 解析结果。
-     *
-     * 将 `indexOf('\\'')`、`lastDigitSegment()` 等分散解析逻辑集中到此数据类，
-     * 减少控制器中重复的下标计算，提高可维护性。
-     */
-    private data class BufferParts(
-        /** 原始 buffer */
-        val raw: String,
-        /** 第一个分隔符位置，-1 表示无分隔符 */
-        val apostropheIndex: Int,
-    ) {
-        /** 是否存在分隔符 */
-        val hasApostrophe: Boolean get() = apostropheIndex >= 0
-
-        /** 第一个分隔符前的已确认拼音；无分隔符时为空 */
-        val confirmedPinyin: String get() = if (hasApostrophe) raw.substring(0, apostropheIndex) else ""
-
-        /** 第一个分隔符后的内容；无分隔符时为整个 raw */
-        val afterApostrophe: String get() = if (hasApostrophe) raw.substring(apostropheIndex + 1) else raw
-
-        /** 当前 buffer 中最后一个连续数字段 */
-        val digitSegment: String get() {
-            val idx = raw.indexOfLast { it !in '0'..'9' }
-            return if (idx >= 0) raw.substring(idx + 1) else raw
-        }
-
-        /** 是否为纯数字 buffer（无分隔符且全是数字） */
-        val isPureDigits: Boolean get() = raw.isNotEmpty() && raw.all { it in '0'..'9' }
-    }
-
-    /** 解析 inputBuffer 为 [BufferParts]，以最后一个分隔符划分已确认拼音与剩余内容 */
-    private fun parseInputBuffer(buffer: String): BufferParts = BufferParts(buffer, buffer.lastIndexOf('\''))
-
-    /**
-     * 更新左侧候选区。
-     *
-     * 使用 [cachedDigitSegment] 缓存避免相同数字段重复调用 T9PinyinMap 的 HashMap 查找。
-     * 仅在 [force]=true 或当前数字段与缓存不同时重新计算。
-     *
-     * @param force 是否强制更新（用户主动选择时强制刷新）
-     */
     fun updateCandidates(force: Boolean = false) {
         val t0 = System.nanoTime()
         if (leftColumnLocked && !force) return
 
-        val parts = parseInputBuffer(inputBuffer)
+        val bufStr = inputBuffer.toBufferString()
+        val hasApostrophe = bufStr.contains("'")
+        val selectionDigits = selectionCandidateDigits
 
-        // 分词键后用户尚未从左侧候选区选择拼音：
-        // 优先显示分词键所消费数字段对应的候选，保持简拼首字母可修改。
-        val lastSeparatorDigits = lastSeparatorConsumedDigits()
-        if (lastSeparatorDigits != null && parts.hasApostrophe) {
-            if (force || cachedDigitSegment != lastSeparatorDigits) {
-                cachedDigitSegment = lastSeparatorDigits
-                cachedFirstOptions = T9PinyinMap.firstSyllableOptions(lastSeparatorDigits, maxResults = 12)
+        // 分词键锁定：继续显示之前确认的数字段的候选
+        if (separatorConsumedDigits != null && hasApostrophe) {
+            if (force || cachedDigitSegment != separatorConsumedDigits) {
+                cachedDigitSegment = separatorConsumedDigits
+                cachedFirstOptions = T9PinyinMap.firstSyllableOptions(separatorConsumedDigits!!, maxResults = 12)
             }
             firstOptions = cachedFirstOptions
             leftColumnLocked = false
             return
         }
 
-        val segment = parts.digitSegment
-        if (segment.isNotEmpty()) {
-            if (force || cachedDigitSegment != segment) {
-                cachedDigitSegment = segment
-                cachedFirstOptions = T9PinyinMap.firstSyllableOptions(segment, maxResults = 12)
-            }
-            firstOptions = cachedFirstOptions
-        } else if (parts.raw.endsWith("'")) {
-            if (force || cachedDigitSegment != null) {
-                // 以分隔符结尾：表示已确认拼音后仍有可编辑空间，
-                // 此时左侧候选区应基于该次确认所消费的数字段显示候选，
-                // 让用户能继续选择该数字段对应的拼音/字母。
-                val digits = lastConsumedDigitsForCandidates()
-                cachedDigitSegment = digits
-                cachedFirstOptions = digits?.let {
-                    T9PinyinMap.firstSyllableOptions(it, maxResults = 12)
-                } ?: emptyList()
-            }
-            firstOptions = cachedFirstOptions
-            leftColumnLocked = false
-        } else {
-            // 已确认完整拼音组合且无剩余数字：左侧候选区进入空闲态
-            cachedDigitSegment = null
-            cachedFirstOptions = emptyList()
-            firstOptions = emptyList()
+        // 使用设计文档 2.5 节 leftCandidates() 纯函数计算候选（T9Buffer 版本）
+        val candidates = leftCandidates(inputBuffer, stateMachine.state, selectionDigits)
+        val effectiveKey = if (candidates.isNotEmpty()) inputBuffer.unassigned.ifEmpty { selectionDigits ?: "" } else ""
+
+        if (force || cachedDigitSegment != effectiveKey) {
+            cachedDigitSegment = effectiveKey
+            cachedFirstOptions = candidates
+        }
+        firstOptions = cachedFirstOptions
+
+        if (!bufStr.endsWith("'")) {
             leftColumnLocked = false
         }
         val elapsed = (System.nanoTime() - t0) / 1_000_000L
         if (elapsed > 2) {
-            try { android.util.Log.d("T9InputCtrl", "updateCandidates took ${elapsed}ms buffer='${inputBuffer.take(20)}'") } catch (_: Throwable) { }
+            try { android.util.Log.d("T9InputCtrl", "updateCandidates took ${elapsed}ms buffer='${inputBuffer.toBufferString().take(20)}'") } catch (_: Throwable) { }
         }
     }
 
     /**
-     * 返回最近一次分词键消费的数字段。
-     * 用于在分词后显示候选，让用户能修改首字母。
+     * 判断当前选中的选项是否应高亮显示。
      */
-    private fun lastSeparatorConsumedDigits(): String? = separatorConsumedDigits
+    fun isSelectedOptionInCurrentCandidates(): Boolean {
+        if (leftPanelState != LeftPanelState.SELECTION || selectedOption == null) return false
+        val selDigits = selectionCandidateDigits ?: return false
+        // 无选择历史 + 有未消费数字 = 纯数字上下文
+        if (inputBuffer.selections.isEmpty() && inputBuffer.unassigned.isNotEmpty()) {
+            return cachedDigitSegment == selDigits
+        }
+        if (inputBuffer.unassigned.isNotEmpty()) return false
+        return cachedDigitSegment == selDigits
+    }
 
-    /**
-     * 返回最近一次左侧候选选择消费的数字段；若不存在则回退到分词键消费的数字段。
-     * 用于在分隔符结尾时显示候选。
-     */
-    private fun lastConsumedDigitsForCandidates(): String? = lastChoiceConsumedDigits ?: separatorConsumedDigits
+    private fun enterSelection(
+        option: T9PinyinMap.SyllableOption,
+        candidateDigits: String,
+        confirmedPinyin: String = "",
+    ) {
+        stateMachine.enterSelection(option, candidateDigits, confirmedPinyin)
+        syncStateFromMachine()
+    }
 
-    /** 将 inputBuffer 发送给 RIME 引擎 */
+    private fun enterIdle() {
+        stateMachine.enterIdle()
+        syncStateFromMachine()
+        firstOptions = emptyList()
+        leftColumnLocked = false
+        if (!undoManager.hasPendingRightCommit()) {
+            undoManager.clear()
+        }
+    }
+
+    fun forceSendToRime() {
+        rimeBridge.setLastRimeInput(null)
+        sendToRime()
+    }
+
     fun sendToRime() {
-        val input = inputBuffer
-        if (input.isEmpty()) {
+        if (inputBuffer.isEmpty) {
             if (lastRimeInput != null) {
-                lastRimeInput = null
-                val hasPendingRightCommit = snapshots.any { it.isRightCommit }
-                onReplaceFullPinyin(if (hasPendingRightCommit) CLEAR_COMPOSITION_ONLY else CLEAR_ALL)
+                rimeBridge.setLastRimeInput(null)
+                val hasPendingRightCommit = undoManager.hasPendingRightCommit()
+                rimeBridge.replaceFullPinyin(if (hasPendingRightCommit) CLEAR_COMPOSITION_ONLY else CLEAR_ALL)
+
             }
             return
         }
-        if (input == lastRimeInput) return
-        lastRimeInput = input
-        onReplaceFullPinyin(input)
+
+        // T9Buffer.toPreeditString() 统一生成预编辑字符串
+        // （分词键确认的拼音已在 selections 中，toPreeditString 自然处理分隔符）
+        val rimeInput = inputBuffer.toPreeditString()
+        if (rimeInput == lastRimeInput) return
+        lastRimeInput = rimeInput
+
+        rimeBridge.replaceFullPinyin(rimeInput)
     }
 
-    /**
-     * 优先通过 RIME 候选 comment 反推当前数字段的最优首音节。
-     *
-     * 取当前 composition 第一个带 comment 的候选，将其 comment（如 "ji gua"）
-     * 按空格拆分为音节，取第一个音节并验证其数字编码是否与 [digits] 前缀匹配。
-     * 若 RIME 未返回有效 comment 或匹配失败，则回退到本地贪婪最长匹配。
-     */
-    private fun inferFirstSyllableFromRime(digits: String): T9PinyinMap.SyllableOption? {
-        val composition = onQueryRimeComposition?.invoke() ?: return fallbackFirstSyllable(digits)
-
-        val comment = composition.candidates
-            .firstOrNull { it.comment.isNotBlank() }
-            ?.comment
-            ?.trim()
-            ?: return fallbackFirstSyllable(digits)
-
-        val firstPinyin = comment.split(Regex("\\s+"))
-            .firstOrNull { it.isNotEmpty() }
-            ?: return fallbackFirstSyllable(digits)
-
-        val code = T9PinyinMap.pinyinToDigitCode(firstPinyin)
-        if (code != null && digits.startsWith(code)) {
-            return T9PinyinMap.SyllableOption(firstPinyin.lowercase(), code.length)
-        }
-        return fallbackFirstSyllable(digits)
-    }
-
-    private fun fallbackFirstSyllable(digits: String): T9PinyinMap.SyllableOption? {
-        return T9PinyinMap.firstSyllableOptions(digits, maxResults = 1).firstOrNull()
-    }
-
-    /** 处理数字按键/分词键按下 */
     fun onDigitPressed(digit: String) {
         val t0 = System.nanoTime()
         if (digit == "1") {
-            // 分词键：将当前数字段转为拼音 + 分隔符，锁定左侧候选区。
-            // 优先通过 RIME 候选 comment 反推最优首音节；失败时回退到贪婪最长匹配。
-            val segment = lastDigitSegment()
-            if (segment.isNotEmpty()) {
-                val segmentStart = inputBuffer.length - segment.length
-                val confirmed = inferFirstSyllableFromRime(segment)
-                if (confirmed != null) {
-                    // 在修改 buffer 前保存快照：保留分词前完整 buffer
-                    snapshots.add(
-                        Snapshot(
-                            buffer = inputBuffer,
-                            isRightCommit = false,
-                            separatorConsumedDigits = separatorConsumedDigits,
-                            lastChoiceConsumedDigits = lastChoiceConsumedDigits,
-                            leftColumnLocked = leftColumnLocked,
-                        )
-                    )
-                    // 记录分词键消费的数字段
-                    separatorConsumedDigits = segment.take(confirmed.digitLength)
-                    lastChoiceConsumedDigits = null
-                    val remaining = segment.drop(confirmed.digitLength)
-                    inputBuffer = inputBuffer.substring(0, segmentStart) + confirmed.pinyin + "'" + remaining
-                } else {
-                    if (!inputBuffer.endsWith("'")) {
-                        inputBuffer += "'"
-                    }
-                }
-            }
-            leftColumnLocked = true
-            sendToRime()
+            handleSeparatorKey()
             return
         }
 
-        // 在 RightCommit 后输入数字会修改 remainingAfterCommit，标记 dirty
-        if (snapshots.isNotEmpty() && snapshots.last().isRightCommit) {
-            rightCommitRemainingDirty = true
+        if (stateMachine.isIdle) {
+            stateMachine.enterInput()
+            syncStateFromMachine()
         }
-        // 已确认拼音（字母结尾）后追加数字时，自动插入分隔符 '。
-        // 让 RIME 把已确认拼音与新数字段解析为多音节，否则 "l4" 会被当作
-        // 单音节展开为 "li"，lua filter 无法替换数字段，preedit 显示 "l4" 而非 "l g"。
-        if (inputBuffer.isNotEmpty() && inputBuffer.last().isLetter()) {
-            inputBuffer += "'"
-        }
-        inputBuffer += digit
+        // T9Buffer 自动处理字母/数字间的分隔——不需要手动插入 '
+        pushCommand(T9Command.DigitPressed(digit))
+        inputBuffer = inputBuffer.addDigit(digit)
         candidateUpdater?.post { updateCandidates() } ?: updateCandidates()
+
         sendToRime()
         val elapsed = (System.nanoTime() - t0) / 1_000_000L
         if (elapsed > 5) {
-            try { android.util.Log.d("T9InputCtrl", "onDigitPressed('$digit') took ${elapsed}ms, buffer='${inputBuffer.take(20)}'") } catch (_: Throwable) { }
+            try { android.util.Log.d("T9InputCtrl", "onDigitPressed('$digit') took ${elapsed}ms, buffer='${inputBuffer.toBufferString().take(20)}'") } catch (_: Throwable) { }
         }
     }
 
-    /** 处理用户从左侧列选择音节 */
-    fun onChoiceSelected(option: T9PinyinMap.SyllableOption) {
-        // 在 RightCommit 后选择左侧候选会修改 remainingAfterCommit，标记 dirty
-        if (snapshots.isNotEmpty() && snapshots.last().isRightCommit) {
-            rightCommitRemainingDirty = true
-        }
-
-        val parts = parseInputBuffer(inputBuffer)
-
-        if (parts.apostropheIndex > 0) {
-            val afterApostrophe = parts.afterApostrophe
-            if (leftColumnLocked) {
-                // ── 锁定态：仅替换已有拼音，不消费新数字 ──
-                // 快照保存到分隔符为止的状态（剩余数字随当前选择一起可撤销）
-                snapshots.add(
-                    Snapshot(
-                        buffer = parts.confirmedPinyin + "'",
-                        isRightCommit = false,
-                        separatorConsumedDigits = separatorConsumedDigits,
-                        lastChoiceConsumedDigits = lastChoiceConsumedDigits,
-                        leftColumnLocked = leftColumnLocked,
-                    )
-                )
-                // 锁定态选择后，将分词键消费的数字段转给 lastChoiceConsumedDigits，
-                // 以便以分隔符结尾时仍能显示候选
-                lastChoiceConsumedDigits = separatorConsumedDigits
-                separatorConsumedDigits = null
-                inputBuffer = option.pinyin + "'" + afterApostrophe
-            } else {
-                // ── 未锁定态：从剩余数字段中消费 N 位 ──
-                val remaining = afterApostrophe.drop(option.digitLength)
-                val consumedDigits = afterApostrophe.take(option.digitLength)
-                // 快照保存撤销后应恢复的状态：confirmedPinyin + "'" + 本次消费的数字段
-                snapshots.add(
-                    Snapshot(
-                        buffer = parts.confirmedPinyin + "'" + consumedDigits,
-                        isRightCommit = false,
-                        separatorConsumedDigits = separatorConsumedDigits,
-                        lastChoiceConsumedDigits = lastChoiceConsumedDigits,
-                        leftColumnLocked = leftColumnLocked,
-                    )
-                )
-                // 记录左侧候选选择消费的数字段
-                lastChoiceConsumedDigits = consumedDigits
-                // 清空分词键消费的数字段
-                separatorConsumedDigits = null
-                inputBuffer = if (remaining.isEmpty()) {
-                    parts.confirmedPinyin + option.pinyin
-                } else {
-                    parts.confirmedPinyin + option.pinyin + "'" + remaining
-                }
+    /** 分词键（数字 1）：确认当前数字段的最优切分音节。 */
+    private fun handleSeparatorKey() {
+        val segment = inputBuffer.unassigned
+        if (segment.isNotEmpty()) {
+            val confirmed = rimeBridge.inferFirstSyllableFromRime(segment)
+            pushCommand(T9Command.Separator(
+                prevBuffer = inputBuffer,
+                prevSeparatorConsumedDigits = separatorConsumedDigits,
+                prevSelectionHistory = stateMachine.selectionHistory.toList(),
+            ))
+            if (confirmed != null) {
+                separatorConsumedDigits = segment.take(confirmed.digitLength)
+                lastChoiceConsumedDigits = null
+                // 确认音节：addSelection 同时记录拼音和消费对应位数
+                // （separatorConfirmedPinyin 已内化到 selections，由 toBufferString/toPreeditString 自然生成）
+                inputBuffer = inputBuffer.addSelection(confirmed.pinyin, confirmed.digitLength)
             }
-            leftColumnLocked = false
-            updateCandidates(force = true)
-            sendToRime()
+            // 无匹配音节：仅记录分词状态（separatorConsumedDigits 保持 null），不修改 inputBuffer
+        }
+        leftColumnLocked = true
+        sendToRime()
+    }
+
+    fun onChoiceSelected(option: T9PinyinMap.SyllableOption) {
+        // SELECTION 态 + 无未分配数字 → 替换
+        if (stateMachine.isSelection && inputBuffer.unassigned.isEmpty()) {
+            handleSelectionReplacementChoice(option)
             return
         }
 
-        // ── 纯数字段（无 '）：消费前 N 位数字 ──
-        val segment = parts.digitSegment
-        if (segment.isEmpty()) return
-        if (option.digitLength > segment.length) return
-        val segmentStart = inputBuffer.length - segment.length
-        val remaining = segment.drop(option.digitLength)
-        val consumedDigits = segment.take(option.digitLength)
-        // 快照保存「前缀已确认拼音 + 本次消费的数字段」：剩余数字由 onDeleted 优先级2逐位删除。
-        // 若只保存 consumedDigits，当 inputBuffer 含前缀字母（如 "l4"）时撤销会丢失前缀 "l"。
-        snapshots.add(
-            Snapshot(
-                buffer = inputBuffer.substring(0, segmentStart) + consumedDigits,
-                isRightCommit = false,
-                separatorConsumedDigits = separatorConsumedDigits,
-                lastChoiceConsumedDigits = lastChoiceConsumedDigits,
-                leftColumnLocked = leftColumnLocked,
-            )
-        )
-        // 记录左侧候选选择消费的数字段
-        lastChoiceConsumedDigits = consumedDigits
-        separatorConsumedDigits = null
-        inputBuffer = if (remaining.isEmpty()) {
-            inputBuffer.substring(0, segmentStart) + option.pinyin
+        // 有未分配数字 → 新选择
+        handleLeftSelectChoice(option)
+    }
+
+    /** 从未分配数字段中选择拼音（统一处理原 apostrophe / digitSegment 两条路径）。 */
+    private fun handleLeftSelectChoice(option: T9PinyinMap.SyllableOption) {
+        if (option.digitLength > inputBuffer.unassigned.length) return
+
+        val prevBuf = inputBuffer
+        val prevSep = separatorConsumedDigits
+        val prevLocked = leftColumnLocked
+        val prevOpt = stateMachine.selectedOption
+        val prevDigits = selectionCandidateDigits
+        val prevConf = stateMachine.confirmedPinyinBeforeSelection
+        val prevHist = stateMachine.selectionHistory.toList()
+
+        val consumedDigits = if (leftColumnLocked) {
+            separatorConsumedDigits ?: inputBuffer.unassigned.take(option.digitLength)
         } else {
-            inputBuffer.substring(0, segmentStart) + option.pinyin + "'" + remaining
+            inputBuffer.unassigned.take(option.digitLength)
         }
+        val confirmedPinyin = inputBuffer.selectedPinyin
+
+        // 撤销语义标记：
+        //   wasFromDigitContext=true  → undo 用 undoLastSelection/copy(dropLast) 移除选择、恢复数字
+        //   wasNoConsume=true         → undo 仅移除选择，不递减 consumedCount（addSelectionNoConsume 场景）
+        val wasFromDigitContext: Boolean
+        val wasNoConsume: Boolean
+
+        if (leftColumnLocked) {
+            lastChoiceConsumedDigits = separatorConsumedDigits
+            separatorConsumedDigits = null
+            if (inputBuffer.selections.isNotEmpty()) {
+                // 分词键确认拼音后替换：undo 用 undoLastSelection 移除替换选择、恢复数字
+                inputBuffer = inputBuffer.replaceLastSelection(option.pinyin, option.digitLength)
+                wasFromDigitContext = true
+                wasNoConsume = false
+            } else {
+                // 分词键未确认拼音后首次选字：undo 仅移除选择，不递减 consumedCount
+                inputBuffer = inputBuffer.addSelectionNoConsume(option.pinyin, option.digitLength)
+                wasFromDigitContext = true
+                wasNoConsume = true
+            }
+            leftColumnLocked = false
+            enterSelection(option, lastChoiceConsumedDigits ?: "", "")
+        } else {
+            // 从 INPUT 态首次选字：undo 用 undoLastSelection 移除选择、恢复数字
+            lastChoiceConsumedDigits = consumedDigits
+            separatorConsumedDigits = null
+            inputBuffer = inputBuffer.addSelection(option.pinyin, option.digitLength)
+            enterSelection(option, consumedDigits, confirmedPinyin)
+            wasFromDigitContext = true
+            wasNoConsume = false
+        }
+
+        pushCommand(T9Command.LeftChoice(
+            prevBuffer = prevBuf, prevSeparatorConsumedDigits = prevSep,
+            prevLeftColumnLocked = prevLocked, prevSelectedOption = prevOpt,
+            prevSelectionCandidateDigits = prevDigits, prevConfirmedPinyin = prevConf,
+            prevSelectionHistory = prevHist,
+            wasFromDigitContext = wasFromDigitContext,
+            wasNoConsume = wasNoConsume,
+        ))
         leftColumnLocked = false
         updateCandidates(force = true)
         sendToRime()
     }
 
-    /**
-     * 处理退格删除。
-     *
-     * 快照式撤销逻辑（优先级）：
-     *   1. RightCommit 后 remaining 未被修改 → 撤销 RightCommit（恢复完整 prevBuffer）
-     *   2. buffer 有数字段 → 逐位删除数字
-     *   3. 快照栈非空 → 撤销到上一个快照
-     *   4. buffer 非空 → 删除最后一个字符
-     *
-     * @return DeleteResult 区分操作类型：
-     *   - UNDO_COMMIT: 撤销右侧候选选词。clearRimeAndResend 已同步删除已提交文本
-     *   - UNDO_CHOICE: 撤销左侧候选区选词/分词键。已内部调用 sendToRime()
-     *   - DELETED:    已删除一个字符。已内部调用 sendToRime()
-     *   - NOT_CONSUMED: 无内容可删
-     */
+    /** SELECTION 替换：筛选层切换拼音/字母选项。 */
+    private fun handleSelectionReplacementChoice(option: T9PinyinMap.SyllableOption) {
+        if (!stateMachine.isSelection || stateMachine.selectedOption == null) return
+
+        val prevBuf = inputBuffer
+        val prevSep = separatorConsumedDigits
+        val prevLocked = leftColumnLocked
+        val prevOpt = stateMachine.selectedOption
+        val prevDigits = selectionCandidateDigits
+        val prevConf = stateMachine.confirmedPinyinBeforeSelection
+        val prevHist = stateMachine.selectionHistory.toList()
+
+        val candidateDigits = selectionCandidateDigits ?: ""
+        if (option.digitLength > candidateDigits.length) return
+
+        val newConsumedDigits = candidateDigits.take(option.digitLength)
+        val remaining = candidateDigits.drop(option.digitLength)
+        val confirmedPrefix = inputBuffer.selectedPinyin.dropLast(
+            (stateMachine.selectedOption?.pinyin?.length ?: 0)
+        )
+
+        inputBuffer = if (inputBuffer.selections.isNotEmpty()) {
+            inputBuffer.replaceLastSelection(option.pinyin, option.digitLength)
+        } else {
+            inputBuffer.addSelection(option.pinyin, option.digitLength)
+        }
+
+        if (stateMachine.selectionHistory.isNotEmpty()) {
+            stateMachine.removeLastSelectionHistoryEntry()
+        }
+        enterSelection(option, newConsumedDigits, confirmedPrefix)
+
+        // 筛选层替换：继承被替换命令的 prev 字段
+        var eBuf: T9Buffer = prevBuf; var eSep = prevSep; var eLocked = prevLocked
+        var eOpt = prevOpt; var eDigits = prevDigits; var eConf = prevConf; var eHist = prevHist
+        val replaced = undoManager.pop() as? T9Command.LeftChoice
+        if (replaced != null) {
+            eBuf = replaced.prevBuffer; eSep = replaced.prevSeparatorConsumedDigits
+            eLocked = replaced.prevLeftColumnLocked; eOpt = replaced.prevSelectedOption
+            eDigits = replaced.prevSelectionCandidateDigits; eConf = replaced.prevConfirmedPinyin
+            eHist = replaced.prevSelectionHistory
+        }
+        pushCommand(T9Command.LeftChoice(
+            prevBuffer = eBuf, prevSeparatorConsumedDigits = eSep,
+            prevLeftColumnLocked = eLocked, prevSelectedOption = eOpt,
+            prevSelectionCandidateDigits = eDigits, prevConfirmedPinyin = eConf,
+            prevSelectionHistory = eHist,
+        ))
+        if (remaining.isNotEmpty()) lastChoiceConsumedDigits = newConsumedDigits
+        updateCandidates(force = true)
+        sendToRime()
+    }
+
+    /** 退格删除。命令模式：pop 栈顶命令 → 执行其 undo()。 */
     fun onDeleted(): DeleteResult {
-        // ── 优先级1：RightCommit 撤销（remaining 未被修改且当前数字段完整保留）──
-        if (snapshots.isNotEmpty()) {
-            val lastSnapshot = snapshots.last()
-            if (lastSnapshot.isRightCommit && !rightCommitRemainingDirty) {
-                val currentDigitSegment = lastDigitSegment()
-                if (currentDigitSegment == lastSnapshot.remainingAfterCommit) {
-                    val snapshot = snapshots.removeAt(snapshots.lastIndex)
-                    rightCommitRemainingDirty = false
-                    separatorConsumedDigits = null
-                    lastChoiceConsumedDigits = null
-                    inputBuffer = snapshot.buffer
-                    leftColumnLocked = false
-                    updateCandidates(force = true)
-                    // UNDO_COMMIT: 不调 sendToRime() — 由 UI 层先删除已提交文本再调用
-                    return DeleteResult.UNDO_COMMIT
-                }
-            }
+        // 检查 RightCommit 是否可立即撤销：
+        // digitSequence 未变化（length == remainingDigitCount）说明用户未做中间操作，
+        // 可安全撤销 RC；digitSequence 缩短（删除了数字）说明用户正在逐步回退，
+        // 应先删完剩余数字再通过 step3 撤销 RC。
+        val top = undoManager.peek()
+        if (top is T9Command.RightCommit &&
+            inputBuffer.digitSequence.length == top.remainingDigitCount) {
+            val ctx = undoCtx()
+            undoManager.popAndUndo(ctx)
+            applyUndoCtx(ctx)
+            return DeleteResult.UNDO_COMMIT
         }
 
-        // ── 优先级2：buffer 有数字段 → 逐位删除数字 ──
-        if (lastDigitSegment().isNotEmpty()) {
-            inputBuffer = inputBuffer.dropLast(1)
-            leftColumnLocked = false
-            updateCandidates()
-            sendToRime()
-            // 如果正在删除 RightCommit 的 remaining，标记 dirty
-            if (snapshots.isNotEmpty() && snapshots.last().isRightCommit) {
-                rightCommitRemainingDirty = true
-            }
-            return DeleteResult.DELETED
-        }
-
-        // ── 优先级3：快照栈非空 → 撤销到上一个快照 ──
-        if (snapshots.isNotEmpty()) {
-            val snapshot = snapshots.removeAt(snapshots.lastIndex)
-            // 恢复辅助状态
-            separatorConsumedDigits = snapshot.separatorConsumedDigits
-            lastChoiceConsumedDigits = snapshot.lastChoiceConsumedDigits
-            leftColumnLocked = snapshot.leftColumnLocked
-
-            if (snapshot.isRightCommit) {
-                rightCommitRemainingDirty = false
-                // remaining 已被删光，只恢复 consumedDigits
-                inputBuffer = snapshot.consumedDigits
-                updateCandidates(force = true)
-                // UNDO_COMMIT: 不调 sendToRime() — 由 UI 层先删除已提交文本再调用
-                return DeleteResult.UNDO_COMMIT
-            } else {
-                // LeftChoice/Separator：快照已预计算好撤销后应恢复的 buffer，直接恢复
-                inputBuffer = snapshot.buffer
-                updateCandidates(force = true)
+        // 有未分配数字 → 逐位删除数字（T9Buffer.unassigned 对应旧的 lastDigitSegment）
+        if (inputBuffer.unassigned.isNotEmpty()) {
+            // 栈顶为 Separator（无 DigitPressed 在其上）→ 撤销分词键
+            if (undoManager.isNotEmpty() && undoManager.peek() is T9Command.Separator) {
+                val ctx = undoCtx()
+                undoManager.popAndUndo(ctx)
+                applyUndoCtx(ctx)
                 sendToRime()
                 return DeleteResult.UNDO_CHOICE
             }
+            // 弹出栈顶一个 DigitPressed 命令（逐位退格，不一次性弹出全部）
+            if (undoManager.isNotEmpty() && undoManager.peek() is T9Command.DigitPressed) {
+                undoManager.pop()
+            }
+            inputBuffer = inputBuffer.removeLastDigit()
+            // 有已确认拼音（selections 非空）时保持列锁定，否则解锁
+            if (inputBuffer.selections.isEmpty()) {
+                leftColumnLocked = false
+            }
+            if (inputBuffer.isEmpty) {
+                enterIdle()
+            } else if (inputBuffer.unassigned.isEmpty() && inputBuffer.consumedCount > 0
+                && inputBuffer.selections.isEmpty() && undoManager.hasPendingRightCommit()) {
+                // 僵尸 RC 状态：所有未分配数字已删完，但 consumed 部分仍存在。
+                // 进入 SELECTION 态显示栈顶 RC 消费的数字段候选，高亮已提交拼音。
+                // 多 RC 叠加时，仅取栈顶 RC 消费的部分（如"策"消费"23"），
+                // 而非全部 consumed 数字段（如"546946423"含"进行"+"策"两次提交）。
+                val topRC = undoManager.peek() as? T9Command.RightCommit
+                val prevConsumedCount = topRC?.prevBuffer?.consumedCount ?: 0
+                val rcDigitStart = prevConsumedCount.coerceAtMost(inputBuffer.digitSequence.length)
+                val rcDigitEnd = inputBuffer.consumedCount.coerceAtMost(inputBuffer.digitSequence.length)
+                val consumedDigits = if (rcDigitStart < rcDigitEnd) {
+                    inputBuffer.digitSequence.substring(rcDigitStart, rcDigitEnd)
+                } else {
+                    inputBuffer.digitSequence.take(inputBuffer.consumedCount)
+                }
+                val options = T9PinyinMap.firstSyllableOptions(consumedDigits)
+                val committedOption = options.firstOrNull { it.digitLength == consumedDigits.length }
+                    ?: options.firstOrNull()
+                if (committedOption != null) {
+                    enterSelection(committedOption, consumedDigits)
+                }
+                updateCandidates(force = true)
+            } else {
+                updateCandidates()
+            }
+            sendToRime()
+            return DeleteResult.DELETED
         }
 
-        // ── 优先级4：buffer 非空 → 删除最后一个字符 ──
-        if (inputBuffer.isNotEmpty()) {
-            inputBuffer = inputBuffer.dropLast(1)
+        // 无未分配数字 → 执行栈顶命令的 undo
+        if (undoManager.isNotEmpty()) {
+            val ctx = undoCtx()
+            val isSep = top is T9Command.Separator
+            val isLC = top is T9Command.LeftChoice
+            undoManager.popAndUndo(ctx)
+            // undo LeftChoice 后清除 stale DigitPressed，避免后续退格时优先删数字而非撤销 Separator
+            if (isLC) {
+                undoManager.removeLastDigitPressed()
+            }
+            applyUndoCtx(ctx)
+            val isRC = top is T9Command.RightCommit
+            if (!isRC) {
+                sendToRime()
+            }
+            return if (isRC) DeleteResult.UNDO_COMMIT else DeleteResult.UNDO_CHOICE
+        }
+
+        // 无命令 → 逐位删字符（字母/符号）
+        if (!inputBuffer.isEmpty) {
+            inputBuffer = inputBuffer.removeLastDigit()
             leftColumnLocked = false
-            updateCandidates()
+            if (inputBuffer.isEmpty) enterIdle() else updateCandidates()
             sendToRime()
             return DeleteResult.DELETED
         }
@@ -531,174 +498,91 @@ class T9InputController(
         return DeleteResult.NOT_CONSUMED
     }
 
-    /**
-     * 处理右侧候选列表选词（partial commit，无拼音注释信息）。
-     *
-     * 委托给 [onRightCandidateSelected] 并传入 null。
-     * 当拼音注释不可用时，回退到基于 [firstSyllableOptions] 消费第一个音节。
-     */
-    fun onRightCandidateSelected(): Boolean = onRightCandidateSelected(null)
-
-    /**
-     * 处理右侧候选列表选词（partial commit）。
-     *
-     * 用户从右侧候选列表选词后，RIME 做 partial commit，提交选中文本并保留剩余拼音。
-     * 本方法接收候选词的拼音注释，通过计算拼音字母数确定消费的数字位数，
-     * 零额外 JNI 调用——拼音注释已由 getCandidatesWithComments() 获取。
-     *
-     * @param candidatePinyin 候选词的拼音注释（如 "jin xing"、"ce"）。
-     *                        null = 无拼音注释，回退到消费第一个音节。
-     *                        拼音注释中每个字母对应一个数字键，字母总数 = 消费位数。
-     *
-     * 设计决策：
-     * - 不调用 sendToRime() — RIME 已有正确状态
-     * - 保存快照，使 backspace 能撤销这次操作恢复原始数字序列
-     * - 零额外 JNI 调用 — 使用已有的拼音注释数据
-     *
-     * @return 如果本次选词后 inputBuffer 已空，说明输入序列被完整消费，调用方应视为 full commit。
-     */
-    fun onRightCandidateSelected(candidatePinyin: String?): Boolean {
-        if (inputBuffer.isEmpty()) return true
-
-        // ── 保存快照 ──
-        // 计算 consumedDigits 与 remainingAfterCommit，用于撤销时恢复
-        val parts = parseInputBuffer(inputBuffer)
-        val (consumedDigits, remainingAfterCommit) = if (parts.apostropheIndex >= 0) {
-            // 带分隔符时，候选词可能消费 confirmed pinyin 之后的剩余字母。
-            // 用候选拼音字母总数减去 confirmed 字母数，得到剩余段应消费的长度。
-            val candidateLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
-            val consumedAfter = candidateLetterCount - parts.confirmedPinyin.length
-            if (consumedAfter > 0) {
-                val remaining = parts.afterApostrophe.drop(consumedAfter)
-                parts.afterApostrophe.take(consumedAfter) to remaining
-            } else {
-                // 候选未消费分隔符后内容：保持原有行为
-                parts.afterApostrophe to parts.afterApostrophe
-            }
-        } else {
-            val segment = parts.digitSegment
-            if (segment.isNotEmpty()) {
-                val consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin)
-                segment.take(consumedCount) to segment.drop(consumedCount)
-            } else {
-                // 纯拼音段：视为消费全部，剩余为空
-                "" to ""
-            }
-        }
-        snapshots.add(
-            Snapshot(
-                buffer = inputBuffer,
-                isRightCommit = true,
-                consumedDigits = consumedDigits,
-                remainingAfterCommit = remainingAfterCommit,
-                separatorConsumedDigits = separatorConsumedDigits,
-                lastChoiceConsumedDigits = lastChoiceConsumedDigits,
-                leftColumnLocked = leftColumnLocked,
-            )
-        )
-        rightCommitRemainingDirty = false
-        // 清空辅助状态
-        separatorConsumedDigits = null
-        lastChoiceConsumedDigits = null
-
-        // Case 1: buffer 含分隔符（已确认拼音 + 剩余数字）
-        //   例如 "pi'4" → RIME 消费 "pi"，保留 "4"
-        //   例如 "k'ge" + 候选 kehu → RIME 消费全部，buffer 清空
-        if (parts.apostropheIndex >= 0) {
-            inputBuffer = remainingAfterCommit
-            leftColumnLocked = false
-            updateCandidates(force = true)
-            lastRimeInput = inputBuffer
-            return inputBuffer.isEmpty()
-        }
-
-        // Case 2: 纯数字段 — 使用候选词拼音注释计算消费位数
-        val segment = parts.digitSegment
-        if (segment.isNotEmpty()) {
-            val consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin)
-            val segmentStart = inputBuffer.length - segment.length
-            val remaining = segment.drop(consumedCount)
-            inputBuffer = inputBuffer.substring(0, segmentStart) + remaining
-            leftColumnLocked = false
-            updateCandidates(force = true)
-            lastRimeInput = inputBuffer
-            return inputBuffer.isEmpty()
-        }
-
-        // Case 3: 纯拼音段（无数字，无分隔符）— RIME 消费全部
-        //   例如 "pi" → RIME 全量消费，buffer 清空
-        inputBuffer = ""
-        firstOptions = emptyList()
-        leftColumnLocked = false
-        lastRimeInput = inputBuffer
-        return true
+    /** 将命令 undo 后的 Ctx 状态同步回控制器字段 */
+    private fun applyUndoCtx(ctx: T9Command.Ctx) {
+        inputBuffer = ctx.buffer
+        leftColumnLocked = ctx.leftColumnLocked
+        separatorConsumedDigits = ctx.separatorConsumedDigits
+        lastChoiceConsumedDigits = ctx.lastChoiceConsumedDigits
+        syncStateFromMachine()
+        updateCandidates(force = true)
     }
 
-    /**
-     * 清除 RIME composition 后重新发送完整 inputBuffer。
-     *
-     * 用于 UNDO_COMMIT 场景：先撤销最近一次右侧候选选词（删除已提交文本并从
-     * partial commit 列表中移除），再清 RIME composition，最后送完整数字序列
-     * （setInput）。同步执行避免异步 KEYCODE_DEL 干扰新 composition。
-     */
+    private val rightCommitHandler = T9RightCommitHandler()
+
+    fun onRightCandidateSelected(): Boolean = onRightCandidateSelected(null)
+
+    /** 右侧候选选词（partial commit），返回 true = 完整消费。 */
+    fun onRightCandidateSelected(candidatePinyin: String?, candidateTextLength: Int = 0): Boolean {
+        if (inputBuffer.isEmpty) return true
+
+        // 全简拼无候选 → enterLike 提交（需控制器级别的 resetState）
+        // 不清除 RIME：服务层需要 composition 完整以便 selectCandidate + commit
+        if (candidatePinyin.isNullOrBlank() && stateMachine.selectionHistory.isNotEmpty() &&
+            stateMachine.selectionHistory.all { it.digitLength == 1 }) {
+            resetState(clearCache = true, clearRime = false)
+            return true
+        }
+
+        var ctxRef: T9RightCommitHandler.Ctx? = null
+        val ctx = T9RightCommitHandler.Ctx(
+            inputBuffer = inputBuffer,
+            leftColumnLocked = leftColumnLocked,
+            separatorConsumedDigits = separatorConsumedDigits,
+            lastChoiceConsumedDigits = lastChoiceConsumedDigits,
+            stateMachine = stateMachine,
+            undoManager = undoManager,
+            syncState = { syncStateFromMachine() },
+            updateCandidates = { force ->
+                leftColumnLocked = ctxRef!!.leftColumnLocked
+                updateCandidates(force)
+            },
+            setRimeInput = { rimeBridge.setLastRimeInput(it) },
+        )
+        ctxRef = ctx
+
+        val result = rightCommitHandler.onRightCandidateSelected(ctx, candidatePinyin, candidateTextLength)
+
+        // handler 已直接操作 T9Buffer，直接同步回控制器
+        inputBuffer = ctx.inputBuffer
+        leftColumnLocked = ctx.leftColumnLocked
+        separatorConsumedDigits = ctx.separatorConsumedDigits
+        lastChoiceConsumedDigits = ctx.lastChoiceConsumedDigits
+        syncStateFromMachine()
+        updateCandidates(force = true)
+        // 不调用 sendToRime()：服务层需要 RIME composition 保持完整，
+        // 以便在 onRightCandidateSelected 返回后调用 rimeEngine.selectCandidate + commit。
+        // full commit：服务 commit 后通过 t9ResetSignal 触发 controller.reset()
+        // partial commit：服务 commit 后调用 forceSendToRime() 发送剩余数字到 RIME
+
+        return result
+    }
+
     fun clearRimeAndResend() {
-        onRightCommitUndone?.invoke(1)
-        lastRimeInput = null
-        onReplaceFullPinyin("")
+        rimeBridge.clearRimeAndResend()
         sendToRime()
     }
 
-    /** 清空所有输入和候选 */
-    fun clearAll() {
-        inputBuffer = ""
+    fun clearAll() = resetState(clearCache = false, clearRime = true)
+
+    fun onEnterCommit() = resetState(clearCache = true, clearRime = true)
+
+    private fun resetState(clearCache: Boolean, clearRime: Boolean) {
+        inputBuffer = T9Buffer.EMPTY
         firstOptions = emptyList()
         leftColumnLocked = false
-        snapshots.clear()
-        rightCommitRemainingDirty = false
+        stateMachine.enterIdle()
+        syncStateFromMachine()
+        undoManager.clear()
         separatorConsumedDigits = null
         lastChoiceConsumedDigits = null
-        onReplaceFullPinyin(CLEAR_ALL)
-    }
-
-    /**
-     * 用户按"换行"键提交预编辑文本后调用。
-     * 彻底清空控制器状态并通知服务层清空 partial commit 累积文本，
-     * 防止下一轮输入出现上一轮 partial commit 残留。
-     */
-    fun onEnterCommit() {
-        inputBuffer = ""
-        firstOptions = emptyList()
-        lastRimeInput = null
-        leftColumnLocked = false
-        snapshots.clear()
-        rightCommitRemainingDirty = false
-        separatorConsumedDigits = null
-        lastChoiceConsumedDigits = null
-        cachedDigitSegment = null
-        cachedFirstOptions = emptyList()
-        onReplaceFullPinyin(CLEAR_ALL)
-    }
-
-    /**
-     * 从候选词拼音注释计算消费的数字位数
-     *
-     * 原理：T9 九宫格中每个字母对应一个数字键，拼音注释的字母总数 = 消费的数字位数。
-     * 例如 "jin xing" = 7 个字母 = 7 位数字，"ce" = 2 个字母 = 2 位数字。
-     *
-     * @param segment 当前纯数字段
-     * @param candidatePinyin 候选词的拼音注释，null 表示无拼音信息
-     * @return 应消费的数字位数
-     */
-    private fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): Int {
-        if (!candidatePinyin.isNullOrEmpty()) {
-            // 计算拼音注释中的 ASCII 字母数量（每个字母对应一个数字键）
-            val letterCount = candidatePinyin.count { it in 'a'..'z' || it in 'A'..'Z' }
-            if (letterCount > 0 && letterCount <= segment.length) {
-                return letterCount
-            }
+        if (clearCache) {
+            rimeBridge.setLastRimeInput(null)
+            cachedDigitSegment = null
+            cachedFirstOptions = emptyList()
         }
-        // 无拼音信息或计算失败，回退到单音节消费
-        val options = T9PinyinMap.firstSyllableOptions(segment, maxResults = 1)
-        return options.firstOrNull()?.digitLength ?: 0
+        if (clearRime) {
+            rimeBridge.replaceFullPinyin(CLEAR_ALL)
+        }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9PinyinMap.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9PinyinMap.kt
@@ -89,6 +89,9 @@ object T9PinyinMap {
         return firstSyllableOptions(digits, maxResults).map { it.pinyin }
     }
 
+    /** pinyinToDigitCode 结果缓存（惰性填充，有效拼音结果才缓存） */
+    private val pinyinCodeCache = mutableMapOf<String, String>()
+
     /**
      * 将拼音字符串转为九宫格数字编码。
      *
@@ -96,12 +99,16 @@ object T9PinyinMap {
      * 若包含无法映射的字符则返回 null。
      */
     fun pinyinToDigitCode(pinyin: String): String? {
-        return buildString {
-            for (ch in pinyin.lowercase()) {
+        val key = pinyin.lowercase()
+        pinyinCodeCache[key]?.let { return it }
+        val code = buildString {
+            for (ch in key) {
                 val digit = LETTER_TO_DIGIT[ch] ?: return null
                 append(digit)
             }
         }
+        pinyinCodeCache[key] = code
+        return code
     }
 
     /** 编码→拼音映射（精确匹配） */
@@ -134,6 +141,18 @@ object T9PinyinMap {
             remaining = remaining.drop(best.digitLength)
         }
         return result
+    }
+
+    /**
+     * 判断两个拼音的 T9 数字编码是否匹配（一个编码是另一个的前缀）。
+     *
+     * 九键中"g"和"ge"同属数字"4"+"3"="43"区，但"g"只映射"4"。
+     * 这解决场景6中精确拼音比较"ge"=="g"失败的问题。
+     */
+    fun areDigitCodesMatching(a: String, b: String): Boolean {
+        val codeA = pinyinToDigitCode(a) ?: return false
+        val codeB = pinyinToDigitCode(b) ?: return false
+        return codeA == codeB || codeA.startsWith(codeB) || codeB.startsWith(codeA)
     }
 
     /** 字母→数字映射 */

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
@@ -1,0 +1,831 @@
+package com.kingzcheung.xime.rime
+
+/**
+ * 右侧候选词选词处理器。
+ *
+ * 从 [T9InputController] 中提取所有右侧选词相关的判定与提交逻辑，
+ * 通过 [Ctx] 暴露控制器所需的最小可变状态接口，降低控制器的体积与复杂度。
+ *
+ * 设计文档 §13.1 扩展：原先 onRightCandidateSelected() 的三层消费算法及所有
+ * 子方法（handleSelectionLetterBufferCommit / tryShengmuFallback 等）
+ * 统一内聚于此。
+ *
+ * 步骤5 重构：Ctx.inputBuffer 类型从 String 改为 T9Buffer，
+ * 消除 String 往返架构。handler 内部直接操作 T9Buffer 结构化模型。
+ */
+class T9RightCommitHandler {
+
+    /**
+     * 控制器可变状态上下文。
+     *
+     * 仅暴露右侧选词处理过程所需的读写字段与回调，
+     * 避免将整个 [T9InputController] 的私有字段全部外泄。
+     */
+    class Ctx(
+        var inputBuffer: T9Buffer,
+        var leftColumnLocked: Boolean,
+        var separatorConsumedDigits: String?,
+        var lastChoiceConsumedDigits: String?,
+        val stateMachine: T9StateMachine,
+        val undoManager: T9UndoManager,
+        val syncState: () -> Unit,
+        val updateCandidates: (Boolean) -> Unit,
+        val setRimeInput: (String?) -> Unit,
+    )
+
+    // ── 公共入口 ──
+
+    /**
+     * 右侧候选选词（partial commit），返回 true = 完整消费（full commit）。
+     *
+     * @param ctx 控制器可变状态上下文
+     * @param candidatePinyin RIME 候选词注释（spelling_hints）
+     * @param candidateTextLength 候选词文字长度（汉字数）
+     */
+    fun onRightCandidateSelected(
+        ctx: Ctx,
+        candidatePinyin: String?,
+        candidateTextLength: Int = 0,
+    ): Boolean {
+        if (ctx.inputBuffer.isEmpty) return true
+
+        // 全简拼无候选 → enterLike 提交
+        if (candidatePinyin.isNullOrBlank() && ctx.stateMachine.selectionHistory.isNotEmpty() &&
+            ctx.stateMachine.selectionHistory.all { it.digitLength == 1 }
+        ) {
+            ctx.undoManager.clear()
+            clearAndEnterIdle(ctx)
+            return true
+        }
+
+        val buf = ctx.inputBuffer
+        val hasSelections = buf.selections.isNotEmpty()
+        val hasUnassigned = buf.unassigned.isNotEmpty()
+
+        // 计算消费（T9Buffer 版本）
+        val (_, remainingDigits) = computeRightCommitConsumption(buf, candidatePinyin)
+
+        val prevBuf = buf
+        val prevSep = ctx.separatorConsumedDigits
+        val prevLC = ctx.lastChoiceConsumedDigits
+        val prevLocked = ctx.leftColumnLocked
+        val prevOpt = ctx.stateMachine.selectedOption
+        val prevDigits = ctx.stateMachine.selectionCandidateDigits
+        val prevConf = ctx.stateMachine.confirmedPinyinBeforeSelection
+        val prevHist = ctx.stateMachine.selectionHistory.toList()
+
+        ctx.undoManager.push(T9Command.RightCommit(
+            prevBuffer = prevBuf,
+            prevSeparatorConsumedDigits = prevSep,
+            prevLastChoiceConsumedDigits = prevLC,
+            prevLeftColumnLocked = prevLocked,
+            prevSelectedOption = prevOpt,
+            prevSelectionCandidateDigits = prevDigits,
+            prevConfirmedPinyin = prevConf,
+            prevSelectionHistory = prevHist,
+        ))
+
+        val selOptTemp = prevOpt
+        val selDigitsTemp = prevDigits
+        val selConfTemp = prevConf
+        ctx.separatorConsumedDigits = null
+        ctx.lastChoiceConsumedDigits = null
+        ctx.stateMachine.selectedOption = null
+        ctx.stateMachine.selectionCandidateDigits = null
+        ctx.stateMachine.confirmedPinyinBeforeSelection = ""
+
+        // 分支判断（基于 T9Buffer 结构）：
+        //   apostrophe 模式 → selections 非空 && unassigned 非空
+        //   digitSegment 模式 → selections 为空 && unassigned 非空
+        //   letterBuffer 模式 → selections 非空 && unassigned 为空
+        val isFullCommit = when {
+            hasSelections && hasUnassigned ->
+                handleApostropheRightCommit(ctx, remainingDigits, candidatePinyin,
+                    selOptTemp, selDigitsTemp, selConfTemp)
+            hasUnassigned ->
+                handleDigitSegmentRightCommit(ctx, candidatePinyin,
+                    selOptTemp, selDigitsTemp, selConfTemp)
+            else ->
+                handleLetterBufferRightCommit(ctx, candidatePinyin, candidateTextLength,
+                    selOptTemp, selDigitsTemp, selConfTemp, prevBuf)
+        }
+        // 记录 commit 后 buffer 的 digitSequence 长度，供撤销时安全检查
+        ctx.undoManager.updateTopRightCommitRemaining(ctx.inputBuffer.digitSequence.length)
+        // full commit 后 inputBuffer 已清空，undo 栈中的命令（含刚入栈的 RightCommit
+        // 及之前的 DigitPressed/LeftChoice）已无意义。若不清空，用户退格会触发
+        // popAndUndo 恢复已提交的状态，造成"提交后撤回"的异常行为。
+        if (isFullCommit) {
+            ctx.undoManager.clear()
+        }
+        return isFullCommit
+    }
+
+    /**
+     * 当上层（XimeInputMethodService）需要携带额外的 candidateTextLength 信息时调用。
+     * 用于服务层已知候选词字数但 RIME 不返回 comment 的场景（如空格提交全简拼）。
+     */
+    fun onRightCandidateSelected(
+        ctx: Ctx,
+        candidatePinyin: String?,
+        candidateTextLength: Int,
+        isSpaceCommit: Boolean, // unused for now, reserved
+    ): Boolean = onRightCandidateSelected(ctx, candidatePinyin, candidateTextLength)
+
+    // ── 辅助 ──
+
+    private fun enterIdle(ctx: Ctx) {
+        ctx.inputBuffer = T9Buffer.EMPTY
+        ctx.leftColumnLocked = false
+        ctx.stateMachine.enterIdle()
+        ctx.syncState()
+    }
+
+    private fun clearAndEnterIdle(ctx: Ctx) {
+        enterIdle(ctx)
+        ctx.updateCandidates(true)
+        // 设 null 而非空字符串：服务层需在 selectCandidate+commit 后
+        // 通过 forceSendToRime/reset 重新同步，避免 lastRimeInput 与实际 RIME 状态不一致
+        ctx.setRimeInput(null)
+    }
+
+    private fun restorePrevState(
+        ctx: Ctx,
+        prevSelectedOption: T9PinyinMap.SyllableOption?,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String = "",
+    ): Boolean {
+        if (prevSelectedOption != null) {
+            ctx.stateMachine.restoreFrom(
+                T9StateMachine.State.SELECTION,
+                prevSelectedOption,
+                prevSelectionCandidateDigits ?: "",
+                prevConfirmedPinyin,
+                ctx.stateMachine.selectionHistory.toList(),
+            )
+        } else {
+            ctx.stateMachine.enterInput()
+        }
+        ctx.syncState()
+        ctx.updateCandidates(true)
+        ctx.setRimeInput(null)
+        return false
+    }
+
+    /**
+     * 从 T9Buffer.selections 头部移除被消费的拼音选择。
+     *
+     * 仅移除 selections，不修改 consumedCount（保持 unassigned 不变）。
+     * 同步调用 [T9StateMachine.removeConsumedHistoryEntries] 更新 selectionHistory。
+     */
+    private fun removeConsumedSelections(
+        ctx: Ctx,
+        buf: T9Buffer,
+        consumedPinyin: String,
+    ): T9Buffer {
+        if (consumedPinyin.isEmpty()) return buf
+        var remaining = consumedPinyin
+        var cutIndex = 0
+        for (i in buf.selections.indices) {
+            if (remaining.isEmpty()) break
+            val sel = buf.selections[i]
+            if (sel.pinyin.length <= remaining.length && remaining.startsWith(sel.pinyin)) {
+                remaining = remaining.drop(sel.pinyin.length)
+                cutIndex = i + 1
+            } else {
+                break
+            }
+        }
+        ctx.stateMachine.removeConsumedHistoryEntries(consumedPinyin)
+        return buf.copy(selections = buf.selections.drop(cutIndex))
+    }
+
+    /**
+     * 构造纯数字 T9Buffer（用于 digitSegment 模式的剩余数字）。
+     * 保留原始 digitSequence 和 totalDigitsEntered。
+     */
+    private fun T9Buffer.withRemainingDigits(
+        remainingDigits: String,
+        originalBuf: T9Buffer,
+    ): T9Buffer {
+        if (remainingDigits.isEmpty()) return T9Buffer.EMPTY
+        // 剩余数字是原始 digitSequence 的后缀
+        // consumedCount = digitSequence.length - remainingDigits.length
+        return T9Buffer(
+            digitSequence = originalBuf.digitSequence,
+            selections = emptyList(),
+            consumedCount = originalBuf.digitSequence.length - remainingDigits.length,
+            totalDigitsEntered = originalBuf.totalDigitsEntered,
+        )
+    }
+
+    // ── 三层消费算法实现（T9Buffer 版本） ──
+
+    /**
+     * 计算右侧候选选词时消费的数字段和剩余段（T9Buffer 版本）。
+     *
+     * 三层消费算法：
+     *   层级1：apostrophe 模式（selections 非空 && unassigned 非空）
+     *     从 unassigned 中按字母数消费
+     *   层级2：digitSegment 模式（selections 为空 && unassigned 非空）
+     *     从 candidatePinyin 逐音节匹配 unassigned 前缀
+     *   层级3：letterBuffer 模式（selections 非空 && unassigned 为空）
+     *     通过 pinyinToDigitCode 回退转为数字，再按数字段模式处理
+     */
+    private fun computeRightCommitConsumption(
+        buf: T9Buffer,
+        candidatePinyin: String?,
+    ): Pair<String, String> {
+        val hasSelections = buf.selections.isNotEmpty()
+        val unassigned = buf.unassigned
+
+        // apostrophe 模式
+        if (hasSelections && unassigned.isNotEmpty()) {
+            val candidateLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
+            val consumedAfter = candidateLetterCount - buf.selectedPinyin.length
+            if (consumedAfter > 0) {
+                val remaining = unassigned.drop(consumedAfter)
+                return unassigned.take(consumedAfter) to remaining
+            }
+            return unassigned to unassigned
+        }
+
+        // digitSegment 模式
+        if (!hasSelections && unassigned.isNotEmpty()) {
+            val segment = unassigned
+            val consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin)
+            return segment.take(consumedCount) to segment.drop(consumedCount)
+        }
+
+        // letterBuffer 模式
+        val selectedPinyin = buf.selectedPinyin
+        val effectiveLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
+        if (effectiveLetterCount > 0 && effectiveLetterCount < selectedPinyin.length) {
+            val consumedDig = T9PinyinMap.pinyinToDigitCode(selectedPinyin.take(effectiveLetterCount)) ?: ""
+            val remainingDig = T9PinyinMap.pinyinToDigitCode(selectedPinyin.drop(effectiveLetterCount)) ?: ""
+            return consumedDig to remainingDig
+        }
+        if (effectiveLetterCount >= selectedPinyin.length) return "" to ""
+
+        val digits = T9PinyinMap.pinyinToDigitCode(selectedPinyin)
+        if (digits != null) {
+            val consumedDigitCount = T9PinyinMap.firstSyllableOptions(digits, maxResults = 1)
+                .firstOrNull()?.digitLength ?: 0
+            if (consumedDigitCount in 1..<digits.length) {
+                return digits.take(consumedDigitCount) to digits.drop(consumedDigitCount)
+            }
+        }
+        return "" to ""
+    }
+
+    private fun handleApostropheRightCommit(
+        ctx: Ctx,
+        remainingDigits: String,
+        candidatePinyin: String?,
+        prevSelectedOption: T9PinyinMap.SyllableOption?,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val confirmedPinyin = buf.selectedPinyin
+
+        if (prevSelectedOption != null && confirmedPinyin.endsWith(prevSelectedOption.pinyin)
+            && confirmedPinyin.length > prevSelectedOption.pinyin.length
+        ) {
+            val selectedPinyin = prevSelectedOption.pinyin
+            val nonSelectedPinyin = confirmedPinyin.dropLast(selectedPinyin.length)
+            val candidateLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
+            val consumedFromNonSelected = minOf(candidateLetterCount, nonSelectedPinyin.length)
+            val unconsumedPinyin = nonSelectedPinyin.drop(consumedFromNonSelected)
+
+            // apostrophe 模式下，候选词注释的音节数必须足以覆盖所有已确认选择
+            // 以及未分配数字（至少一个额外音节）。若音节不足，即使字母数模型显示
+            // remainingDigits 为空，也不能触发 full commit，否则会把未分配数字一并提交。
+            // 典型场景：kg'3 + "客观(ke guan)" → ke/k, guan/g，剩余 3 未被覆盖。
+            val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
+                ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+            val requiredSyllables = buf.selections.size + if (buf.unassigned.isNotEmpty()) 1 else 0
+            val canCoverAllBySyllableCount = commentSyllables.size >= requiredSyllables
+
+            if (canCoverAllBySyllableCount &&
+                shouldFullCommitInSelection(consumedFromNonSelected, nonSelectedPinyin.length, remainingDigits, candidatePinyin, selectedPinyin)
+            ) {
+                clearAndEnterIdle(ctx)
+                return true
+            }
+            val consumedNonSelectedPinyin = nonSelectedPinyin.take(consumedFromNonSelected)
+            // 移除被消费的前缀选择，保留 unassigned 不变
+            ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedNonSelectedPinyin)
+            ctx.leftColumnLocked = false
+
+            // 声母级消费选中项：当 nonSelected 已完全消费、候选词最后一个音节的声母
+            // 与当前选中项（简拼）首字母数字码匹配时，表示该选中项也被候选项消费。
+            // 例如 kg'3 右选 "客观(ke guan)"：ke 消费 k，guan 的声母 g 消费选中项 g，
+            // 仅保留未分配数字 3 并进入 INPUT 态。
+            if (unconsumedPinyin.isEmpty() &&
+                prevSelectedOption.digitLength == 1 &&
+                commentSyllables.isNotEmpty()
+            ) {
+                val lastSyl = commentSyllables.last()
+                val lastInitial = lastSyl.first().toString()
+                val selInitial = prevSelectedOption.pinyin.first().toString()
+                val lastInitialCode = T9PinyinMap.pinyinToDigitCode(lastInitial)
+                val selInitialCode = T9PinyinMap.pinyinToDigitCode(selInitial)
+                val selDigits = prevSelectionCandidateDigits ?: ""
+                if (lastInitialCode != null && selInitialCode != null &&
+                    lastInitialCode == selInitialCode &&
+                    selDigits.startsWith(lastInitialCode)
+                ) {
+                    // 移除最后一个选择，仅保留未分配数字
+                    ctx.inputBuffer = ctx.inputBuffer.copy(
+                        selections = ctx.inputBuffer.selections.dropLast(1),
+                    )
+                    // 所有已确认选择均已被消费，进入纯数字 INPUT 态时清空历史，
+                    // 避免后续左选→右选时历史残留导致 full commit 判定失败（场景4.5）。
+                    ctx.stateMachine.clearSelectionHistory()
+                    ctx.stateMachine.enterInput()
+                    ctx.syncState()
+                    ctx.updateCandidates(true)
+                    ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+                    return false
+                }
+            }
+
+            return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+        }
+        // 非 SELECTION 或 confirmedPinyin 不以 selectedPinyin 结尾：
+        // 候选词消费了部分 unassigned 数字，新 buffer 为剩余数字。
+        // 与主分支一致地校验音节覆盖：即使 remainingDigits 为空，若候选词注释音节数
+        // 不足以覆盖 selections.size + unassigned 数字段，不能触发 full commit，
+        // 否则未分配数字会被一并提交（数据丢失）。
+        val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
+            ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+        val requiredSyllables = buf.selections.size + if (buf.unassigned.isNotEmpty()) 1 else 0
+        val canCoverAllBySyllableCount = commentSyllables.size >= requiredSyllables
+
+        if (remainingDigits.isEmpty() && !canCoverAllBySyllableCount) {
+            // 音节覆盖不足但字母数模型显示 remaining 为空：保留选中部分为字母形式，
+            // 避免直接 full commit 把未分配数字一并提交。
+            ctx.inputBuffer = removeConsumedSelections(ctx, buf, buf.selectedPinyin)
+            ctx.leftColumnLocked = false
+            return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+        }
+
+        ctx.inputBuffer = if (remainingDigits.isEmpty()) {
+            T9Buffer.EMPTY
+        } else {
+            buf.withRemainingDigits(remainingDigits, buf)
+        }
+        ctx.leftColumnLocked = false
+        if (ctx.inputBuffer.isEmpty) ctx.stateMachine.enterIdle() else ctx.stateMachine.enterInput()
+        ctx.syncState()
+        ctx.updateCandidates(true)
+        ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+        return ctx.inputBuffer.isEmpty
+    }
+
+    private fun handleDigitSegmentRightCommit(
+        ctx: Ctx,
+        candidatePinyin: String?,
+        prevSelectedOption: T9PinyinMap.SyllableOption?,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val segment = buf.unassigned
+        var consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin)
+        val lockedDigits = if (prevSelectedOption != null) {
+            // prevSelectionCandidateDigits 为 null 时（异常状态）视为全部 segment 被锁定，
+            // 走 maxConsumable <= 0 分支恢复状态，避免消费本应被锁定的数字
+            prevSelectionCandidateDigits?.length ?: segment.length
+        } else 0
+        val maxConsumable = segment.length - lockedDigits
+        if (maxConsumable <= 0) {
+            if (consumedCount > 0) {
+                clearAndEnterIdle(ctx)
+                return true
+            }
+            ctx.leftColumnLocked = false
+            ctx.stateMachine.restoreFrom(
+                if (prevSelectedOption != null) T9StateMachine.State.SELECTION else T9StateMachine.State.INPUT,
+                prevSelectedOption,
+                prevSelectionCandidateDigits,
+                history = ctx.stateMachine.selectionHistory.toList(),
+            )
+            ctx.syncState()
+            ctx.undoManager.pop()
+            return false
+        }
+        if (consumedCount > maxConsumable) consumedCount = maxConsumable
+        val remaining = segment.drop(consumedCount)
+        // 新 buffer：digitSequence 不变，selections 为空，consumedCount = 已消费数
+        ctx.inputBuffer = if (remaining.isEmpty()) {
+            T9Buffer.EMPTY
+        } else {
+            T9Buffer(
+                digitSequence = buf.digitSequence,
+                selections = emptyList(),
+                consumedCount = buf.consumedCount + consumedCount,
+                totalDigitsEntered = buf.totalDigitsEntered,
+            )
+        }
+        ctx.leftColumnLocked = false
+        if (ctx.inputBuffer.isEmpty) {
+            ctx.stateMachine.enterIdle()
+            ctx.syncState()
+            ctx.updateCandidates(true)
+            ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+            return true
+        }
+        return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+    }
+
+    private fun handleLetterBufferRightCommit(
+        ctx: Ctx,
+        candidatePinyin: String?,
+        candidateTextLength: Int,
+        prevSelectedOption: T9PinyinMap.SyllableOption?,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+        prevBuf: T9Buffer,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val selectedPinyin = buf.selectedPinyin
+        val effectiveLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
+        if (effectiveLetterCount > 0) {
+            if (effectiveLetterCount < selectedPinyin.length) {
+                if (prevSelectedOption != null) {
+                    // SELECTION 态：保留未消费部分为字母形式（与 scenario 16 设计一致）
+                    val consumedPinyin = selectedPinyin.take(effectiveLetterCount)
+                    ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedPinyin)
+                    ctx.leftColumnLocked = false
+                    return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+                }
+                // INPUT 态：候选词覆盖部分数字 buffer，转为剩余数字
+                val remainingDigits = T9PinyinMap.pinyinToDigitCode(selectedPinyin.drop(effectiveLetterCount))
+                if (remainingDigits != null) {
+                    val consumedPinyin = selectedPinyin.take(effectiveLetterCount)
+                    ctx.stateMachine.removeConsumedHistoryEntries(consumedPinyin)
+                    ctx.inputBuffer = T9Buffer(
+                        digitSequence = remainingDigits,
+                        selections = emptyList(),
+                        consumedCount = 0,
+                        totalDigitsEntered = remainingDigits.length,
+                    )
+                    ctx.leftColumnLocked = false
+                    return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits)
+                }
+            }
+            if (prevSelectedOption != null && selectedPinyin.endsWith(prevSelectedOption.pinyin)) {
+                return handleSelectionLetterBufferCommit(
+                    ctx, candidatePinyin, candidateTextLength, effectiveLetterCount,
+                    prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin, prevBuf,
+                )
+            }
+            clearAndEnterIdle(ctx)
+            return true
+        }
+        return handleDefensiveNoCommentCommit(
+            ctx, candidateTextLength,
+            prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin, prevBuf,
+        )
+    }
+
+    // ── SELECTION 态字母 buffer 处理 ──
+
+    private fun handleSelectionLetterBufferCommit(
+        ctx: Ctx,
+        candidatePinyin: String?,
+        candidateTextLength: Int,
+        effectiveLetterCount: Int,
+        prevSelectedOption: T9PinyinMap.SyllableOption,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+        prevBuf: T9Buffer,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val selectedPinyin = buf.selectedPinyin
+
+        val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
+            ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+        val hasSyllableBoundaries = commentSyllables.size > 1
+
+        val isFullCommitWithoutBoundaries = !hasSyllableBoundaries &&
+            ctx.stateMachine.selectionHistory.isNotEmpty() &&
+            ctx.stateMachine.selectionHistory.joinToString("") { it.pinyin } == selectedPinyin &&
+            candidateTextLength > 0 &&
+            candidateTextLength >= ctx.stateMachine.selectionHistory.size
+        val isFullCommit = (hasSyllableBoundaries && candidateTextLength > 0 &&
+            candidateTextLength >= commentSyllables.size &&
+            (selectedPinyin.dropLast(prevSelectedOption.pinyin.length).isEmpty() ||
+                isAllSelectedConsumed(selectedPinyin, commentSyllables, ctx.stateMachine.selectionHistory))) ||
+            isFullCommitWithoutBoundaries
+        if (isFullCommit) {
+            clearAndEnterIdle(ctx)
+            return true
+        }
+
+        val nonSelectedPart = selectedPinyin.dropLast(prevSelectedOption.pinyin.length)
+        if (nonSelectedPart.isEmpty()) {
+            return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+        }
+
+        // 有音节边界时，使用基于选择历史的消费（每个音节消费一个选择）
+        if (hasSyllableBoundaries && candidateTextLength > 0) {
+            val lastSyl = commentSyllables.lastOrNull()
+            val lastSylInitial = lastSyl?.first()?.toString()
+            val optInitial = prevSelectedOption.pinyin.first().toString()
+            val lastSylInitialCode = lastSylInitial?.let { T9PinyinMap.pinyinToDigitCode(it) }
+            val optInitialCode = T9PinyinMap.pinyinToDigitCode(optInitial)
+            val wouldTriggerShengmu = lastSylInitialCode != null && optInitialCode != null &&
+                lastSylInitialCode == optInitialCode
+            if (!wouldTriggerShengmu) {
+                val nonSelectedSyllables = if (commentSyllables.lastOrNull() == prevSelectedOption.pinyin)
+                    commentSyllables.dropLast(1) else commentSyllables
+                if (nonSelectedSyllables.isNotEmpty()) {
+                    val consumedSelections = nonSelectedSyllables.size
+                    val nonSelectedHistory = ctx.stateMachine.selectionHistory.dropLast(1)
+                    if (consumedSelections >= nonSelectedHistory.size) {
+                        // 消费全部非选中部分
+                        ctx.inputBuffer = removeConsumedSelections(ctx, buf, nonSelectedPart)
+                        ctx.leftColumnLocked = false
+                        return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+                    }
+                    val consumedPinyin = nonSelectedHistory.take(consumedSelections).joinToString("") { it.pinyin }
+                    ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedPinyin)
+                    val remainingPinyinStr = nonSelectedPart.drop(consumedPinyin.length)
+                    ctx.leftColumnLocked = false
+                    return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, remainingPinyinStr)
+                }
+            }
+        }
+
+        val nonSelectedDigits = T9PinyinMap.pinyinToDigitCode(nonSelectedPart) ?: run {
+            clearAndEnterIdle(ctx)
+            return true
+        }
+
+        val consumedCount = computeSelectionConsumedCount(
+            hasSyllableBoundaries, candidateTextLength, commentSyllables,
+            effectiveLetterCount, prevSelectedOption, nonSelectedDigits, candidatePinyin,
+        )
+
+        if (consumedCount >= nonSelectedDigits.length) {
+            return handleConsumedAllNonSelected(
+                ctx, hasSyllableBoundaries, candidateTextLength, commentSyllables,
+                candidatePinyin, prevSelectedOption, prevSelectionCandidateDigits,
+                nonSelectedPart, nonSelectedDigits, consumedCount, prevBuf,
+            )
+        }
+        if (consumedCount > 0) {
+            return handlePartialConsumedNonSelected(
+                ctx, consumedCount, nonSelectedPart, nonSelectedDigits,
+                prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin,
+            )
+        }
+
+        clearAndEnterIdle(ctx)
+        return true
+    }
+
+    private fun computeSelectionConsumedCount(
+        hasSyllableBoundaries: Boolean,
+        candidateTextLength: Int,
+        commentSyllables: List<String>,
+        effectiveLetterCount: Int,
+        prevSelectedOption: T9PinyinMap.SyllableOption,
+        nonSelectedDigits: String,
+        candidatePinyin: String?,
+    ): Int {
+        if (hasSyllableBoundaries && candidateTextLength > 0 && commentSyllables.size > candidateTextLength) {
+            var consumed = 0
+            for (i in 0 until minOf(candidateTextLength, commentSyllables.size)) {
+                consumed += T9PinyinMap.pinyinToDigitCode(commentSyllables[i])?.length ?: 0
+            }
+            return consumed
+        }
+
+        val candidateNonSelectedLetters = effectiveLetterCount - prevSelectedOption.pinyin.length
+        if (candidateNonSelectedLetters in 1..nonSelectedDigits.length) {
+            if (hasSyllableBoundaries && candidateNonSelectedLetters >= nonSelectedDigits.length) {
+                val nonSelectedSyllables = if (commentSyllables.lastOrNull() == prevSelectedOption.pinyin)
+                    commentSyllables.dropLast(1) else commentSyllables
+                val totalSyllableDigits = nonSelectedSyllables.sumOf {
+                    T9PinyinMap.pinyinToDigitCode(it)?.length ?: 0
+                }
+                return if (totalSyllableDigits > nonSelectedDigits.length) {
+                    computeConsumedDigitsFromPinyin(nonSelectedDigits, candidatePinyin)
+                } else {
+                    candidateNonSelectedLetters
+                }
+            }
+            return candidateNonSelectedLetters
+        }
+        return computeConsumedDigitsFromPinyin(nonSelectedDigits, candidatePinyin)
+    }
+
+    private fun handleConsumedAllNonSelected(
+        ctx: Ctx,
+        hasSyllableBoundaries: Boolean,
+        candidateTextLength: Int,
+        commentSyllables: List<String>,
+        candidatePinyin: String?,
+        prevSelectedOption: T9PinyinMap.SyllableOption,
+        prevSelectionCandidateDigits: String?,
+        nonSelectedPart: String,
+        nonSelectedDigits: String,
+        consumedCount: Int,
+        prevBuf: T9Buffer,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val selectedPinyin = buf.selectedPinyin
+        if (hasSyllableBoundaries && candidateTextLength >= commentSyllables.size) {
+            val candidateClean = candidatePinyin?.filter { it.isLetter() } ?: ""
+            if (candidateClean.isNotEmpty()) {
+                val candidateDigitCode = T9PinyinMap.pinyinToDigitCode(candidateClean)
+                val fullBufferDigitCode = T9PinyinMap.pinyinToDigitCode(selectedPinyin)
+                if (candidateDigitCode != null && fullBufferDigitCode != null &&
+                    candidateDigitCode == fullBufferDigitCode
+                ) {
+                    clearAndEnterIdle(ctx)
+                    return true
+                }
+                val lastSyl = commentSyllables.lastOrNull()
+                if (lastSyl != null) {
+                    val lastSylCode = T9PinyinMap.pinyinToDigitCode(lastSyl)
+                    val selCode = T9PinyinMap.pinyinToDigitCode(prevSelectedOption.pinyin)
+                    val isExactFullMatch = lastSylCode != null && selCode != null && lastSylCode == selCode
+                    val isAbbrevFullMatch = prevSelectedOption.digitLength == 1 &&
+                        lastSylCode != null && selCode != null &&
+                        (lastSylCode.startsWith(selCode) || selCode.startsWith(lastSylCode))
+                    if (isExactFullMatch || isAbbrevFullMatch) {
+                        clearAndEnterIdle(ctx)
+                        return true
+                    }
+                }
+            }
+        }
+
+        if (tryShengmuFallback(ctx, hasSyllableBoundaries, commentSyllables, prevSelectedOption,
+                prevSelectionCandidateDigits, nonSelectedPart, prevBuf)) {
+            return false
+        }
+
+        // 消费全部非选中部分，只保留 prevSelectedOption
+        ctx.inputBuffer = removeConsumedSelections(ctx, buf, nonSelectedPart)
+        ctx.leftColumnLocked = false
+        return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits)
+    }
+
+    private fun tryShengmuFallback(
+        ctx: Ctx,
+        hasSyllableBoundaries: Boolean,
+        commentSyllables: List<String>,
+        prevSelectedOption: T9PinyinMap.SyllableOption,
+        prevSelectionCandidateDigits: String?,
+        nonSelectedPart: String,
+        prevBuf: T9Buffer,
+    ): Boolean {
+        if (!hasSyllableBoundaries || commentSyllables.isEmpty()) return false
+        val buf = ctx.inputBuffer
+        val lastSyl = commentSyllables.last()
+        val selDigits = prevSelectionCandidateDigits ?: return false
+        val lastInitial = lastSyl.first().toString()
+        val optInitial = prevSelectedOption.pinyin.first().toString()
+        val initialCode = T9PinyinMap.pinyinToDigitCode(lastInitial) ?: return false
+        val optInitialCode = T9PinyinMap.pinyinToDigitCode(optInitial) ?: return false
+        if (initialCode != optInitialCode || !selDigits.startsWith(initialCode) || selDigits.length <= initialCode.length) {
+            return false
+        }
+
+        val remainingFromSelected = selDigits.drop(initialCode.length)
+        // 消费全部非选中部分 + 移除最后一个选择（prevSelectedOption）
+        ctx.inputBuffer = removeConsumedSelections(ctx, buf, nonSelectedPart)
+        // removeConsumedSelections 只移除非选中部分的选择，需要额外移除 prevSelectedOption
+        if (ctx.inputBuffer.selections.isNotEmpty()) {
+            ctx.inputBuffer = ctx.inputBuffer.copy(
+                selections = ctx.inputBuffer.selections.dropLast(1),
+            )
+        }
+        // 新 buffer 是剩余数字
+        ctx.inputBuffer = T9Buffer(
+            digitSequence = remainingFromSelected,
+            selections = emptyList(),
+            consumedCount = 0,
+            totalDigitsEntered = remainingFromSelected.length,
+        )
+        ctx.leftColumnLocked = false
+        // 声母回退完全重置输入上下文（buffer 从字母变为数字，状态从 SELECTION 变为 INPUT），
+        // 旧的 selectionHistory 已无意义，必须清除，否则后续左选→右选时
+        // selectionHistory 中残留旧条目导致 isFullCommitWithoutBoundaries 误判失败
+        ctx.stateMachine.clearSelectionHistory()
+        ctx.stateMachine.enterInput()
+        ctx.syncState()
+        ctx.updateCandidates(true)
+        ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+        return true
+    }
+
+    private fun handlePartialConsumedNonSelected(
+        ctx: Ctx,
+        consumedCount: Int,
+        nonSelectedPart: String,
+        nonSelectedDigits: String,
+        prevSelectedOption: T9PinyinMap.SyllableOption,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val remainingPinyinStr = if (prevConfirmedPinyin.isNotEmpty() && nonSelectedPart == prevConfirmedPinyin) {
+            val totalDigits = T9PinyinMap.pinyinToDigitCode(prevConfirmedPinyin)?.length
+                ?: prevConfirmedPinyin.length
+            val remainingDigits = totalDigits - consumedCount
+            if (remainingDigits <= 0) {
+                ""
+            } else {
+                val sb = StringBuilder()
+                var digitsToSkip = remainingDigits
+                for (ch in prevConfirmedPinyin.reversed()) {
+                    if (digitsToSkip <= 0) break
+                    sb.append(ch)
+                    digitsToSkip -= T9PinyinMap.pinyinToDigitCode(ch.toString())?.length ?: 1
+                }
+                sb.reverse().toString()
+            }
+        } else {
+            nonSelectedDigits.drop(consumedCount)
+        }
+        // 消费前 consumedCount 位数字对应的选择
+        val consumedPinyin = nonSelectedPart.take(consumedCount)
+        ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedPinyin)
+        ctx.leftColumnLocked = false
+        return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, remainingPinyinStr)
+    }
+
+    private fun handleDefensiveNoCommentCommit(
+        ctx: Ctx,
+        candidateTextLength: Int,
+        prevSelectedOption: T9PinyinMap.SyllableOption?,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+        prevBuf: T9Buffer,
+    ): Boolean {
+        val buf = ctx.inputBuffer
+        val selectedPinyin = buf.selectedPinyin
+        if (prevSelectedOption != null && selectedPinyin.endsWith(prevSelectedOption.pinyin)) {
+            if (ctx.stateMachine.selectionHistory.isNotEmpty() &&
+                ctx.stateMachine.selectionHistory.joinToString("") { it.pinyin } == selectedPinyin &&
+                candidateTextLength > 0 &&
+                candidateTextLength >= ctx.stateMachine.selectionHistory.size
+            ) {
+                clearAndEnterIdle(ctx)
+                return true
+            }
+            val nonSelectedPart = selectedPinyin.dropLast(prevSelectedOption.pinyin.length)
+            val selectedDigits = prevSelectionCandidateDigits ?: ""
+            if (nonSelectedPart.isNotEmpty() && selectedDigits.isNotEmpty()) {
+                val nonSelectedDigits = T9PinyinMap.pinyinToDigitCode(nonSelectedPart)
+                if (nonSelectedDigits != null) {
+                    val firstSyl = T9PinyinMap.firstSyllableOptions(nonSelectedDigits, maxResults = 1).firstOrNull()
+                    if (firstSyl != null && firstSyl.digitLength in 1..nonSelectedDigits.length) {
+                        val consumedPinyin = nonSelectedPart.take(firstSyl.digitLength)
+                        ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedPinyin)
+                        val remainingAfterConsume = nonSelectedDigits.drop(firstSyl.digitLength) + selectedDigits
+                        ctx.inputBuffer = if (remainingAfterConsume == selectedDigits) {
+                            // 只保留 prevSelectedOption — 但 removeConsumedSelections 已经移除了非选中部分
+                            // 此时 ctx.inputBuffer.selections 应该只剩 prevSelectedOption
+                            ctx.inputBuffer
+                        } else {
+                            T9Buffer(
+                                digitSequence = remainingAfterConsume,
+                                selections = emptyList(),
+                                consumedCount = 0,
+                                totalDigitsEntered = remainingAfterConsume.length,
+                            )
+                        }
+                        ctx.leftColumnLocked = false
+                        return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+                    }
+                }
+            }
+        }
+
+        val digits = T9PinyinMap.pinyinToDigitCode(selectedPinyin)
+        if (digits != null) {
+            val consumedDigitCount = T9PinyinMap.firstSyllableOptions(digits, maxResults = 1)
+                .firstOrNull()?.digitLength ?: 0
+            if (consumedDigitCount in 1..<digits.length) {
+                ctx.inputBuffer = T9Buffer(
+                    digitSequence = digits.drop(consumedDigitCount),
+                    selections = emptyList(),
+                    consumedCount = 0,
+                    totalDigitsEntered = digits.drop(consumedDigitCount).length,
+                )
+                ctx.leftColumnLocked = false
+                return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+            }
+        }
+
+        clearAndEnterIdle(ctx)
+        return true
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
@@ -317,30 +317,36 @@ class T9RightCommitHandler {
             ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedNonSelectedPinyin)
             ctx.leftColumnLocked = false
 
-            // 声母级消费选中项：当 nonSelected 已完全消费、候选词最后一个音节的声母
-            // 与当前选中项（简拼）首字母数字码匹配时，表示该选中项也被候选项消费。
+            // 候选词消费选中项：当 nonSelected 已完全消费、候选词最后一个音节
+            // 与当前选中项匹配时，表示该选中项也被候选项消费。
+            // 两种匹配模式：
+            //   声母匹配：选中项为简拼(digitLength==1)，候选词最后音节声母数字码
+            //            与选中项数字码一致（如 g 匹配 guan 的声母 g）
+            //   全拼匹配：选中项为全拼(digitLength>1)，候选词最后音节数字码
+            //            与选中项数字码完全一致（如 shan 匹配 shan）
             // 例如 kg'3 右选 "客观(ke guan)"：ke 消费 k，guan 的声母 g 消费选中项 g，
             // 仅保留未分配数字 3 并进入 INPUT 态。
-            if (unconsumedPinyin.isEmpty() &&
-                prevSelectedOption.digitLength == 1 &&
-                commentSyllables.isNotEmpty()
-            ) {
+            // 例如 yunshan'98726 右选 "云山(yun shan)"：yun 消费 yun，shan 消费选中项 shan，
+            // 仅保留未分配数字 98726 并进入 INPUT 态。
+            if (unconsumedPinyin.isEmpty() && commentSyllables.isNotEmpty()) {
                 val lastSyl = commentSyllables.last()
-                val lastInitial = lastSyl.first().toString()
-                val selInitial = prevSelectedOption.pinyin.first().toString()
-                val lastInitialCode = T9PinyinMap.pinyinToDigitCode(lastInitial)
-                val selInitialCode = T9PinyinMap.pinyinToDigitCode(selInitial)
+                val lastSylCode = T9PinyinMap.pinyinToDigitCode(lastSyl)
+                val selCode = T9PinyinMap.pinyinToDigitCode(prevSelectedOption.pinyin)
                 val selDigits = prevSelectionCandidateDigits ?: ""
-                if (lastInitialCode != null && selInitialCode != null &&
-                    lastInitialCode == selInitialCode &&
-                    selDigits.startsWith(lastInitialCode)
-                ) {
-                    // 移除最后一个选择，仅保留未分配数字
+
+                val isShengmuMatch = prevSelectedOption.digitLength == 1 &&
+                    lastSylCode != null && selCode != null &&
+                    lastSylCode.startsWith(selCode) &&
+                    selDigits.startsWith(selCode)
+
+                val isFullPinyinMatch = prevSelectedOption.digitLength > 1 &&
+                    lastSylCode != null && selCode != null &&
+                    lastSylCode == selCode
+
+                if (isShengmuMatch || isFullPinyinMatch) {
                     ctx.inputBuffer = ctx.inputBuffer.copy(
                         selections = ctx.inputBuffer.selections.dropLast(1),
                     )
-                    // 所有已确认选择均已被消费，进入纯数字 INPUT 态时清空历史，
-                    // 避免后续左选→右选时历史残留导致 full commit 判定失败（场景4.5）。
                     ctx.stateMachine.clearSelectionHistory()
                     ctx.stateMachine.enterInput()
                     ctx.syncState()

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
@@ -7,11 +7,44 @@ package com.kingzcheung.xime.rime
 /**
  * 根据候选拼音注释计算数字段中被消费的位数。
  *
- * 优先使用 candidatePinyin 中的字母数（每个字母对应一位数字），
- * 若 candidatePinyin 为空或无字母，则回退到贪婪最长匹配。
+ * 逐音节匹配数字码：将 candidatePinyin 按空格拆分为音节，每个音节通过
+ * [T9PinyinMap.pinyinToDigitCode] 转为数字码，与剩余数字段前缀匹配。
+ * - 完全匹配：音节数字码与剩余段前缀完全一致，消费全部数字码位数
+ * - 前缀匹配（声母匹配）：用户仅输入了声母对应的数字，RIME 翻译器补全了韵母，
+ *   此时音节数字码的前缀与剩余段匹配，仅消费前缀长度的数字
+ *   例：用户输入 9435，候选 "这里(zhe li)"，"li" 数字码 "54"，
+ *   剩余 "5" 是 "54" 的前缀（声母 l 对应 digit 5），消费 1 位
+ *
+ * 若音节匹配失败（pinyinToDigitCode 返回 null 或无前缀匹配），
+ * 回退到字母数（每个字母对应一位数字），最终回退到贪婪最长匹配。
  */
 fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): Int {
     if (!candidatePinyin.isNullOrEmpty()) {
+        val syllables = candidatePinyin.trim().split("\\s+".toRegex())
+            .filter { it.any { c -> c.isLetter() } }
+        if (syllables.isNotEmpty()) {
+            var consumed = 0
+            var remaining = segment
+            for (syl in syllables) {
+                val sylCode = T9PinyinMap.pinyinToDigitCode(syl)
+                if (sylCode == null) break
+                if (remaining.startsWith(sylCode)) {
+                    consumed += sylCode.length
+                    remaining = remaining.drop(sylCode.length)
+                } else {
+                    // 前缀匹配：声母场景，用户只输入了音节首字母对应的数字
+                    var matchLen = 0
+                    for (len in 1..minOf(sylCode.length, remaining.length)) {
+                        if (remaining.startsWith(sylCode.take(len))) matchLen = len
+                    }
+                    if (matchLen > 0) {
+                        consumed += matchLen
+                        remaining = remaining.drop(matchLen)
+                    } else break
+                }
+            }
+            if (consumed > 0) return consumed
+        }
         val letterCount = candidatePinyin.count { it in 'a'..'z' || it in 'A'..'Z' }
         if (letterCount > 0 && letterCount <= segment.length) return letterCount
     }

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
@@ -1,0 +1,74 @@
+package com.kingzcheung.xime.rime
+
+// ─────────────────────────────────────────────────────────
+// 设计文档 6.2 节：三层消费算法 — 纯函数
+// ─────────────────────────────────────────────────────────
+
+/**
+ * 根据候选拼音注释计算数字段中被消费的位数。
+ *
+ * 优先使用 candidatePinyin 中的字母数（每个字母对应一位数字），
+ * 若 candidatePinyin 为空或无字母，则回退到贪婪最长匹配。
+ */
+fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): Int {
+    if (!candidatePinyin.isNullOrEmpty()) {
+        val letterCount = candidatePinyin.count { it in 'a'..'z' || it in 'A'..'Z' }
+        if (letterCount > 0 && letterCount <= segment.length) return letterCount
+    }
+    return T9PinyinMap.firstSyllableOptions(segment, maxResults = 1).firstOrNull()?.digitLength ?: 0
+}
+
+/**
+ * 判断 selectionHistory 是否完全覆盖 inputBuffer，且候选词的 comment 音节与选择历史逐位对齐。
+ *
+ * 当 buffer 完全由 selectionHistory 的拼音拼接构成，且候选词的 comment 音节数字码
+ * 与 selectionHistory 的数字码逐位对齐时，表示候选词覆盖了所有已确认选择，
+ * 应触发全量提交（full commit）。
+ *
+ * @param inputBuffer 当前输入缓冲区
+ * @param commentSyllables 候选词拼音注释的音节列表
+ * @param selectionHistory 左侧已确认的选择历史
+ * @return true 表示候选词完全覆盖了所有已确认选择
+ */
+fun isAllSelectedConsumed(
+    inputBuffer: String,
+    commentSyllables: List<String>,
+    selectionHistory: List<T9PinyinMap.SyllableOption>,
+): Boolean {
+    if (selectionHistory.isEmpty()) return false
+    if (selectionHistory.joinToString("") { it.pinyin } != inputBuffer) return false
+    if (commentSyllables.size != selectionHistory.size) return false
+    return commentSyllables.indices.all { i ->
+        val sylCode = T9PinyinMap.pinyinToDigitCode(commentSyllables[i])
+        val selCode = T9PinyinMap.pinyinToDigitCode(selectionHistory[i].pinyin)
+        sylCode != null && selCode != null && sylCode == selCode
+    }
+}
+
+/**
+ * 判断在 SELECTION 保护路径中是否应触发 full commit。
+ *
+ * 当非选中部分已被完全消费、remainingAfterCommit 为空（计算消费声明全部消费），
+ * 且候选词注释中包含选中部分的拼音音节（数字码匹配）时，说明候选词覆盖了全部输入，
+ * 应触发 full commit 而非 partial commit。
+ *
+ * @param consumedFromNonSelected 已从非选中部分消费的字母数
+ * @param nonSelectedPinyinLength 非选中部分的拼音长度
+ * @param remainingAfterCommit computeRightCommitConsumption 返回的剩余数字段
+ * @param candidatePinyin 候选词拼音注释
+ * @param selectedPinyin 当前选中项的拼音
+ * @return true 表示应触发 full commit
+ */
+fun shouldFullCommitInSelection(
+    consumedFromNonSelected: Int,
+    nonSelectedPinyinLength: Int,
+    remainingAfterCommit: String,
+    candidatePinyin: String?,
+    selectedPinyin: String,
+): Boolean {
+    if (consumedFromNonSelected < nonSelectedPinyinLength) return false
+    if (remainingAfterCommit.isNotEmpty()) return false
+    val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
+        ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+    return commentSyllables.any { T9PinyinMap.areDigitCodesMatching(it, selectedPinyin) }
+}

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RimeBridge.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RimeBridge.kt
@@ -1,0 +1,101 @@
+package com.kingzcheung.xime.rime
+
+/**
+ * T9 输入控制器与 RIME 引擎的通信桥接
+ *
+ * 封装 RIME 通信相关的常量、回调管理和发送缓存。
+ * 从 [T9InputController] 中提取，降低控制器复杂度。
+ *
+ * 设计决策：
+ * - sendToRime() 核心逻辑仍留在控制器中，因为其依赖大量控制器状态
+ *   （buffer、stateMachine、selectionCandidateDigits 等），
+ *   提取为独立模块需要传递过多参数，反而降低可读性。
+ *   后续阶段5 可考虑将 sendToRime 逻辑进一步拆分。
+ * - 本类仅管理通信常量、回调引用和发送缓存。
+ */
+class T9RimeBridge(
+    private val onReplaceFullPinyin: (String) -> Unit,
+    private val onQueryRimeComposition: (() -> RimeComposition)? = null,
+    private val onRightCommitUndone: ((Int) -> Unit)? = null,
+) {
+    companion object {
+        /** 仅清除 RIME composition，保留 partial commit 累积文本 */
+        const val CLEAR_COMPOSITION_ONLY = "\u0000CLEAR_COMPOSITION_ONLY"
+
+        /** 清除所有内容（composition + partial commit 累积文本） */
+        const val CLEAR_ALL = "\u0000CLEAR_ALL"
+    }
+
+    /** 上次发送到 RIME 的输入，用于去重 */
+    private var lastRimeInput: String? = null
+
+    /** 获取上次发送的输入 */
+    fun getLastRimeInput(): String? = lastRimeInput
+
+    /** 设置上次发送的输入 */
+    fun setLastRimeInput(input: String?) {
+        lastRimeInput = input
+    }
+
+    /** 发送全拼音替换到 RIME 引擎 */
+    fun replaceFullPinyin(pinyin: String) {
+        onReplaceFullPinyin(pinyin)
+    }
+
+    /** 查询 RIME 当前 composition */
+    fun queryRimeComposition(): RimeComposition? = onQueryRimeComposition?.invoke()
+
+    /** 通知服务层撤销右侧候选选词 */
+    fun undoRightCommit(count: Int = 1) {
+        onRightCommitUndone?.invoke(count)
+    }
+
+    /**
+     * 强制重新发送当前 inputBuffer 到 RIME，绕过发送缓存。
+     */
+    fun forceSendToRime() {
+        lastRimeInput = null
+    }
+
+    /**
+     * 清除 RIME composition 并重新发送当前 buffer。
+     * 先撤销一个 partial commit（从 partial commit 列表中移除），
+     * 再清 RIME composition，最后送完整数字序列（setInput）。
+     */
+    fun clearRimeAndResend() {
+        onRightCommitUndone?.invoke(1)
+        lastRimeInput = null
+        onReplaceFullPinyin("")
+    }
+
+    /**
+     * 优先通过 RIME 候选 comment 反推当前数字段的最优首音节。
+     *
+     * 取当前 composition 第一个带 comment 的候选，将其 comment（如 "ji gua"）
+     * 按空格拆分为音节，取第一个音节并验证其数字编码是否与 [digits] 前缀匹配。
+     * 若 RIME 未返回有效 comment 或匹配失败，则回退到本地贪婪最长匹配。
+     */
+    fun inferFirstSyllableFromRime(digits: String): T9PinyinMap.SyllableOption? {
+        val composition = queryRimeComposition() ?: return fallbackFirstSyllable(digits)
+
+        val comment = composition.candidates
+            .firstOrNull { it.comment.isNotBlank() }
+            ?.comment
+            ?.trim()
+            ?: return fallbackFirstSyllable(digits)
+
+        val firstPinyin = comment.split(Regex("\\s+"))
+            .firstOrNull { it.isNotEmpty() }
+            ?: return fallbackFirstSyllable(digits)
+
+        val code = T9PinyinMap.pinyinToDigitCode(firstPinyin)
+        if (code != null && digits.startsWith(code)) {
+            return T9PinyinMap.SyllableOption(firstPinyin.lowercase(), code.length)
+        }
+        return fallbackFirstSyllable(digits)
+    }
+
+    private fun fallbackFirstSyllable(digits: String): T9PinyinMap.SyllableOption? {
+        return T9PinyinMap.firstSyllableOptions(digits, maxResults = 1).firstOrNull()
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9StateMachine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9StateMachine.kt
@@ -1,0 +1,181 @@
+package com.kingzcheung.xime.rime
+
+/**
+ * 左侧候选区三态状态机
+ *
+ * 封装 [T9InputController] 中左侧候选区的状态管理逻辑。
+ * 严格遵循设计文档第 2.3 节"左侧选择模型"和第 3.2 节"交互状态机"。
+ *
+ * 设计决策：
+ * - 本类为纯逻辑层，不持有 Compose 状态。
+ * - [selectionHistory] 记录当前会话中每次左选确认，用于候选词过滤。
+ * - [LeftSelection] 封装选中态的完整上下文（文档 2.3 节）。
+ */
+class T9StateMachine {
+
+    /** 左侧候选区状态 */
+    enum class State { IDLE, INPUT, SELECTION }
+
+    /** 
+     * 左侧选择模型（设计文档 2.3 节）。
+     * 封装 SELECTION 态下当前选中项的完整上下文。
+     */
+    data class LeftSelection(
+        /** 当前选中的拼音/字母 */
+        val selectedOption: T9PinyinMap.SyllableOption,
+        /** 选中项对应的数字子串（来自 unassigned） */
+        val selectionDigits: String,
+        /** 选中项之前、已由左侧选择产生的拼音序列 */
+        val preSelectedPinyin: String = "",
+    ) {
+        val digitLength: Int get() = selectedOption.digitLength
+        val pinyin: String get() = selectedOption.pinyin
+    }
+
+    /** 当前状态 */
+    var state: State = State.IDLE
+        private set
+
+    /** 当前选择上下文；非 SELECTION 态时为 null */
+    val leftSelection: LeftSelection?
+        get() {
+            val opt = selectedOption
+            return if (isSelection && opt != null)
+                LeftSelection(opt, selectionCandidateDigits ?: "", confirmedPinyinBeforeSelection)
+            else null
+        }
+
+    /** 选择态下当前选中的拼音/字母选项 */
+    var selectedOption: T9PinyinMap.SyllableOption? = null
+        internal set
+
+    /** 选择态下产生当前候选列表的数字段 */
+    var selectionCandidateDigits: String? = null
+        internal set
+
+    /** 选择态下选中项之前的已确认拼音前缀 */
+    var confirmedPinyinBeforeSelection: String = ""
+        internal set
+
+    /** 当前输入会话中所有已选择的拼音/字母历史（按选择顺序） */
+    private val _selectionHistory: MutableList<T9PinyinMap.SyllableOption> = mutableListOf()
+    val selectionHistory: List<T9PinyinMap.SyllableOption> get() = _selectionHistory
+
+    /** 清空选择历史 */
+    fun clearSelectionHistory() = _selectionHistory.clear()
+
+    /** 移除最后一个选择历史条目 */
+    fun removeLastSelectionHistoryEntry() {
+        if (_selectionHistory.isNotEmpty()) _selectionHistory.removeAt(_selectionHistory.lastIndex)
+    }
+
+    /** 替换整个选择历史（用于撤销恢复） */
+    fun setSelectionHistory(history: List<T9PinyinMap.SyllableOption>) {
+        _selectionHistory.clear()
+        _selectionHistory.addAll(history)
+    }
+
+    /** 进入选择态，记录本次选择到历史 */
+    fun enterSelection(option: T9PinyinMap.SyllableOption, candidateDigits: String, confirmedPinyin: String = "") {
+        state = State.SELECTION
+        selectedOption = option
+        selectionCandidateDigits = candidateDigits
+        confirmedPinyinBeforeSelection = confirmedPinyin
+        _selectionHistory.add(option)
+    }
+
+    /** 退出选择态，回到输入态（保留选择历史） */
+    fun exitSelection() {
+        state = State.INPUT
+        selectedOption = null
+        selectionCandidateDigits = null
+        confirmedPinyinBeforeSelection = ""
+    }
+
+    /** 进入空闲态，清空全部状态含选择历史 */
+    fun enterIdle() {
+        state = State.IDLE
+        selectedOption = null
+        selectionCandidateDigits = null
+        confirmedPinyinBeforeSelection = ""
+        _selectionHistory.clear()
+    }
+
+    /** 进入输入态（保留选择历史） */
+    fun enterInput() {
+        state = State.INPUT
+        selectedOption = null
+        selectionCandidateDigits = null
+        confirmedPinyinBeforeSelection = ""
+    }
+
+    /** 完全重置，清空选择历史 */
+    fun reset() {
+        state = State.IDLE
+        selectedOption = null
+        selectionCandidateDigits = null
+        confirmedPinyinBeforeSelection = ""
+        _selectionHistory.clear()
+    }
+
+    /** 状态快照，用于撤销恢复 */
+    data class StateSnapshot(
+        val state: State,
+        val selectedOption: T9PinyinMap.SyllableOption?,
+        val selectionCandidateDigits: String?,
+        val confirmedPinyinBeforeSelection: String = "",
+        val selectionHistory: List<T9PinyinMap.SyllableOption> = emptyList(),
+    )
+
+    /** 获取当前状态快照 */
+    fun snapshot(): StateSnapshot = StateSnapshot(
+        state, selectedOption, selectionCandidateDigits, confirmedPinyinBeforeSelection,
+        _selectionHistory.toList(),
+    )
+
+    /** 从快照恢复状态 */
+    fun restore(snapshot: StateSnapshot) {
+        state = snapshot.state
+        selectedOption = snapshot.selectedOption
+        selectionCandidateDigits = snapshot.selectionCandidateDigits
+        confirmedPinyinBeforeSelection = snapshot.confirmedPinyinBeforeSelection
+        _selectionHistory.clear()
+        _selectionHistory.addAll(snapshot.selectionHistory)
+    }
+
+    /** 从原始值恢复状态（用于快照撤销场景） */
+    fun restoreFrom(
+        state: State,
+        option: T9PinyinMap.SyllableOption?,
+        digits: String?,
+        confirmedPinyin: String = "",
+        history: List<T9PinyinMap.SyllableOption> = emptyList(),
+    ) {
+        this.state = state
+        this.selectedOption = option
+        this.selectionCandidateDigits = digits
+        this.confirmedPinyinBeforeSelection = confirmedPinyin
+        _selectionHistory.clear()
+        _selectionHistory.addAll(history)
+    }
+
+    /** partial commit 后从 selectionHistory 头部移除已被消费的条目 */
+    fun removeConsumedHistoryEntries(consumedPinyin: String) {
+        var remaining = consumedPinyin
+        while (_selectionHistory.isNotEmpty() && remaining.isNotEmpty()) {
+            val first = _selectionHistory.first()
+            if (remaining.startsWith(first.pinyin)) {
+                remaining = remaining.drop(first.pinyin.length)
+                _selectionHistory.removeAt(0)
+            } else {
+                break
+            }
+        }
+    }
+
+    // 便捷查询
+    val isIdle: Boolean get() = state == State.IDLE
+    val isInput: Boolean get() = state == State.INPUT
+    val isSelection: Boolean get() = state == State.SELECTION
+    val hasSelection: Boolean get() = isSelection && selectedOption != null
+}

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9UndoManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9UndoManager.kt
@@ -1,0 +1,232 @@
+package com.kingzcheung.xime.rime
+
+/**
+ * 九键输入撤销管理器（命令模式 — 设计文档 Phase 3）。
+ *
+ * 每个操作封装为 [T9Command]，自带 undo() 方法，
+ * 替代旧版 Snapshot 全量快照 + onDeleted() 优先级迷宫。
+ *
+ * 设计原则：
+ * - 每个命令精确知道如何撤销自己，无需"猜测"
+ * - 回退只需 pop().undo()，逻辑极简
+ * - 命令存储代价可忽略（< 30 chars / command）
+ */
+
+// ─────────────────────────────────────────────────────────
+// 命令定义
+// ─────────────────────────────────────────────────────────
+
+/** 可撤销的 T9 操作命令 */
+sealed class T9Command {
+
+    /**
+     * 撤销上下文：undo() 需要的可变状态引用。
+     * 由 [T9InputController] 构造并传入。
+     */
+    class Ctx(
+        var buffer: T9Buffer,
+        var leftColumnLocked: Boolean,
+        var separatorConsumedDigits: String?,
+        var lastChoiceConsumedDigits: String?,
+        val stateMachine: T9StateMachine,
+        val onRestored: () -> Unit,
+    )
+
+    /** 执行撤销操作 */
+    abstract fun undo(ctx: Ctx)
+
+    // ── 具体命令 ──
+
+    /** 按下数字键 n ∈ {2..9} */
+    data class DigitPressed(val digit: String) : T9Command() {
+        override fun undo(ctx: Ctx) {
+            ctx.buffer = ctx.buffer.removeLastDigit()
+            ctx.leftColumnLocked = false
+        }
+    }
+
+    /** 按下分词键 1 */
+    data class Separator(
+        val prevBuffer: T9Buffer,
+        val prevSeparatorConsumedDigits: String?,
+        val prevSelectionHistory: List<T9PinyinMap.SyllableOption> = emptyList(),
+    ) : T9Command() {
+        override fun undo(ctx: Ctx) {
+            ctx.buffer = prevBuffer.copy(
+                digitSequence = ctx.buffer.digitSequence,
+                totalDigitsEntered = ctx.buffer.totalDigitsEntered,
+            )
+            ctx.separatorConsumedDigits = prevSeparatorConsumedDigits
+            ctx.leftColumnLocked = false
+            ctx.stateMachine.enterInput()
+            ctx.stateMachine.setSelectionHistory(prevSelectionHistory)
+        }
+    }
+
+    /** 左侧候选区选择拼音/字母 */
+    data class LeftChoice(
+        val prevBuffer: T9Buffer,
+        val prevSeparatorConsumedDigits: String?,
+        val prevLeftColumnLocked: Boolean,
+        val prevSelectedOption: T9PinyinMap.SyllableOption?,
+        val prevSelectionCandidateDigits: String?,
+        val prevConfirmedPinyin: String = "",
+        val prevSelectionHistory: List<T9PinyinMap.SyllableOption> = emptyList(),
+        /** 所选拼音是否来自数字编码上下文（INPUT 态首次选择）。
+         * 为 true 时 undo 移除最后选择、恢复数字；
+         * 为 false（SELECTION 态筛选层替换/追加）时恢复 prevBuffer。 */
+        val wasFromDigitContext: Boolean = false,
+        /** 是否使用 addSelectionNoConsume（分词键确认失败后首次选字）。
+         * 为 true 时 undo 仅移除选择，不递减 consumedCount。 */
+        val wasNoConsume: Boolean = false,
+    ) : T9Command() {
+        override fun undo(ctx: Ctx) {
+            ctx.buffer = if (wasFromDigitContext) {
+                // 从数字上下文选择：移除最后选择，恢复数字（保留用户删除的 digitSequence）
+                if (wasNoConsume) {
+                    ctx.buffer.copy(selections = ctx.buffer.selections.dropLast(1))
+                } else {
+                    ctx.buffer.undoLastSelection()
+                }
+            } else {
+                // 筛选层替换/追加：恢复 prevBuffer 的 selections 和 consumedCount
+                prevBuffer.copy(
+                    digitSequence = ctx.buffer.digitSequence,
+                    totalDigitsEntered = ctx.buffer.totalDigitsEntered,
+                )
+            }
+            ctx.separatorConsumedDigits = prevSeparatorConsumedDigits
+            ctx.leftColumnLocked = prevLeftColumnLocked
+            if (prevSelectedOption != null) {
+                ctx.stateMachine.enterSelection(
+                    prevSelectedOption,
+                    prevSelectionCandidateDigits ?: "",
+                    prevConfirmedPinyin,
+                )
+                if (prevSelectionHistory.isNotEmpty()) {
+                    ctx.stateMachine.setSelectionHistory(prevSelectionHistory)
+                }
+            } else {
+                ctx.stateMachine.enterInput()
+                ctx.stateMachine.setSelectionHistory(prevSelectionHistory)
+            }
+        }
+    }
+
+    /** 右侧候选词选择汉字。
+     *  prevBuffer 为 T9Buffer，undo 时恢复其 selections/consumedCount，
+     *  但保留当前 digitSequence（right commit 后可能已有新数字输入）。
+     *  remainingDigitCount 记录 commit 后 buffer.digitSequence.length，
+     *  用于撤销时判断当前 buffer 是否可安全恢复（digitSequence 未增长 = 无新增数字）。 */
+    data class RightCommit(
+        val prevBuffer: T9Buffer,
+        val prevSeparatorConsumedDigits: String?,
+        val prevLastChoiceConsumedDigits: String?,
+        val prevLeftColumnLocked: Boolean,
+        val prevSelectedOption: T9PinyinMap.SyllableOption?,
+        val prevSelectionCandidateDigits: String?,
+        val prevConfirmedPinyin: String = "",
+        val prevSelectionHistory: List<T9PinyinMap.SyllableOption> = emptyList(),
+        val remainingDigitCount: Int = 0,
+    ) : T9Command() {
+        override fun undo(ctx: Ctx) {
+            ctx.separatorConsumedDigits = prevSeparatorConsumedDigits
+            ctx.lastChoiceConsumedDigits = prevLastChoiceConsumedDigits
+            ctx.leftColumnLocked = prevLeftColumnLocked
+            if (prevSelectedOption != null) {
+                ctx.stateMachine.enterSelection(
+                    prevSelectedOption,
+                    prevSelectionCandidateDigits ?: "",
+                    prevConfirmedPinyin,
+                )
+                if (prevSelectionHistory.isNotEmpty()) {
+                    ctx.stateMachine.setSelectionHistory(prevSelectionHistory)
+                }
+            } else {
+                ctx.stateMachine.enterInput()
+                ctx.stateMachine.setSelectionHistory(prevSelectionHistory)
+            }
+            // 恢复 prevBuffer 的 selections/consumedCount，
+            // 但保留当前 digitSequence（right commit 后可能已有新数字输入）。
+            //
+            // digitSegment 模式：RC 保持原始 digitSequence（仅增加 consumedCount），
+            //   回退删除缩短了 digitSequence，undo 时应保留缩短后的序列。
+            //   判定条件：consumedCount > 0 且当前序列是 prevBuffer 序列的前缀。
+            // letterBuffer 模式：RC 创建了全新 T9Buffer（声母回退），
+            //   digitSequence 完全不同，undo 时应恢复 prevBuffer 的原始序列。
+            val restoredDigitSeq = when {
+                ctx.buffer.consumedCount > 0 &&
+                    prevBuffer.digitSequence.startsWith(ctx.buffer.digitSequence) &&
+                    ctx.buffer.digitSequence.length < prevBuffer.digitSequence.length ->
+                    ctx.buffer.digitSequence  // digitSegment: 保留缩短后的序列
+                ctx.buffer.digitSequence.length < prevBuffer.digitSequence.length ->
+                    prevBuffer.digitSequence  // letterBuffer: 恢复原始完整序列
+                else ->
+                    ctx.buffer.digitSequence  // 同长度：无需恢复
+            }
+            ctx.buffer = prevBuffer.copy(
+                digitSequence = restoredDigitSeq,
+                totalDigitsEntered = maxOf(prevBuffer.totalDigitsEntered, ctx.buffer.totalDigitsEntered),
+            )
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// 撤销管理器
+// ─────────────────────────────────────────────────────────
+
+class T9UndoManager {
+
+    private val commands = mutableListOf<T9Command>()
+
+    val size: Int get() = commands.size
+    fun isEmpty(): Boolean = commands.isEmpty()
+    fun isNotEmpty(): Boolean = commands.isNotEmpty()
+
+    /** 查看栈顶命令 */
+    fun peek(): T9Command? = commands.lastOrNull()
+
+    /** 压入命令 */
+    fun push(cmd: T9Command) {
+        commands.add(cmd)
+    }
+
+    /** 弹出栈顶命令并执行 undo() */
+    fun popAndUndo(ctx: T9Command.Ctx) {
+        if (commands.isEmpty()) return
+        val cmd = commands.removeAt(commands.lastIndex)
+        cmd.undo(ctx)
+    }
+
+    /** 清空命令栈 */
+    fun clear() {
+        commands.clear()
+    }
+
+    /** 弹出栈顶命令（不执行 undo，用于滚动 back 场景） */
+    fun pop(): T9Command? =
+        if (commands.isNotEmpty()) commands.removeAt(commands.lastIndex) else null
+
+    /** 是否存在 RightCommit 类型的命令 */
+    fun hasPendingRightCommit(): Boolean = commands.any { it is T9Command.RightCommit }
+
+    /** 栈顶是否为 RightCommit */
+    val topIsRightCommit: Boolean get() = commands.lastOrNull() is T9Command.RightCommit
+
+    /** 移除栈中最后一个 DigitPressed 命令（不限位置）。用于 undo LeftChoice 后清除 stale 标记。 */
+    fun removeLastDigitPressed() {
+        val idx = commands.indexOfLast { it is T9Command.DigitPressed }
+        if (idx >= 0) {
+            commands.removeAt(idx)
+        }
+    }
+
+    /** 更新栈顶 RightCommit 的 remainingDigitCount（commit 后 buffer.digitSequence.length） */
+    fun updateTopRightCommitRemaining(count: Int) {
+        val top = commands.lastOrNull()
+        if (top is T9Command.RightCommit) {
+            commands[commands.lastIndex] = top.copy(remainingDigitCount = count)
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -84,6 +84,8 @@ import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.rime.T9InputController
 import com.kingzcheung.xime.rime.convertT9PreeditToPinyin
+import com.kingzcheung.xime.rime.buildT9DisplayState
+
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SettingsPreferences
@@ -1489,6 +1491,12 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun clearInputState() {
         calculatorEngine.clear()
         rimeEngine.clearComposition()
+        t9PartialCommitTexts.clear()
+        uiState.value = uiState.value.copy(
+            t9ResetSignal = uiState.value.t9ResetSignal + 1,
+            t9RightCandidateSelectedCount = 0,
+            t9SelectedCandidatePinyin = ""
+        )
         candidateState.value = candidateState.value.copy(
             candidates = emptyList(),
             candidateComments = emptyList(),
@@ -1550,20 +1558,40 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         }
 
         val isT9Schema = isT9Schema(uiState.value.currentSchemaId)
-        val displayText = if (isT9Schema) {
+        // T9 候选词过滤：根据左侧选择历史过滤不匹配的候选词
+        val (t9FilteredTexts, t9FilteredComments) = if (isT9Schema) {
+            keyboardCallbacks?.onFilterT9Candidates?.invoke(filteredTexts, filteredComments)
+                ?: (filteredTexts to filteredComments)
+        } else {
+            filteredTexts to filteredComments
+        }
+        val displayText: String
+        val displayCandidates: List<String>
+        val displayComments: List<String>
+        val isComposing: Boolean
+        if (isT9Schema) {
             val rawPreedit = if (preeditText.isNotEmpty()) preeditText else inputText
             val convertedPreedit = convertT9PreeditToPinyin(rawPreedit, candidatesWithComments.firstOrNull()?.comment ?: "")
-            PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, convertedPreedit)
+            val display = buildT9DisplayState(
+                t9PartialCommitTexts, convertedPreedit, inputText, t9FilteredTexts, t9FilteredComments
+            )
+            displayText = display.displayText
+            displayCandidates = display.displayCandidates
+            displayComments = display.displayComments
+            isComposing = display.isComposing
         } else {
-            inputText
+            displayText = inputText
+            displayCandidates = filteredTexts
+            displayComments = filteredComments
+            isComposing = inputText.isNotEmpty()
         }
-        val isComposing = inputText.isNotEmpty() || (isT9Schema && t9PartialCommitTexts.isNotEmpty())
+
 
         candidateState.value = candidateState.value.copy(
             inputText = displayText,
             preeditText = displayText,
-            candidates = filteredTexts,
-            candidateComments = filteredComments,
+            candidates = displayCandidates,
+            candidateComments = displayComments,
             isComposing = isComposing,
             associationCandidates = if ((isAsciiMode || !isChineseMode) && pendingEnglish.isEmpty()) emptyList() else candidateState.value.associationCandidates,
             isShowingRecentClipboard = false,
@@ -1606,20 +1634,39 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         // 非 T9 方案（如双拼）使用原始输入文本显示，
         // 避免显示 rime speller 展开后的编码（如双拼 i → ch）
         val isT9Schema = isT9Schema(uiState.value.currentSchemaId)
-        val displayText = if (isT9Schema) {
+        // T9 候选词过滤：根据左侧选择历史（全拼/简拼）过滤不匹配的候选词
+        val (t9FilteredTexts, t9FilteredComments) = if (isT9Schema) {
+            keyboardCallbacks?.onFilterT9Candidates?.invoke(filteredTexts, filteredComments)
+                ?: (filteredTexts to filteredComments)
+        } else {
+            filteredTexts to filteredComments
+        }
+        val displayText: String
+        val displayCandidates: List<String>
+        val displayComments: List<String>
+        val isComposing: Boolean
+        if (isT9Schema) {
             val rawPreedit = if (result.preeditText.isNotEmpty()) result.preeditText else result.inputText
             val convertedPreedit = convertT9PreeditToPinyin(rawPreedit, candidatesWithComments.firstOrNull()?.comment ?: "")
-            PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, convertedPreedit)
+            val display = buildT9DisplayState(
+                t9PartialCommitTexts, convertedPreedit, result.inputText, t9FilteredTexts, t9FilteredComments
+            )
+            displayText = display.displayText
+            displayCandidates = display.displayCandidates
+            displayComments = display.displayComments
+            isComposing = display.isComposing
         } else {
-            result.inputText
+            displayText = result.inputText
+            displayCandidates = filteredTexts
+            displayComments = filteredComments
+            isComposing = result.inputText.isNotEmpty()
         }
-        val isComposing = result.inputText.isNotEmpty() || (isT9Schema && t9PartialCommitTexts.isNotEmpty())
 
         candidateState.value = candidateState.value.copy(
             inputText = displayText,
             preeditText = displayText,
-            candidates = filteredTexts,
-            candidateComments = filteredComments,
+            candidates = displayCandidates,
+            candidateComments = displayComments,
             isComposing = isComposing,
             associationCandidates = if ((isAsciiMode || !isChineseMode) && pendingEnglish.isEmpty()) emptyList() else candidateState.value.associationCandidates,
             isShowingRecentClipboard = false,
@@ -1964,6 +2011,18 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     commitText(input)
                                 }
                                 rimeEngine.clearComposition()
+                                // T9模式：清空partialCommit累积文本，避免下一轮输入
+                                // preedit中残留上一轮的提交内容（如"看"→下一轮"看jihua"）
+                                if (isT9Schema(state.currentSchemaId)) {
+                                    withContext(Dispatchers.Main) {
+                                        t9PartialCommitTexts.clear()
+                                        uiState.value = uiState.value.copy(
+                                            t9ResetSignal = uiState.value.t9ResetSignal + 1,
+                                            t9RightCandidateSelectedCount = 0,
+                                            t9SelectedCandidatePinyin = ""
+                                        )
+                                    }
+                                }
                                 needsUIUpdate = true
                             }
                         }
@@ -2224,21 +2283,22 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
 
         // 在 RIME 真正 select/commit 之前，先同步通知 T9 控制器消费数字。
         // 控制器返回 true 表示输入序列已被该候选词完整消费，服务层应视为 full commit。
+        val candidateTextLength = selectedCandidate?.length ?: 0
         val fullyConsumed = if (isT9) {
-            keyboardCallbacks?.onT9RightCandidateWillBeSelected?.invoke(candidatePinyin) ?: false
+            keyboardCallbacks?.onT9RightCandidateWillBeSelected?.invoke(candidatePinyin, candidateTextLength) ?: false
         } else {
             false
         }
 
         if (rimeEngine.selectCandidate(index)) {
             val committedText = rimeEngine.commit()
-            val isFullCommit = if (isT9 && committedText.isEmpty() && fullyConsumed) {
-                // committedText 为空说明 RIME 未实际提交，但 T9 控制器消费了全部数字。
-                // 此时需检查 RIME 是否还有活动 composition，若有则是 partial commit 误判。
-                val comp = rimeEngine.getComposition()
-                comp.input.isEmpty()
+            // T9 模式下 fullyConsumed 是判断 full/partial commit 的唯一权威：
+            // 当控制器明确 partial commit 时，即使 RIME commit() 返回非空文本
+            // （RIME 内部做了 partial commit），也不应走 full commit 路径。
+            val isFullCommit = if (isT9) {
+                fullyConsumed && selectedCandidate != null
             } else {
-                committedText.isNotEmpty() || (isT9 && fullyConsumed && selectedCandidate != null)
+                committedText.isNotEmpty()
             }
             if (isFullCommit) {
                 if (SettingsPreferences.isSmartPredictionEnabled(this) && selectedCandidate != null && AssociationManager.isInitialized()) {
@@ -2286,6 +2346,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             t9RightCandidateSelectedCount = uiState.value.t9RightCandidateSelectedCount + 1,
                             t9SelectedCandidatePinyin = candidatePinyin ?: ""
                         )
+                        // RIME commit() 已清除 composition，需要控制器重新发送剩余数字到 RIME
+                        keyboardCallbacks?.onT9ForceSendToRime?.invoke()
                     }
                     updateUI()
                 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -39,11 +39,26 @@ data class KeyboardCallbacks(
     /**
      * 右侧候选词即将被 RIME select 前同步通知 T9 控制器。
      * 返回 true 表示控制器判断输入序列已被该候选词完整消费。
+     * @param pinyin RIME 候选词注释
+     * @param textLength 候选词文字长度（汉字数），0 表示未知
      */
-    var onT9RightCandidateWillBeSelected: ((String?) -> Boolean)? = null,
+    var onT9RightCandidateWillBeSelected: ((String?, Int) -> Boolean)? = null,
     /**
      * T9 键盘切换离开（至数字/英文键盘）时调用。
      * 服务层负责提交首位候选词并清理 T9 状态。
      */
     val onT9SwitchAway: (() -> Unit)? = null,
+    /**
+     * 强制 T9 控制器重新发送当前 inputBuffer 到 RIME。
+     * 用于右侧候选 partial commit 后，RIME composition 被清除需要重新构建。
+     */
+    var onT9ForceSendToRime: (() -> Unit)? = null,
+    /**
+     * T9 候选词过滤器。服务层在获取 RIME 候选词后调用，由键盘层根据
+     * [com.kingzcheung.xime.rime.T9InputController.selectionHistory] 过滤不匹配的候选词。
+     * @param candidates 候选词文本列表
+     * @param comments 候选词拼音注释列表
+     * @return 过滤后的 (候选词列表, 注释列表)
+     */
+    var onFilterT9Candidates: ((List<String>, List<String>) -> Pair<List<String>, List<String>>)? = null,
 )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayoutScreen.kt
@@ -40,6 +40,8 @@ fun KeyboardLayoutScreen(
         else KeyboardThemes.getSpecialKeyTextColor(uiState.themeId, false)
     val kbShadow = KeysConfigHelper.getKeyboardShadow()
     val kbKey = KeysConfigHelper.getKeyboardKeyConfig()
+    val accentColor = KeyboardThemes.getAccentColor(uiState.themeId, uiState.isDarkTheme)
+
 
     val onGestureAction: (GestureAction, String) -> Unit = { action, value ->
         when (action) {
@@ -183,6 +185,7 @@ fun KeyboardLayoutScreen(
                     keyBackgroundColor = keyBgColor,
                     keyTextColor = keyTextColor,
                     specialKeyBackgroundColor = specialKeyBgColor,
+                    accentColor = accentColor,
                     keyboardBackgroundColor = keyboardBgColor,
                     shadowEnabled = kbShadow.enabled,
                     shadowElevation = kbShadow.elevation.dp,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -41,6 +41,7 @@ import com.kingzcheung.xime.keyboard.PanelType
 import com.kingzcheung.xime.keyboard.ToolbarAction
 import com.kingzcheung.xime.keyboard.ToolbarButton
 import com.kingzcheung.xime.rime.T9InputController
+import com.kingzcheung.xime.rime.filterCandidatesBySelectionHistory
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.ui.menubar.ClipboardView
@@ -107,9 +108,17 @@ fun KeyboardView(
     }
 
     SideEffect {
-        callbacks.onT9RightCandidateWillBeSelected = { pinyin ->
-            t9Controller.onRightCandidateSelected(pinyin)
-            t9Controller.inputBuffer.isEmpty()
+        callbacks.onT9RightCandidateWillBeSelected = { pinyin, textLength ->
+            t9Controller.onRightCandidateSelected(pinyin, textLength)
+            t9Controller.inputBuffer.isEmpty
+        }
+        callbacks.onT9ForceSendToRime = {
+            t9Controller.forceSendToRime()
+        }
+        callbacks.onFilterT9Candidates = { candidates, comments ->
+            filterCandidatesBySelectionHistory(
+                candidates, comments, t9Controller.selectionHistory
+            )
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -95,6 +95,7 @@ fun T9KeyboardLayout(
     keyBackgroundColor: Color,
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
+    accentColor: Color = Color(0xFF1A73E8),
     keyboardBackgroundColor: Color = Color.Transparent,
     shadowEnabled: Boolean = true,
     shadowElevation: Dp = 1.dp,
@@ -137,6 +138,7 @@ fun T9KeyboardLayout(
         controller = controller,
         keyBackgroundColor = keyBackgroundColor,
         specialKeyBackgroundColor = specialKeyBackgroundColor,
+        accentColor = accentColor,
         shadowEnabled = shadowEnabled,
         shadowElevation = shadowElevation,
         shadowShapeRadius = shadowShapeRadius,
@@ -163,6 +165,7 @@ private fun T9KeyboardSwipeOverlay(
     controller: T9InputController,
     keyBackgroundColor: Color,
     specialKeyBackgroundColor: Color,
+    accentColor: Color,
     shadowEnabled: Boolean,
     shadowElevation: Dp,
     shadowShapeRadius: Dp,
@@ -246,21 +249,22 @@ private fun T9KeyboardSwipeOverlay(
                         LocalKeyVisualPadding provides PaddingValues(horizontal = 1.dp, vertical = 2.dp)
                     ) {
                         T9KeyboardContent(
-                            onKeyPress = onKeyPress,
-                            callbacks = callbacks,
-                            uiState = uiState,
-                            controller = controller,
-                            keyBackgroundColor = keyBackgroundColor,
-                            keyTextColor = keyTextColor,
-                            specialKeyBackgroundColor = specialKeyBackgroundColor,
-                            shadowEnabled = shadowEnabled,
-                            shadowElevation = shadowElevation,
-                            shadowShapeRadius = shadowShapeRadius,
-                            onKeyPressDown = onKeyPressDown,
-                            onSwipeStateChange = ::processSwipeState,
-                            onDelete = onDelete,
-                            compactMode = true,
-                        )
+                        onKeyPress = onKeyPress,
+                        callbacks = callbacks,
+                        uiState = uiState,
+                        controller = controller,
+                        keyBackgroundColor = keyBackgroundColor,
+                        keyTextColor = keyTextColor,
+                        specialKeyBackgroundColor = specialKeyBackgroundColor,
+                        accentColor = accentColor,
+                        shadowEnabled = shadowEnabled,
+                        shadowElevation = shadowElevation,
+                        shadowShapeRadius = shadowShapeRadius,
+                        onKeyPressDown = onKeyPressDown,
+                        onSwipeStateChange = ::processSwipeState,
+                        onDelete = onDelete,
+                        compactMode = true,
+                    )
                     }
                 }
             }
@@ -282,6 +286,7 @@ private fun T9KeyboardSwipeOverlay(
                         keyBackgroundColor = keyBackgroundColor,
                         keyTextColor = keyTextColor,
                         specialKeyBackgroundColor = specialKeyBackgroundColor,
+                        accentColor = accentColor,
                         shadowEnabled = shadowEnabled,
                         shadowElevation = shadowElevation,
                         shadowShapeRadius = shadowShapeRadius,
@@ -434,6 +439,7 @@ private fun T9KeyboardContent(
     keyBackgroundColor: Color,
     keyTextColor: Color,
     specialKeyBackgroundColor: Color,
+    accentColor: Color,
     shadowEnabled: Boolean,
     shadowElevation: Dp,
     shadowShapeRadius: Dp,
@@ -486,9 +492,10 @@ private fun T9KeyboardContent(
                     .clip(RoundedCornerShape(LocalKeyCornerRadius.current))
                     .background(keyBackgroundColor)
             ) {
-                val showCandidates = controller.firstOptions.isNotEmpty()
+                val showCandidates = controller.leftPanelState != T9InputController.LeftPanelState.IDLE
+                val currentFirstOptions = controller.firstOptions
                 val displayItems: List<String> = if (showCandidates) {
-                    controller.firstOptions.map { it.pinyin }
+                    currentFirstOptions.map { it.pinyin }
                 } else {
                     listOf("，", "。", "？", "！")
                 }
@@ -499,14 +506,19 @@ private fun T9KeyboardContent(
                     ) {
                         displayItems.forEachIndexed { index, item ->
                             if (showCandidates) {
-                            val option = controller.firstOptions[index]
+                            val option = currentFirstOptions[index]
+                            val isSelected = controller.leftPanelState == T9InputController.LeftPanelState.SELECTION &&
+                                    controller.selectedOption == option &&
+                                    controller.isSelectedOptionInCurrentCandidates()
                                     CandidateItem(
                                         text = option.pinyin,
                                         onClick = { controller.onChoiceSelected(option) },
                                         onPress = { onKeyPressDown?.invoke(option.pinyin) },
                                         textColor = keyTextColor,
                                         backgroundColor = keyBackgroundColor,
+                                        accentColor = accentColor,
                                         fontSize = candidateFontSize,
+                                        isSelected = isSelected,
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .weight(1f)
@@ -518,7 +530,9 @@ private fun T9KeyboardContent(
                                     onPress = { onKeyPressDown?.invoke(item) },
                                     textColor = keyTextColor,
                                     backgroundColor = keyBackgroundColor,
+                                    accentColor = accentColor,
                                     fontSize = candidateFontSize,
+                                    isSelected = false,
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .weight(1f)
@@ -532,14 +546,19 @@ private fun T9KeyboardContent(
                         verticalArrangement = Arrangement.spacedBy(0.dp)
                     ) {
                         itemsIndexed(displayItems) { index, _ ->
-                            val option = controller.firstOptions[index]
+                            val option = currentFirstOptions[index]
+                            val isSelected = controller.leftPanelState == T9InputController.LeftPanelState.SELECTION &&
+                                    controller.selectedOption == option &&
+                                    controller.isSelectedOptionInCurrentCandidates()
                             CandidateItem(
                                 text = option.pinyin,
                                 onClick = { controller.onChoiceSelected(option) },
                                 onPress = { onKeyPressDown?.invoke(option.pinyin) },
                                 textColor = keyTextColor,
                                 backgroundColor = keyBackgroundColor,
+                                accentColor = accentColor,
                                 fontSize = candidateFontSize,
+                                isSelected = isSelected,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(if (compactMode) 26.dp else 32.dp)
@@ -841,8 +860,10 @@ private fun CandidateItem(
     onPress: (() -> Unit)?,
     textColor: Color,
     backgroundColor: Color = Color.Transparent,
+    accentColor: Color = Color(0xFF1A73E8),
     modifier: Modifier = Modifier,
     fontSize: androidx.compose.ui.unit.TextUnit = 13.sp,
+    isSelected: Boolean = false,
 ) {
     var isPressed by remember { mutableStateOf(false) }
     val currentOnClick by rememberUpdatedState(onClick)
@@ -850,10 +871,7 @@ private fun CandidateItem(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                if (isPressed) backgroundColor.copy(alpha = 0.7f)
-                else Color.Transparent
-            )
+            .background(if (isPressed) backgroundColor.copy(alpha = 0.7f) else Color.Transparent)
             .pointerInput(Unit) {
                 detectTapGestures(onPress = {
                     isPressed = true
@@ -861,16 +879,35 @@ private fun CandidateItem(
                     tryAwaitRelease()
                     isPressed = false
                 }, onTap = { currentOnClick() })
-            }, contentAlignment = Alignment.Center
+            },
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = text,
-            color = textColor,
-            fontSize = fontSize,
-            fontWeight = FontWeight.Normal,
-            textAlign = TextAlign.Center,
-            maxLines = 1
-        )
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(accentColor.copy(alpha = 0.2f))
+                    .padding(horizontal = 8.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = text,
+                    color = accentColor,
+                    fontSize = fontSize,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1
+                )
+            }
+        } else {
+            Text(
+                text = text,
+                color = textColor,
+                fontSize = fontSize,
+                fontWeight = FontWeight.Normal,
+                textAlign = TextAlign.Center,
+                maxLines = 1
+            )
+        }
     }
 }
 

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9BufferManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9BufferManagerTest.kt
@@ -1,0 +1,48 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * T9Buffer 单元测试。
+ *
+ * 覆盖 T9Buffer 核心数据模型的基本操作。
+ * （遗留的 DigitStream / BufferParts / 字符串函数已在步骤7中删除）
+ */
+class T9BufferManagerTest {
+
+    // ── T9Buffer 基本操作 ──
+
+    @Test
+    fun `buffer addDigit extends digitSequence`() {
+        val buf = T9Buffer().addDigit("5").addDigit("4")
+        assertEquals("54", buf.digitSequence)
+    }
+
+    @Test
+    fun `buffer addSelection updates selections and consumedCount`() {
+        val buf = T9Buffer("54482").addSelection("ji", 2)
+        assertEquals(1, buf.selections.size)
+        assertEquals("ji", buf.selections[0].pinyin)
+        assertEquals(2, buf.consumedCount)
+        assertEquals("482", buf.unassigned)
+    }
+
+    @Test
+    fun `buffer removeLastDigit shortens sequence`() {
+        val buf = T9Buffer("54482").removeLastDigit()
+        assertEquals("5448", buf.digitSequence)
+    }
+
+    @Test
+    fun `buffer toBufferString with selections`() {
+        val buf = T9Buffer("54482", selections = listOf(T9Buffer.Selection("ji", 2)), consumedCount = 2)
+        assertEquals("ji'482", buf.toBufferString())
+    }
+
+    @Test
+    fun `buffer toPreeditString with selections`() {
+        val buf = T9Buffer("54482", selections = listOf(T9Buffer.Selection("ji", 2)), consumedCount = 2)
+        assertEquals("ji'482", buf.toPreeditString())
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9InputControllerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9InputControllerTest.kt
@@ -4,16 +4,9 @@ import org.junit.Assert.*
 import org.junit.Test
 
 /**
- * T9InputController 单元测试
+ * T9InputController 单元测试 — 命令模式（Phase 3）。
  *
- * 覆盖以下关键场景：
- * - 数字按键 → inputBuffer 更新 + 候选区更新
- * - 分词键 → 确认拼音 + 锁定 + 锁定后继续输入
- * - 从锁定候选区选词（替换已确认拼音）
- * - 从剩余数字选词（消费剩余数字）
- * - 退格键 — 返回 DeleteResult 区分操作类型
- * - 右侧候选列表选词（partial commit）+ 撤销
- * - 清空
+ * 覆盖基础输入场景、分词键、选区操作、右侧候选选词、退格撤销。
  */
 class T9InputControllerTest {
 
@@ -34,13 +27,221 @@ class T9InputControllerTest {
         assertEquals(expected.toList(), controller.firstOptions.map { it.pinyin })
     }
 
-    // ── 基础按键 ──
+    // ═══════════════════════════════════════════════════════════
+    // 场景3：全拼左选li+gua后空格选"离卦"（full commit）
+    // 操作：54482 → 左选li → 左选gua → 空格(选择首位候选"离卦")
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 3 - select li then gua then space with space-separated comment should full commit`() {
+        val ctrl = createController()
+        // 1. 输入54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        assertEquals("54482", ctrl.bufferString)
+
+        // 2. 左选li
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        assertEquals("li'482", ctrl.bufferString)
+
+        // 3. 左选gua
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ligua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("gua", 3), ctrl.selectedOption)
+
+        // 4. 空格选"离卦"(comment="li gua", 空格分隔)
+        val result = ctrl.onRightCandidateSelected("li gua", 2)
+        assertTrue("右选'离卦'(li gua)应完整消费, buffer=${ctrl.bufferString}", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertNull(ctrl.selectionCandidateDigits)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `scenario 3 - select li then gua then space with no-space comment should full commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ligua", ctrl.bufferString)
+
+        // RIME可能返回无音节分隔的注释(如"ligua"而非"li gua")
+        // 当selectionHistory完全覆盖buffer且候选字数>=选择数时，应判定为full commit
+        val result = ctrl.onRightCandidateSelected("ligua", 2)
+        assertTrue("右选'离卦'(ligua无分隔)应完整消费, buffer=${ctrl.bufferString}", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+    }
+
+    @Test
+    fun `scenario 3 - select li then gua then space with null comment should full commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ligua", ctrl.bufferString)
+
+        // 实机场景：RIME不返回spelling_hints注释时candidatePinyin=null
+        // selectionHistory=[li, gua]完全覆盖buffer="ligua"，应判定为full commit
+        val result = ctrl.onRightCandidateSelected(null, 2)
+        assertTrue("右选'离卦'(null注释)应完整消费, buffer=${ctrl.bufferString}", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertNull(ctrl.selectionCandidateDigits)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `scenario 3 - backspace sequence after selecting li and gua takes 7 steps`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        assertEquals("li'482", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ligua", ctrl.bufferString)
+
+        // 回退顺序：【gua点击, 2, 8, 4, li点击, 4, 5】= 7次
+        // 1. 撤销gua选中
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("li'482", ctrl.bufferString)
+
+        // 2. 删除2
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("li'48", ctrl.bufferString)
+
+        // 3. 删除8
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("li'4", ctrl.bufferString)
+
+        // 4. 删除4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("li'", ctrl.bufferString)
+
+        // 5. 撤销li选中
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("54", ctrl.bufferString)
+
+        // 6. 删除4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+
+        // 7. 删除5
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 场景4：左选全拼后上屏（基础输入场景4）
+    // 操作：54482 → 左选ji → 右选"计划"(full commit)
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 4 - input 54482 select ji then right candidate plan full commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ji", 2))
+        assertEquals("ji'482", ctrl.bufferString)
+        assertTrue(ctrl.firstOptions.any { it.pinyin == "gua" })
+        assertTrue(ctrl.firstOptions.any { it.pinyin == "hua" })
+
+        val result = ctrl.onRightCandidateSelected("ji hua", 2)
+        assertTrue("右选'计划'应完整消费所有数字", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertNull(ctrl.selectionCandidateDigits)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `scenario 4 - verify sendToRime sends ji-apostrophe-482 after selecting ji`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        assertTrue("sendToRime should send '54482'",
+            rimeCalls.any { it == "54482" })
+
+        rimeCalls.clear()
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ji", 2))
+        assertEquals("ji'482", ctrl.bufferString)
+
+        // 关键验证：左选ji后sendToRime必须发送"ji'482"而非"ji"
+        assertTrue("should send 'ji'482' to RIME, got: $rimeCalls",
+            rimeCalls.any { it == "ji'482" })
+        assertFalse("should NOT send 'ji' alone",
+            rimeCalls.any { it == "ji" })
+
+        rimeCalls.clear()
+        ctrl.onRightCandidateSelected("ji hua", 2)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 场景5：左选全拼后空格（基础输入场景5）
+    // 操作：54482 → 左选ji → 空格(选择首位候选"计划")
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 5 - input 54482 select ji then space full commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ji", 2))
+        assertEquals("ji'482", ctrl.bufferString)
+
+        val result = ctrl.onRightCandidateSelected("ji hua", 2)
+        assertTrue("右选'计划'应完整消费数字", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 场景6：左选简拼后上屏（基础输入场景6）
+    // 操作：5 → 左选j → 4 → 左选g → 空格
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 6 - input 5 select j 4 select g then space full commit`() {
+        val ctrl = createController()
+        ctrl.onDigitPressed("5")
+        assertEquals("5", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("j", 1), ctrl.selectedOption)
+
+        ctrl.onDigitPressed("4")
+        assertEquals("j'4", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        val result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertTrue("左选j+g后右选'价格'应完整消费, 当前buffer=${ctrl.bufferString}", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertNull(ctrl.selectionCandidateDigits)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 基础按键
+    // ═══════════════════════════════════════════════════════════
 
     @Test
     fun `press 5 updates buffer and candidates`() {
         val ctrl = createController()
         ctrl.onDigitPressed("5")
-        assertEquals("5", ctrl.inputBuffer)
+        assertEquals("5", ctrl.bufferString)
         assertTrue(ctrl.firstOptions.isNotEmpty())
         assertEquals("j", ctrl.firstOptions.first().pinyin)
     }
@@ -50,17 +251,19 @@ class T9InputControllerTest {
         val ctrl = createController()
         ctrl.onDigitPressed("5")
         ctrl.onDigitPressed("4")
-        assertEquals("54", ctrl.inputBuffer)
+        assertEquals("54", ctrl.bufferString)
     }
 
-    // ── 分词键 ──
+    // ═══════════════════════════════════════════════════════════
+    // 分词键
+    // ═══════════════════════════════════════════════════════════
 
     @Test
     fun `separator key converts digit 5 to j-apostrophe and locks`() {
         val ctrl = createController()
         ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("1") // 分词键
-        assertEquals("j'", ctrl.inputBuffer)
+        ctrl.onDigitPressed("1")
+        assertEquals("j'", ctrl.bufferString)
         assertTrue(ctrl.leftColumnLocked)
     }
 
@@ -68,167 +271,129 @@ class T9InputControllerTest {
     fun `after separator pressing 43 appends digits and keeps panel locked`() {
         val ctrl = createController()
         ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("1") // 分词 → "j'"
-        ctrl.onDigitPressed("4") // "j'4" — panel locked, no update
-        ctrl.onDigitPressed("3") // "j'43" — panel locked, no update
-        assertEquals("j'43", ctrl.inputBuffer)
+        ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
         assertTrue(ctrl.leftColumnLocked)
     }
-
-    // ── 分词键：RIME comment 反推音节切分 ──
 
     @Test
     fun `separator uses rime comment to choose li over ji`() {
-        // RIME 返回首选候选 comment 为 "li hua"，分词键应按 RIME 意图确认 "li"
         val composition = RimeComposition(
-            input = "54482",
-            preedit = "li hua",
-            committedText = "",
+            input = "54482", preedit = "li hua", committedText = "",
             candidates = arrayOf(RimeCandidate("梨花", "li hua")),
-            hasNextPage = false,
-            hasPrevPage = false,
-            isAsciiMode = false
+            hasNextPage = false, hasPrevPage = false, isAsciiMode = false
         )
         val ctrl = createControllerWithRime(composition)
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("8")
-        ctrl.onDigitPressed("2")
-        ctrl.onDigitPressed("1") // 分词键
-
-        assertEquals("li'482", ctrl.inputBuffer)
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onDigitPressed("1")
+        assertEquals("li'482", ctrl.bufferString)
         assertTrue(ctrl.leftColumnLocked)
     }
 
-    @Test
-    fun `separator falls back to greedy when rime comment is empty`() {
-        val composition = RimeComposition(
-            input = "54482",
-            preedit = "",
-            committedText = "",
-            candidates = arrayOf(RimeCandidate("ji", "")),
-            hasNextPage = false,
-            hasPrevPage = false,
-            isAsciiMode = false
-        )
-        val ctrl = createControllerWithRime(composition)
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("8")
-        ctrl.onDigitPressed("2")
-        ctrl.onDigitPressed("1") // 分词键
-
-        // 贪婪最长匹配："ji" 消费 54，剩余 482
-        assertEquals("ji'482", ctrl.inputBuffer)
-    }
-
-    @Test
-    fun `separator falls back to greedy when comment does not match digits prefix`() {
-        // RIME comment 中的首音节 "gua" 对应 482，与当前数字段 54482 前缀不匹配
-        val composition = RimeComposition(
-            input = "54482",
-            preedit = "",
-            committedText = "",
-            candidates = arrayOf(RimeCandidate("瓜", "gua")),
-            hasNextPage = false,
-            hasPrevPage = false,
-            isAsciiMode = false
-        )
-        val ctrl = createControllerWithRime(composition)
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("8")
-        ctrl.onDigitPressed("2")
-        ctrl.onDigitPressed("1") // 分词键
-
-        assertEquals("ji'482", ctrl.inputBuffer)
-    }
-
-    // ── 从锁定候选区选词（替换已确认拼音）──
+    // ═══════════════════════════════════════════════════════════
+    // 从锁定候选区选词 / 从剩余数字选词
+    // ═══════════════════════════════════════════════════════════
 
     @Test
     fun `select k from locked panel replaces j with k`() {
         val ctrl = createController()
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("1") // "j'" (locked)
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("3") // "j'43" (still locked)
-
-        val result = ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
-        assertEquals("k'43", ctrl.inputBuffer)
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
         assertFalse(ctrl.leftColumnLocked)
-        assertTrue(ctrl.firstOptions.isNotEmpty())
         assertTrue(ctrl.firstOptions.any { it.pinyin == "he" })
     }
-
-    // ── 从剩余数字选词（消费剩余数字） ──
-
-    @Test
-    fun `select he from unlocked panel with remaining 43 merges to khe`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("1") // "j'"
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("3") // "j'43"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1)) // "k'43", unlocked
-
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
-        assertEquals("khe", ctrl.inputBuffer)
-        // 完整拼音组合且无剩余数字：左侧候选区进入空闲态
-        assertTrue(ctrl.firstOptions.isEmpty())
-        assertFalse(ctrl.leftColumnLocked)
-    }
-
-    @Test
-    fun `select g from remaining 43 with digit length 1 leaves 3`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("1") // "j'"
-        ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("3") // "j'43"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1)) // "k'43", unlocked
-
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
-        assertEquals("kg'3", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isNotEmpty())
-    }
-
-    // ── 纯数字段（无 '）选词 ──
 
     @Test
     fun `select ji from 54482 produces ji-apostrophe-482`() {
         val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
-
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
         ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ji", 2))
-        assertEquals("ji'482", ctrl.inputBuffer)
+        assertEquals("ji'482", ctrl.bufferString)
         assertFalse(ctrl.leftColumnLocked)
     }
 
     @Test
     fun `select j from 54482 produces j-apostrophe-4482`() {
         val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
-
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
         ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
-        assertEquals("j'4482", ctrl.inputBuffer)
+        assertEquals("j'4482", ctrl.bufferString)
     }
-
-    // ── 退格键 ──
 
     @Test
-    fun `backspace removes last char and updates candidates`() {
+    fun `selection state - clicking another left option replaces selected pinyin`() {
         val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("5", ctrl.inputBuffer)
-        assertFalse(ctrl.leftColumnLocked)
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        assertEquals("li'482", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ligua", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("lihua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // 右侧候选选词
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `rightCandidate on 23744 consumes first 2 digits to 744`() {
+        val ctrl = createController()
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected()
+        assertEquals("744", ctrl.bufferString)
+        assertTrue("left options should contain shi", ctrl.firstOptions.any { it.pinyin == "shi" })
+    }
+
+    @Test
+    fun `rightCandidate on empty buffer does nothing`() {
+        val ctrl = createController()
+        ctrl.onRightCandidateSelected()
+        assertEquals("", ctrl.bufferString)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `rightCandidate on 5 consumes all to empty`() {
+        val ctrl = createController()
+        ctrl.onDigitPressed("5")
+        ctrl.onRightCandidateSelected()
+        assertEquals("", ctrl.bufferString)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `bug1 - consecutive right candidate selections consume buffer correctly`() {
+        val ctrl = createController()
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected()
+        assertEquals("744", ctrl.bufferString)
+        ctrl.onRightCandidateSelected()
+        assertEquals("", ctrl.bufferString)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `scenario 10 - right candidate full commit clears all state`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        val fullyConsumed = ctrl.onRightCandidateSelected("ji hua", 2)
+        assertTrue(fullyConsumed)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 退格与撤销
+    // ═══════════════════════════════════════════════════════════
 
     @Test
     fun `backspace on empty buffer returns NOT_CONSUMED`() {
@@ -240,179 +405,22 @@ class T9InputControllerTest {
     fun `backspace unlocks panel and undoes separator`() {
         val ctrl = createController()
         ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
-        assertEquals("j'", ctrl.inputBuffer)
+        assertEquals("j'", ctrl.bufferString)
         assertTrue(ctrl.leftColumnLocked)
-
-        // 分词键后按退格：撤销分词键，恢复原始数字并解锁
         ctrl.delete()
-        assertEquals("5", ctrl.inputBuffer)
+        assertEquals("5", ctrl.bufferString)
         assertFalse(ctrl.leftColumnLocked)
     }
 
-    // ── Backspace with undo（候选点击撤销） ──
-
     @Test
-    fun `scenario 1 - after li backspace returns DELETED not UNDO_CHOICE when digits present`() {
+    fun `first backspace after rightCandidate returns UNDO_COMMIT`() {
         val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
-
-        // "li'482" 有数字段，先删除数字而非撤销
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("li'48", ctrl.inputBuffer)
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected()
+        assertEquals("744", ctrl.bufferString)
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
+        assertEquals("23744", ctrl.bufferString)
     }
-
-    @Test
-    fun `scenario 1 - 54482 plus li hua equals 7 backspaces total`() {
-        val ctrl = createController()
-        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
-        assertEquals("lihua", ctrl.inputBuffer)
-
-        // 预期回退顺序：hua→2→8→4→li→4→5 (7次)
-        // BS1: 撤销 hua (UNDO_CHOICE)
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("li'482", ctrl.inputBuffer)
-        // BS2: 删除数字 2 (DELETED)
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("li'48", ctrl.inputBuffer)
-        // BS3: 删除数字 8 (DELETED)
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("li'4", ctrl.inputBuffer)
-        // BS4: 删除数字 4 (DELETED) → "li'"，左侧应显示 li 对应数字段 54 的候选
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("li'", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.map { it.pinyin }.containsAll(listOf("ji", "li", "j", "k", "l")))
-        // BS5: 撤销 li (UNDO_CHOICE) — 无数字段了
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("54", ctrl.inputBuffer)
-        // BS6: 删除数字 4 (DELETED)
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("5", ctrl.inputBuffer)
-        // BS7: 删除数字 5 (DELETED)
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    @Test
-    fun `scenario 1 variant - 54482 li gu b backspace order`() {
-        val ctrl = createController()
-        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gu", 2))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
-        assertEquals("ligub", ctrl.inputBuffer)
-
-        // 回退顺序：b, 2, gu, 8, 2, li, 4, 5
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("ligu'2", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("ligu'", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("li'48", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("li'4", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("li'", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("54", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("5", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    @Test
-    fun `scenario 2 - 54482 no clicks equals 5 backspaces`() {
-        val ctrl = createController()
-        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
-
-        for (expected in listOf("5448", "544", "54", "5", "")) {
-            assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-            assertEquals(expected, ctrl.inputBuffer)
-        }
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    @Test
-    fun `scenario 3 - 5143 no clicks equals 4 backspaces`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
-        assertEquals("j'43", ctrl.inputBuffer)
-        // 锁定态下左侧候选区保持分词前的 5 键字母映射
-        assertPinyins(ctrl, "j", "k", "l")
-
-        // BS1: 删除 3 → "j'4"，未进行左侧候选区选择，继续显示分词键 5 的字母映射
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("j'4", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-        // BS2: 删除 4 → "j'"，仍显示 5 的字母映射
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("j'", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-        // BS3: 撤销分词键 → 恢复 "5"
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("5", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-        // BS4: 删除 5 → ""
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    @Test
-    fun `scenario 4 - 5143 plus k ge equals 6 backspaces total`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ge", 2))
-        assertEquals("kge", ctrl.inputBuffer)
-        // 完整拼音组合且无剩余数字：左侧候选区进入空闲态
-        assertTrue(ctrl.firstOptions.isEmpty())
-
-        // BS1: 撤销 ge (UNDO_CHOICE) → "k'43"
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("k'43", ctrl.inputBuffer)
-        assertPinyins(ctrl, "ge", "he", "g", "h", "i")
-        // BS2: 删除 3 (DELETED) → "k'4"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("k'4", ctrl.inputBuffer)
-        assertPinyins(ctrl, "g", "h", "i")
-        // BS3: 删除 4 (DELETED) → "k'"，以分隔符结尾，显示 5 键字母映射
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("k'", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-        // BS4: 撤销 k (UNDO_CHOICE) → "j'"，以分隔符结尾，仍显示 5 键字母映射
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("j'", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-        // BS5: 撤销分词键 (UNDO_CHOICE) → "5"
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("5", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-        // BS6: 删除 5 (DELETED) → ""
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    // ── 清空 ──
 
     @Test
     fun `clearAll resets everything`() {
@@ -420,674 +428,415 @@ class T9InputControllerTest {
         ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
         ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
         ctrl.clearAll()
-        assertEquals("", ctrl.inputBuffer)
+        assertEquals("", ctrl.bufferString)
         assertTrue(ctrl.firstOptions.isEmpty())
         assertFalse(ctrl.leftColumnLocked)
     }
 
-    @Test
-    fun `reset clears buffer candidates and partial commit state`() {
-        val ctrl = createController()
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        ctrl.onRightCandidateSelected()
-        assertTrue(ctrl.inputBuffer.isNotEmpty())
+    // ═══════════════════════════════════════════════════════════
+    // 候选词过滤（filterCandidatesBySelectionHistory）
+    // ═══════════════════════════════════════════════════════════
 
+    @Test
+    fun `filter - selecting ji should keep ji-hua candidates like plan`() {
+        // 场景4：输入54482 → 左选ji → RIME返回"计划(ji hua)"等候选
+        // selectionHistory = [SyllableOption("ji", 2)]
+        // "计划" 的 comment = "ji hua"，应通过过滤
+        val candidates = listOf("计划", "即", "及")
+        val comments = listOf("ji hua", "ji", "ji")
+        val selectionHistory = listOf(T9PinyinMap.SyllableOption("ji", 2))
+
+        val (filtered, _) = filterCandidatesBySelectionHistory(
+            candidates, comments, selectionHistory
+        )
+
+        assertTrue("过滤后应保留'计划(ji hua)'，实际: $filtered",
+            filtered.contains("计划"))
+    }
+
+    @Test
+    fun `filter - selecting ji then hua keeps all digit-code-matching candidates`() {
+        // 场景4完整：54482 → 左选ji → 左选hua
+        // 数字码约束：ji(54) + hua(482)
+        // 九键约束仅在数字码级别，hua/gua 同码 482 不可区分
+        // 精确拼音过滤由 RIME 的 setInput("ji'482") 实现，客户端只做数字码辅助过滤
+        val candidates = listOf("计划", "记挂", "梨花", "客户")
+        val comments = listOf("ji hua", "ji gua", "li hua", "ke hu")
+        val selectionHistory = listOf(
+            T9PinyinMap.SyllableOption("ji", 2),
+            T9PinyinMap.SyllableOption("hua", 3)
+        )
+
+        val (filtered, _) = filterCandidatesBySelectionHistory(
+            candidates, comments, selectionHistory
+        )
+
+        // 数字码匹配的都保留
+        assertTrue("应保留'计划(ji hua)'", filtered.contains("计划"))
+        assertTrue("应保留'记挂(ji gua)'，gua(482)==hua(482)", filtered.contains("记挂"))
+        // 数字码不匹配的排除
+        assertFalse("应排除'客户(ke hu)'，ke(53)!=ji(54)且hu(48)!=hua(482)",
+            filtered.contains("客户"))
+    }
+
+    @Test
+    fun `filter - selecting only first syllable should not require matching last comment syllable`() {
+        // 核心bug验证：只选了第一个音节ji时，不应要求ji的数字码(54)等于comment末音节的数字码
+        // 即"计划(ji hua)"不应因"54"!="482"而被过滤掉
+        val candidates = listOf("计划", "激化", "即", "及")
+        val comments = listOf("ji hua", "ji hua", "ji", "ji")
+        val selectionHistory = listOf(T9PinyinMap.SyllableOption("ji", 2))
+
+        val (filtered, filteredComments) = filterCandidatesBySelectionHistory(
+            candidates, comments, selectionHistory
+        )
+
+        // 选了ji后，组合词(ji hua)和单字(ji)都应该保留
+        assertTrue("应保留'计划(ji hua)'", filtered.contains("计划"))
+        assertTrue("应保留'激化(ji hua)'", filtered.contains("激化"))
+        assertTrue("应保留'即(ji)'", filtered.contains("即"))
+    }
+
+    @Test
+    fun `filter - selecting k then he keeps prefix-matched candidates like ke-hu`() {
+        // 场景5143：左选k → 左选he
+        // "空格(kong ge)" 全匹配 → FULL
+        // "考核(kao he)" 全匹配 → FULL
+        // "客户(ke hu)" k→ke 前缀匹配成功，he≠hu → PREFIX（保留，排在FULL后面）
+        val candidates = listOf("空格", "客户", "考核")
+        val comments = listOf("kong ge", "ke hu", "kao he")
+        val selectionHistory = listOf(
+            T9PinyinMap.SyllableOption("k", 1),
+            T9PinyinMap.SyllableOption("he", 2)
+        )
+
+        val (filtered, _) = filterCandidatesBySelectionHistory(
+            candidates, comments, selectionHistory
+        )
+
+        // 全匹配排前，前缀匹配排后
+        assertTrue("应保留'空格(kong ge)'全匹配", filtered.contains("空格"))
+        assertTrue("应保留'考核(kao he)'全匹配", filtered.contains("考核"))
+        assertTrue("应保留'客户(ke hu)'前缀匹配(k→ke)", filtered.contains("客户"))
+        // 全匹配应在前缀匹配之前
+        assertTrue("空格应排在客户前面",
+            filtered.indexOf("空格") < filtered.indexOf("客户"))
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 三态状态机
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `state machine - idle to input to selection to idle cycle`() {
+        val ctrl = createController()
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        ctrl.onDigitPressed("5")
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("j", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+        ctrl.onDigitPressed("4")
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 场景3.1：全拼左选li+gua后右选单字"里"（partial commit）
+    // 操作：54482 → 左选li → 左选gua → 右选"里"(li, 1字)
+    // Bug：buffer变为"482"导致RIME收到"gua'482"产生"瓜瓜"候选
+    // 修复：buffer应为"gua"(拼音), selectionHistory移除已消费的"li"
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 3_1 - partial commit of li leaves gua as pinyin buffer not digits`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 1. 输入54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 2. 左选li
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        assertEquals("li'482", ctrl.bufferString)
+
+        // 3. 左选gua
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ligua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 4. 右选"里"(单字, pinyin="li") — partial commit
+        rimeCalls.clear()
+        val result = ctrl.onRightCandidateSelected("li", 1)
+        assertFalse("右选'里'应partial commit, buffer=${ctrl.bufferString}", result)
+
+        // 核心验证：buffer应为拼音"gua"而非数字"482"（String buffer 解析被 T9Buffer 替代）
+        assertEquals("buffer应为拼音'gua'而非数字'482'", "gua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("gua", 3), ctrl.selectedOption)
+        assertEquals("482", ctrl.selectionCandidateDigits)
+
+        // partial commit消费了"li"，selectionHistory只保留[gua]
+        assertEquals(listOf(T9PinyinMap.SyllableOption("gua", 3)), ctrl.selectionHistory)
+
+        // 左候选区仍显示482的有效拼音
+        assertTrue("应包含gua", ctrl.firstOptions.any { it.pinyin == "gua" })
+        assertTrue("应包含hua", ctrl.firstOptions.any { it.pinyin == "hua" })
+
+        // RIME输入验证：应为"gua"而非"gua'482"
+        ctrl.forceSendToRime()
+        assertTrue("RIME应收到'gua', 实际: $rimeCalls",
+            rimeCalls.any { it == "gua" })
+        assertFalse("RIME不应收到含'482'的输入, 实际: $rimeCalls",
+            rimeCalls.any { it.contains("482") })
+    }
+
+    @Test
+    fun `scenario 3_1 - null comment partial commit also leaves gua as pinyin buffer`() {
+        val ctrl = createController()
+
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+
+        // RIME不返回注释时candidatePinyin=null
+        val result = ctrl.onRightCandidateSelected(null, 1)
+        assertFalse("null注释右选'里'应partial commit, buffer=${ctrl.bufferString}", result)
+        assertEquals("gua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(listOf(T9PinyinMap.SyllableOption("gua", 3)), ctrl.selectionHistory)
+    }
+
+    @Test
+    fun `scenario 3_1 - after partial commit, selecting remaining char full commits`() {
+        val ctrl = createController()
+
+        // 1-3: 输入54482, 左选li, 左选gua
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+
+        // 4: 右选"里"(partial commit)
+        val result1 = ctrl.onRightCandidateSelected("li", 1)
+        assertFalse(result1)
+        assertEquals("gua", ctrl.bufferString)
+
+        // 5: 右选"瓜"(full commit)
+        val result2 = ctrl.onRightCandidateSelected("gua", 1)
+        assertTrue("右选'瓜'应full commit, buffer=${ctrl.bufferString}", result2)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertTrue(ctrl.firstOptions.isEmpty())
+    }
+
+    @Test
+    fun `scenario 3_1 - backspace after partial commit takes 8 steps`() {
+        val ctrl = createController()
+
+        // 1-4: 输入54482, 左选li, 左选gua, 右选"里"(partial commit)
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        ctrl.onRightCandidateSelected("li", 1)
+        assertEquals("gua", ctrl.bufferString)
+
+        // 回退顺序：【"里"commit, gua选中, 2, 8, 4, li选中, 4, 5】= 8次
+
+        // 1. 撤销"里"commit (RightCommit undo)
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
+        assertEquals("ligua", ctrl.bufferString)
+
+        // 2. 撤销gua选中 (LeftChoice undo)
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("li'482", ctrl.bufferString)
+
+        // 3. 删除2
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("li'48", ctrl.bufferString)
+
+        // 4. 删除8
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("li'4", ctrl.bufferString)
+
+        // 5. 删除4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("li'", ctrl.bufferString)
+
+        // 6. 撤销li选中 (LeftChoice undo)
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("54", ctrl.bufferString)
+
+        // 7. 删除4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+
+        // 8. 删除5
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // Bug：onRightCandidateSelected 不应在服务层 selectCandidate+commit 之前
+    // 调用 sendToRime()，否则会破坏 RIME composition 导致上屏空白
+    // ═══════════════════════════════════════════════════════════
+
+    @Test
+    fun `onRightCandidateSelected full commit must not send to RIME - preserving composition for service selectCandidate`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 输入 54482 → 左选li → 左选gua（预编辑：ligua）
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+
+        // 清除之前的 rime 调用记录，只观察 onRightCandidateSelected 期间的调用
+        rimeCalls.clear()
+
+        val result = ctrl.onRightCandidateSelected("li gua", 2)
+        assertTrue("应完整消费", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+
+        // 关键断言：onRightCandidateSelected 期间不应向 RIME 发送任何内容
+        // 服务层需要 RIME composition 保持完整，以便调用 selectCandidate + commit
+        assertTrue(
+            "onRightCandidateSelected 期间不应调用 replaceFullPinyin（会破坏 RIME composition），实际调用: $rimeCalls",
+            rimeCalls.isEmpty()
+        )
+    }
+
+    @Test
+    fun `onRightCandidateSelected partial commit must not send to RIME - service calls forceSendToRime after commit`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 输入 544826 → 左选li（预编辑：li'4826）
+        for (d in listOf("5", "4", "4", "8", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+
+        rimeCalls.clear()
+
+        // 右选"李华"(lihua) — 消费5位数字，剩余1位(6)
+        val result = ctrl.onRightCandidateSelected("li hua", 2)
+        assertFalse("应部分消费，剩余数字6", result)
+
+        // 关键断言：partial commit 期间也不应向 RIME 发送
+        // 服务层会先 rimeEngine.selectCandidate+commit，然后调用 forceSendToRime
+        assertTrue(
+            "onRightCandidateSelected(partial) 期间不应调用 replaceFullPinyin，实际调用: $rimeCalls",
+            rimeCalls.isEmpty()
+        )
+    }
+
+    @Test
+    fun `onRightCandidateSelected digit-segment full commit must not send to RIME`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 输入 54482（无左选，纯数字段模式）
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        rimeCalls.clear()
+
+        // 右选"计划"（jihua，消费全部5位数字）
+        val result = ctrl.onRightCandidateSelected("ji hua", 2)
+        assertTrue("应完整消费", result)
+        assertEquals("", ctrl.bufferString)
+
+        assertTrue(
+            "digit-segment full commit 期间不应调用 replaceFullPinyin，实际调用: $rimeCalls",
+            rimeCalls.isEmpty()
+        )
+    }
+
+    @Test
+    fun `after partial commit forceSendToRime sends remaining preedit to RIME`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 输入 544826 → 左选li（预编辑：li'4826）
+        for (d in listOf("5", "4", "4", "8", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+
+        rimeCalls.clear()
+
+        // 右选"李华"(lihua) — partial commit，剩余数字6
+        val result = ctrl.onRightCandidateSelected("li hua", 2)
+        assertFalse("应部分消费", result)
+
+        // onRightCandidateSelected 期间不应调用 replaceFullPinyin
+        assertTrue("partial commit 期间不应调用 replaceFullPinyin，实际调用: $rimeCalls", rimeCalls.isEmpty())
+
+        // 服务层调用 forceSendToRime：应发送剩余预编辑
+        ctrl.forceSendToRime()
+
+        // 验证：forceSendToRime 应发送剩余的预编辑（6）
+        assertTrue(
+            "forceSendToRime 应发送剩余预编辑到 RIME，实际调用: $rimeCalls",
+            rimeCalls.any { it == "6" }
+        )
+    }
+
+    @Test
+    fun `after full commit controller reset clears state without clearing RIME`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 输入 54482 → 左选li → 左选gua
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+
+        rimeCalls.clear()
+
+        // 右选"离卦" — full commit
+        val result = ctrl.onRightCandidateSelected("li gua", 2)
+        assertTrue("应完整消费", result)
+        assertEquals("", ctrl.bufferString)
+
+        // onRightCandidateSelected 期间不应调用 replaceFullPinyin
+        assertTrue("full commit 期间不应调用 replaceFullPinyin，实际调用: $rimeCalls", rimeCalls.isEmpty())
+
+        // 服务层 commit 后调用 controller.reset()
         ctrl.reset()
 
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-        assertFalse(ctrl.leftColumnLocked)
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.onDeleted())
-    }
-
-    // ── 完整流程（5143 左侧选词） ──
-
-    @Test
-    fun `full flow 5143 select k then select he results in khe`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
-        assertEquals("j'43", ctrl.inputBuffer)
-        assertTrue(ctrl.leftColumnLocked)
-
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
-        assertEquals("k'43", ctrl.inputBuffer)
-        assertFalse(ctrl.leftColumnLocked)
-        assertTrue(ctrl.firstOptions.any { it.pinyin == "he" })
-
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
-        assertEquals("khe", ctrl.inputBuffer)
-        // 完整拼音组合且无剩余数字：左侧候选区进入空闲态
+        // reset 不应向 RIME 发送任何内容（RIME 已被 commit 清除）
+        // 只需验证控制器状态正确
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
         assertTrue(ctrl.firstOptions.isEmpty())
     }
 
-    // ── lastDigitSegment ──
+    // ═══════════════════════════════════════════════════════════
+    // Bug：右侧候选词选词后 backspace 撤销应正确恢复左侧候选区
+    // ═══════════════════════════════════════════════════════════
 
     @Test
-    fun `lastDigitSegment on pure digits returns all`() {
+    fun `backspace after full right commit returns NOT_CONSUMED when buffer is empty`() {
         val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
-        assertEquals("54", ctrl.lastDigitSegment())
-    }
 
-    @Test
-    fun `lastDigitSegment with apostrophe returns after apostrophe`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
-        assertEquals("43", ctrl.lastDigitSegment())
-    }
-
-    @Test
-    fun `lastDigitSegment on merged pinyin returns empty`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
-        assertEquals("", ctrl.lastDigitSegment())
-    }
-
-    // ── Right candidate selection (partial commit from prediction list) ──
-    //
-    // 用户从右侧候选列表选词后，RIME 做 partial commit（提交文本，保留拼音变体）。
-    // T9Controller 同步消费对应数字，刷新左侧候选区。
-    // 回退时 backspace 返回 UNDO_COMMIT => 由 UI 层先发送 delete 删除已提交文本，再 sendToRime 恢复数字。
-
-    @Test
-    fun `rightCandidate on 23744 consumes first 2 digits to 744`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("2"); ctrl.onDigitPressed("3")
-        ctrl.onDigitPressed("7"); ctrl.onDigitPressed("4"); ctrl.onDigitPressed("4")
-        ctrl.onRightCandidateSelected()
-        assertEquals("744", ctrl.inputBuffer)
-        assertTrue("left options should contain shi", ctrl.firstOptions.any { it.pinyin == "shi" })
-        assertFalse(ctrl.leftColumnLocked)
-    }
-
-    @Test
-    fun `rightCandidate on empty buffer does nothing`() {
-        val ctrl = createController()
-        ctrl.onRightCandidateSelected()
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-    }
-
-    @Test
-    fun `rightCandidate on 5 consumes all to empty`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5")
-        ctrl.onRightCandidateSelected()
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-    }
-
-    @Test
-    fun `rightCandidate on 5143 with delimiter consumes confirmed pinyin j leaving 43`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")  // 5→分词→j'
-        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")  // j'43
-        ctrl.onRightCandidateSelected()
-        // RIME 消费 confirmed pinyin "j"，保留剩余数字 "43"
-        assertEquals("43", ctrl.inputBuffer)
-        assertTrue("left options should contain ge/he for 43", ctrl.firstOptions.isNotEmpty())
-        assertFalse(ctrl.leftColumnLocked)
-    }
-
-    @Test
-    fun `first backspace after rightCandidate returns UNDO_COMMIT restores buffer without sendToRime`() {
-        val ctrl = createController()
-        ctrl.onDigitPressed("2"); ctrl.onDigitPressed("3")
-        ctrl.onDigitPressed("7"); ctrl.onDigitPressed("4"); ctrl.onDigitPressed("4")
-        ctrl.onRightCandidateSelected() // buffer="744", lastRimeInput="744"
-        assertEquals("744", ctrl.inputBuffer)
-
-        // BS1: UNDO_COMMIT — 恢复 buffer，但不调用 sendToRime (lastRimeInput 不变)
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("23744", ctrl.inputBuffer)
-        assertTrue("left options should contain ce", ctrl.firstOptions.any { it.pinyin == "ce" })
-
-        // sendToRime() 应当被调用（调用后 lastRimeInput 同步）
-        ctrl.sendToRime()
-    }
-
-    @Test
-    fun `full flow 23744 candidate ce then 6 backspaces clears all`() {
-        val ctrl = createController()
-        // 5 次按键
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        assertTrue(ctrl.firstOptions.any { it.pinyin == "ce" })
-
-        // 1 次右侧候选选词
-        ctrl.onRightCandidateSelected()
-        assertEquals("744", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.any { it.pinyin == "shi" })
-
-        // BS1: UNDO_COMMIT — 恢复 "23744"，未调用 sendToRime
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("23744", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.any { it.pinyin == "ce" })
-
-        // 模拟 UI 层行为：sendToRime 后 RIME 接收 "23744"
-        ctrl.sendToRime()
-
-        // BS2-6: 5 次 DELETED → 逐步清空
-        for (expected in listOf("2374", "237", "23", "2", "")) {
-            assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-            assertEquals(expected, ctrl.inputBuffer)
-        }
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    // ── callback spy 验证 ──
-
-    @Test
-    fun `rightCandidate undo does not invoke onReplaceFullPinyin`() {
-        val calls = mutableListOf<String>()
-        val ctrl = T9InputController(onReplaceFullPinyin = { calls.add(it) })
-
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        val digitCalls = calls.size // 每次 onDigitPressed 调用 sendToRime
-
-        // 初始 log
-        calls.clear()
-        ctrl.onRightCandidateSelected()
-        // onRightCandidateSelected 不调用 sendToRime
-        assertTrue("rightCandidate should not call sendToRime", calls.isEmpty())
-
-        // UNDO_COMMIT 也不调用 sendToRime
-        ctrl.delete()
-        assertTrue("rightCandidate undo should not call sendToRime", calls.isEmpty())
-
-        // 显式调用 sendToRime 后才触发
-        ctrl.sendToRime()
-        assertEquals(1, calls.size)
-        assertEquals("23744", calls[0])
-    }
-
-    // ── clearRimeAndResend ──
-
-    @Test
-    fun `clearRimeAndResend calls onRightCommitUndone then clears composition and resends full input`() {
-        val calls = mutableListOf<String>()
-        var undoCount = 0
-        val ctrl = T9InputController(
-            onReplaceFullPinyin = { calls.add(it) },
-            onRightCommitUndone = { undoCount += it }
-        )
-
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        calls.clear()
-
-        ctrl.clearRimeAndResend()
-        assertEquals(1, undoCount)
-        assertEquals(2, calls.size)
-        assertEquals("", calls[0])
-        assertEquals("23744", calls[1])
-    }
-
-    // ── Bug 1 修复验证：右侧候选连续选词不应重复消费 inputBuffer ──
-    //
-    // 场景：输入 "23744" → 右侧选"策"(partial commit) → 右侧选"使"(full commit)
-    // onRightCandidateSelected 第一次消费 "23" → buffer="744"
-    // onRightCandidateSelected 第二次消费 "744" → buffer=""
-    // 两次选词后 inputBuffer 应为空，不应出现重复消费
-
-    @Test
-    fun `bug1 - consecutive right candidate selections consume buffer correctly`() {
-        val ctrl = createController()
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        // 第一次右侧选词：RIME partial commit 消费 "23"(ce)，剩余 "744"
-        ctrl.onRightCandidateSelected()
-        assertEquals("744", ctrl.inputBuffer)
-
-        // 第二次右侧选词：RIME full commit 消费 "744"(shi)，剩余为空
-        ctrl.onRightCandidateSelected()
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-    }
-
-    // ── Bug 2 修复验证：左侧选词后右侧选词，inputBuffer 应正确同步 ──
-    //
-    // 场景：输入 "23744" → 右侧选"测"(partial commit) → 左侧选"pi" → 右侧选"披"
-    // 步骤1: 输入 "23744"
-    // 步骤2: 右侧选"测" → RIME 消费 "23"(ce)，inputBuffer 应为 "744"
-    // 步骤3: 左侧选 "pi"(digitLength=2) → inputBuffer 应为 "pi'4"
-    // 步骤4: 右侧选"披" → RIME 消费 "pi"，inputBuffer 应为 "4"
-    //        左侧候选区应显示 "4" 对应的拼音选项 [g, h, i]
-
-    @Test
-    fun `bug2 - right candidate after left choice syncs buffer with remaining digits`() {
-        val ctrl = createController()
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-
-        // 右侧选"测"：消费 "23"
-        ctrl.onRightCandidateSelected()
-        assertEquals("744", ctrl.inputBuffer)
-
-        // 左侧选 "pi"（digitLength=2）：确认 "pi"，剩余 "4"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
-        assertEquals("pi'4", ctrl.inputBuffer)
-
-        // 右侧选"披"：RIME 消费 "pi"，剩余 "4"
-        // 修复前：onRightCandidateSelected 错误地从 lastDigitSegment("4") 消费，
-        //         导致 buffer 变为 "pi'" 而非 "4"
-        // 修复后：应正确识别 "pi" 被消费，buffer 变为 "4"
-        ctrl.onRightCandidateSelected()
-        assertEquals("4", ctrl.inputBuffer)
-        assertTrue("left options should contain g/h/i for digit 4",
-            ctrl.firstOptions.map { it.pinyin }.containsAll(listOf("g", "h", "i")))
-    }
-
-    @Test
-    fun `bug2 - right candidate after left choice with no remaining digits clears buffer`() {
-        val ctrl = createController()
-        for (d in listOf("2", "3", "7", "4")) ctrl.onDigitPressed(d)
-
-        // 右侧选词：消费 "23"
-        ctrl.onRightCandidateSelected()
-        assertEquals("74", ctrl.inputBuffer)
-
-        // 左侧选 "qi"（digitLength=2）：确认 "qi"，剩余为空
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("qi", 2))
-        assertEquals("qi", ctrl.inputBuffer)
-
-        // 右侧选词：RIME 消费 "qi"，buffer 清空
-        ctrl.onRightCandidateSelected()
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-    }
-
-    // ── 场景6：右侧候选 + 左侧候选混合链路退格 ──
-    //
-    // 操作流程：
-    // 1. 输入 "23744" → buffer="23744"
-    // 2. 点击"策"(右侧候选) → RIME partial commit，消费 "23"(ce)，buffer="744"
-    // 3. 点击"pi"(左侧) → 消费 "74"，buffer="pi'4"
-    // 4. 点击"h"(左侧) → 消费 "4"，buffer="pih"
-    // 5. 退格：撤销 h → pi'4 → 删 4 → pi' → 撤销 pi → 74 → 删 4 → 7 → 删 7 → "" → 撤销 策 → 23 → 删 3 → 2 → 删 2 → ""
-    // 总计：8 次退格
-
-    @Test
-    fun `scenario 6 - right candidate then left choices backspace in correct order`() {
-        val ctrl = createController()
-        // 步骤1: 输入 "23744"
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        assertEquals("23744", ctrl.inputBuffer)
-
-        // 步骤2: 点击"策"(右侧候选) → 消费 "23"，剩余 "744"
-        ctrl.onRightCandidateSelected("ce")
-        assertEquals("744", ctrl.inputBuffer)
-
-        // 步骤3: 点击"pi"(左侧) → 消费 "74"，剩余 "4"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
-        assertEquals("pi'4", ctrl.inputBuffer)
-
-        // 步骤4: 点击"h"(左侧) → 消费 "4"，无剩余
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
-        assertEquals("pih", ctrl.inputBuffer)
-
-        // 步骤5: 退格流程（8次）
-        // BS1: 撤销 h (UNDO_CHOICE) → "pi'4"
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("pi'4", ctrl.inputBuffer)
-
-        // BS2: 删除数字 "4" (DELETED) → "pi'"，左侧应显示 pi 对应数字段 74 的候选
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("pi'", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.map { it.pinyin }.containsAll(listOf("pi", "qi", "p", "q", "r", "s")))
-
-        // BS3: 撤销 pi (UNDO_CHOICE) → "74"
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("74", ctrl.inputBuffer)
-
-        // BS4: 删除数字 "4" (DELETED) → "7"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("7", ctrl.inputBuffer)
-
-        // BS5: 删除数字 "7" (DELETED) → ""
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-
-        // BS6: 撤销 策 (UNDO_COMMIT) → "23"（只恢复消费的数字，不是全量 prevBuffer）
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("23", ctrl.inputBuffer)
-
-        // BS7: 删除数字 "3" (DELETED) → "2"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("2", ctrl.inputBuffer)
-
-        // BS8: 删除数字 "2" (DELETED) → ""
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    @Test
-    fun `scenario 6 - undo RightCommit only restores consumed digits not full prevBuffer`() {
-        val ctrl = createController()
-        // 输入 "23744"
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-
-        // 右侧选"策"：消费 "23"，剩余 "744"
-        ctrl.onRightCandidateSelected("ce")
-        assertEquals("744", ctrl.inputBuffer)
-
-        // 继续输入数字 "4"（模拟用户继续输入）
-        ctrl.onDigitPressed("4")
-        assertEquals("7444", ctrl.inputBuffer)
-
-        // 退格：删除 "4" → "744"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("744", ctrl.inputBuffer)
-
-        // 继续删除 "4" → "74"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("74", ctrl.inputBuffer)
-
-        // 继续删除 "4" → "7"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("7", ctrl.inputBuffer)
-
-        // 继续删除 "7" → ""
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-
-        // 撤销 策：只恢复 "23"，不是 "23744"
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("23", ctrl.inputBuffer)
-    }
-
-    @Test
-    fun `scenario 6 - BS5 sends CLEAR_COMPOSITION_ONLY not empty string when RightCommit pending`() {
-        val rimeCalls = mutableListOf<String>()
-        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
-
-        // 输入 "23744" → 右侧选"策" → 选"pi" → 选"h"
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        ctrl.onRightCandidateSelected("ce")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
-        rimeCalls.clear()
-
-        // BS1-4: undo h, delete 4, undo pi, delete 4
-        ctrl.delete() // undo h
-        ctrl.delete() // delete 4
-        ctrl.delete() // undo pi
-        ctrl.delete() // delete 4 → buffer = "7"
-        rimeCalls.clear()
-
-        // BS5: 删除数字 "7" → buffer 为空，但有 RightCommit 未撤销
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-
-        // sendToRime 应发送 CLEAR_COMPOSITION_ONLY 而非空串
-        // 这样服务层不会清空 t9PartialCommitTexts，预编辑文本仍显示"策"
+        // 输入 54482 → 左选li → 左选gua
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+
+        // 右选"离卦" — full commit
+        val result = ctrl.onRightCandidateSelected("li gua", 2)
+        assertTrue("应完整消费", result)
+        assertEquals("", ctrl.bufferString)
+
+        // full commit 后控制器状态：buffer 空，但 undo 栈中可能有 RightCommit
+        // backspace 应尝试撤销 RightCommit 或返回 NOT_CONSUMED
+        val deleteResult = ctrl.onDeleted()
+        // full commit 后 buffer 为空，unassigned 为空，
+        // 但 RightCommit 可能在栈顶 → UNDO_COMMIT
         assertTrue(
-            "Expected CLEAR_COMPOSITION_ONLY in $rimeCalls",
-            rimeCalls.contains(T9InputController.CLEAR_COMPOSITION_ONLY)
+            "full commit 后 backspace 应返回 UNDO_COMMIT 或 NOT_CONSUMED，实际: $deleteResult",
+            deleteResult == T9InputController.DeleteResult.UNDO_COMMIT ||
+                deleteResult == T9InputController.DeleteResult.NOT_CONSUMED
         )
-        assertFalse(
-            "Should NOT send empty string when RightCommit is pending",
-            rimeCalls.contains("")
-        )
-    }
-
-    @Test
-    fun `scenario 6 - after undo RightCommit sendToRime clears all when no pending commit`() {
-        val rimeCalls = mutableListOf<String>()
-        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
-
-        // 输入 "23744" → 右侧选"策" → 选"pi" → 选"h"
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        ctrl.onRightCandidateSelected("ce")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
-
-        // 完整8次退格到空buffer
-        repeat(5) { ctrl.delete() } // BS1-5: undo h, delete 4, undo pi, delete 4, delete 7
-        assertEquals("", ctrl.inputBuffer)
-
-        // BS6: 撤销 RightCommit → buffer = "23"
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("23", ctrl.inputBuffer)
-
-        // BS7-8: 删除 3, 2
-        ctrl.delete() // delete 3
-        ctrl.delete() // delete 2
-        assertEquals("", ctrl.inputBuffer)
-
-        // 此时 undoHistory 为空，clearRimeAndResend 发送空串仅清除 composition
-        rimeCalls.clear()
-        ctrl.clearRimeAndResend()
-        assertTrue(
-            "clearRimeAndResend should send empty string to clear composition",
-            rimeCalls.contains("")
-        )
-    }
-
-    // ── 场景 4.1：简拼+全拼混合输入后右侧选"客户"应完整消费输入 ──
-
-    @Test
-    fun `scenario 4_1 - right candidate kehu consumes the whole k'ge buffer`() {
-        val ctrl = createController()
-
-        // 模拟场景4步骤1-3后控制器状态：左侧已选 k 和 ge，buffer 为 k'ge
-        ctrl.inputBuffer = "k'ge"
-        ctrl.updateCandidates(force = true)
-        assertEquals("k'ge", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-
-        // 右侧候选"客户"的拼音注释为 kehu，应完整消费 k'ge
-        ctrl.onRightCandidateSelected("kehu")
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-    }
-
-    // ── 场景 6.1：半提交后按"换行"键提交预编辑文本，再次输入不应残留 partial commit ──
-
-    @Test
-    fun `scenario 6_1 - enter after partial commit clears controller state and sends CLEAR_ALL`() {
-        val rimeCalls = mutableListOf<String>()
-        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
-
-        // 1. 输入 23744 → 右侧选"策"，模拟 partial commit 后 controller 状态
-        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
-        ctrl.onRightCandidateSelected("ce")
-        assertEquals("744", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isNotEmpty())
-
-        // 2. 用户按"换行"键，controller 应收到 enter 通知并彻底清空
-        ctrl.onEnterCommit()
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-        assertTrue(
-            "Enter commit should notify service to clear all T9 state",
-            rimeCalls.contains(T9InputController.CLEAR_ALL)
-        )
-    }
-
-    // ── 场景 8：多个 RightCommit 连续撤销时 partial commit 顺序 ──
-
-    @Test
-    fun `scenario 8 - undoing later RightCommit preserves earlier partial commit`() {
-        var undoCount = 0
-        val ctrl = T9InputController(
-            onReplaceFullPinyin = { /* no-op */ },
-            onRightCommitUndone = { undoCount += it }
-        )
-
-        // 输入 546946423744（分词后等价于 jin xing ce shi）
-        for (d in listOf("5", "4", "6", "9", "4", "6", "4", "2", "3", "7", "4", "4")) {
-            ctrl.onDigitPressed(d)
-        }
-
-        // 右侧选"进行"：消费 "5469464"，剩余 "23744"
-        ctrl.onRightCandidateSelected("jin xing")
-        assertEquals("23744", ctrl.inputBuffer)
-
-        // 右侧选"策"：消费 "23"，剩余 "744"
-        ctrl.onRightCandidateSelected("ce")
-        assertEquals("744", ctrl.inputBuffer)
-
-        // 左侧选"pi" → "pi'4"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
-        assertEquals("pi'4", ctrl.inputBuffer)
-
-        // 左侧选"h" → "pih"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
-        assertEquals("pih", ctrl.inputBuffer)
-
-        // 回退顺序：h, 4, pi, 4, 7, 策, 3, 2, 进行, ...
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete()) // h → pi'4
-        assertEquals("pi'4", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete()) // 4 → pi'
-        assertEquals("pi'", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete()) // pi → 74
-        assertEquals("74", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete()) // 4 → 7
-        assertEquals("7", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete()) // 7 → ""
-        assertEquals("", ctrl.inputBuffer)
-
-        // 撤销"策"：当前数字段已空，只恢复 consumedDigits="23"，触发一次 onRightCommitUndone
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("23", ctrl.inputBuffer)
-        ctrl.clearRimeAndResend()
-        assertEquals(1, undoCount)
-
-        // 继续删除 3, 2
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete()) // 3 → 2
-        assertEquals("2", ctrl.inputBuffer)
-
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete()) // 2 → ""
-        assertEquals("", ctrl.inputBuffer)
-
-        // 撤销"进行"：当前数字段已空，只恢复 consumedDigits="5469464"，再次触发 onRightCommitUndone
-        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.delete())
-        assertEquals("5469464", ctrl.inputBuffer)
-        ctrl.clearRimeAndResend()
-        assertEquals(2, undoCount)
-    }
-
-    // ── 场景9：简拼左选后继续输入数字，再左选，退格顺序 ──
-    //
-    // 操作流程（来自 .trae/回退测试.md 场景9）：
-    // 1. 输入 5 → inputBuffer="5"，左侧候选区【j,k,l】
-    // 2. 左选 l → inputBuffer="l"，左侧候选区空闲态
-    // 3. 输入 4 → inputBuffer="l'4"（修复后自动加分隔符，让 RIME 解析为 "l"+"4" 多音节）
-    //            左侧候选区【g,h,i】
-    // 4. 左选 h → inputBuffer="lh"，左侧候选区空闲态
-    // 5. 退格4次：撤销h → "l'4" → 删4 → "l'" → 撤销l → "5" → 删5 → ""
-    //
-    // 修复前 bug：
-    //   - 步骤3：inputBuffer="l4"（无分隔符），RIME 解析为单音节 "li"，
-    //     lua filter 无法替换数字段，preedit 显示 "l4" 而非 "l g"
-    //   - BS1：snapshot.buffer=consumedDigits="4"，撤销后 inputBuffer="4"，
-    //     丢失前缀已确认拼音 "l"
-
-    @Test
-    fun `scenario 9 - left choice then digit then left choice backspace order`() {
-        val ctrl = createController()
-
-        // 步骤1: 输入 5
-        ctrl.onDigitPressed("5")
-        assertEquals("5", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-
-        // 步骤2: 左选 l
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("l", 1))
-        assertEquals("l", ctrl.inputBuffer)
-        assertTrue("left panel should be idle after full pinyin choice",
-            ctrl.firstOptions.isEmpty())
-
-        // 步骤3: 输入 4（修复后自动加分隔符 "l'4"，让 RIME 解析多音节）
-        ctrl.onDigitPressed("4")
-        assertEquals("l'4", ctrl.inputBuffer)
-        assertPinyins(ctrl, "g", "h", "i")
-
-        // 步骤4: 左选 h
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
-        assertEquals("lh", ctrl.inputBuffer)
-        assertTrue("left panel should be idle after full pinyin choice",
-            ctrl.firstOptions.isEmpty())
-
-        // 步骤5: 退格（4次）
-        // BS1: 撤销 h → "l'4"（修复后：snapshot 保留完整前缀 "l"）
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("l'4", ctrl.inputBuffer)
-        assertPinyins(ctrl, "g", "h", "i")
-
-        // BS2: 删除 4 → "l'"
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("l'", ctrl.inputBuffer)
-        // 以分隔符结尾：显示 l 对应数字段 5 的候选
-        assertPinyins(ctrl, "j", "k", "l")
-
-        // BS3: 撤销 l → "5"
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("5", ctrl.inputBuffer)
-        assertPinyins(ctrl, "j", "k", "l")
-
-        // BS4: 删除 5 → ""
-        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
-        assertEquals("", ctrl.inputBuffer)
-        assertTrue(ctrl.firstOptions.isEmpty())
-
-        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.delete())
-    }
-
-    @Test
-    fun `bug3 - digit pressed after letter inserts apostrophe for multi-syllable parsing`() {
-        val ctrl = createController()
-        // 输入 5，选 l → "l"
-        ctrl.onDigitPressed("5")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("l", 1))
-        assertEquals("l", ctrl.inputBuffer)
-
-        // 输入 4 → 应自动加分隔符 "l'4"，让 RIME 把 "l" 和 "4" 解析为两个音节
-        // 修复前：inputBuffer="l4"，RIME 解析为单音节 "li"，lua filter 无法替换数字段
-        ctrl.onDigitPressed("4")
-        assertEquals("l'4", ctrl.inputBuffer)
-        assertPinyins(ctrl, "g", "h", "i")
-    }
-
-    @Test
-    fun `bug3 - left choice after letter-digit preserves prefix in snapshot`() {
-        val ctrl = createController()
-        // 输入 5，选 l → "l"
-        ctrl.onDigitPressed("5")
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("l", 1))
-        // 输入 4 → "l'4"
-        ctrl.onDigitPressed("4")
-        assertEquals("l'4", ctrl.inputBuffer)
-        // 选 h → "lh"
-        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
-        assertEquals("lh", ctrl.inputBuffer)
-
-        // 撤销 h → 应恢复 "l'4"，不丢失 "l"
-        // 修复前：snapshot.buffer=consumedDigits="4"，撤销后 inputBuffer="4"（丢失 "l"）
-        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
-        assertEquals("l'4", ctrl.inputBuffer)
-    }
-
-    @Test
-    fun `bug3 - digit pressed after pure digits does not insert apostrophe`() {
-        val ctrl = createController()
-        // 纯数字 inputBuffer 不应加分隔符
-        ctrl.onDigitPressed("5")
-        ctrl.onDigitPressed("4")
-        assertEquals("54", ctrl.inputBuffer)
-
-        // 分隔符后输入数字也不应再加分隔符
-        // 分词键贪婪匹配最长拼音 "ji"（digitLength=2），消费 "54" → "ji'"
-        ctrl.onDigitPressed("1") // 分词键 → "ji'"
-        ctrl.onDigitPressed("4")
-        assertEquals("ji'4", ctrl.inputBuffer)
     }
 }

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
@@ -38,6 +38,57 @@ class T9RightCommitHandlerTest {
         assertEquals(0, computeConsumedDigitsFromPinyin("", null))
     }
 
+    @Test
+    fun `computeConsumedDigitsFromPinyin handles partial syllable when letter count exceeds segment length`() {
+        // "zhe li" has 5 letters but segment "9435" only has 4 digits.
+        // "zhe"(943) fully matches, "li"(54) partially matches remaining "5"(initial l only).
+        assertEquals(4, computeConsumedDigitsFromPinyin("9435", "zhe li"))
+    }
+
+    @Test
+    fun `computeConsumedDigitsFromPinyin partial syllable with remaining digits after match`() {
+        // "zhe li"(94354) partially matches "94356": zhe=943, li=54 prefix "5" matches → 4 consumed
+        assertEquals(4, computeConsumedDigitsFromPinyin("94356", "zhe li"))
+    }
+
+    @Test
+    fun `computeConsumedDigitsFromPinyin full syllable match still works`() {
+        // Normal case: "ji hua" letters=5, segment "54482" has 5 digits, all fully match
+        assertEquals(5, computeConsumedDigitsFromPinyin("54482", "ji hua"))
+    }
+
+    // ── 简拼声母匹配集成测试：digitSegment 模式右选候选词应 full commit ──
+
+    @Test
+    fun `digitSegment mode - right candidate with partial syllable should full commit when all digits consumed`() {
+        val ctrl = createController()
+        // Input 9435 without any left selection
+        for (d in listOf("9", "4", "3", "5")) ctrl.onDigitPressed(d)
+        assertEquals("9435", ctrl.bufferString)
+        // Right-select "这里" (comment "zhe li")
+        // "zhe" consumes 943, "li" partially matches digit 5 (initial "l" only)
+        // All 4 digits consumed → full commit
+        val result = ctrl.onRightCandidateSelected("zhe li", 2)
+        assertTrue("Should be full commit — all 4 digits consumed by zhe li", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `digitSegment mode - right candidate with partial syllable partial commit when digits remain`() {
+        val ctrl = createController()
+        // Input 94356 without any left selection
+        for (d in listOf("9", "4", "3", "5", "6")) ctrl.onDigitPressed(d)
+        assertEquals("94356", ctrl.bufferString)
+        // Right-select "这里" (comment "zhe li")
+        // "zhe" consumes 943, "li" partially matches digit 5 (initial "l" only)
+        // 4 digits consumed, remaining "6" → partial commit
+        val result = ctrl.onRightCandidateSelected("zhe li", 2)
+        assertFalse("Should be partial commit — digit 6 remains after zhe li", result)
+        assertEquals("6", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
     // ── bug4 集成测试：SELECTION 态下纯字母 buffer 右选 ──
 
     @Test
@@ -1108,6 +1159,83 @@ class T9RightCommitHandlerTest {
         assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 5
         assertEquals("", ctrl.bufferString)
         assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 全拼左选后右选候选词：apostrophe 路径全拼匹配消费选中项
+    //
+    // 操作流程：
+    //   1. 输入 986742698726 → 左选 yun(3) → 左选 shan(4)
+    //      buffer="yunshan'98726", SELECTION(shan, "7426")
+    //   2. 右选"云山"(comment="yun shan", textLength=2)
+    //      预期：partial commit — yun+shan 全部消费，保留未分配数字 98726
+    //      修复前：只消费 yun(986)，shan 保留 → buffer="shan'98726"
+    //      修复后：yun+shan 全部消费 → buffer="98726", INPUT 态
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `full pinyin left select then right select - apostrophe mode consumes selected option`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 986742698726
+        for (d in listOf("9", "8", "6", "7", "4", "2", "6", "9", "8", "7", "2", "6"))
+            ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 yun(3)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("yun", 3))
+        assertEquals("yun'742698726", ctrl.bufferString)
+
+        // 步骤3: 左选 shan(4)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("shan", 4))
+        assertEquals("yunshan'98726", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("shan", 4), ctrl.selectedOption)
+        assertEquals("7426", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 右选"云山"(comment="yun shan", textLength=2)
+        // 修复前：只消费 yun → buffer="shan'98726"，SELECTION 态
+        // 修复后：yun+shan 全部消费 → buffer="98726"，INPUT 态
+        val result = ctrl.onRightCandidateSelected("yun shan", 2)
+        assertFalse("Should be partial commit — unassigned digits 98726 remain", result)
+        assertEquals("98726", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull("Selected option should be null after consuming all selections", ctrl.selectedOption)
+        assertTrue("Selection history should be cleared", ctrl.selectionHistory.isEmpty())
+    }
+
+    @Test
+    fun `full pinyin left select then right select - with single selection also works`() {
+        // 变体：仅左选一个全拼，右选候选词覆盖该选中项
+        val ctrl = createController()
+        for (d in listOf("9", "8", "6", "7", "4", "2", "6"))
+            ctrl.onDigitPressed(d)
+
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("yun", 3))
+        assertEquals("yun'7426", ctrl.bufferString)
+
+        // 右选"云"(comment="yun", textLength=1) — digitSegment 模式，无 apostrophe
+        // 这是 digitSegment 模式，不走 apostrophe 路径，已有逻辑处理
+        val result = ctrl.onRightCandidateSelected("yun", 1)
+        assertFalse("Should be partial commit — unassigned digits 7426 remain", result)
+        assertEquals("7426", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `full pinyin left select then right select - shengmu match still works after refactor`() {
+        // 回归验证：声母匹配（digitLength==1）仍然工作
+        val ctrl = createController()
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+
+        val result = ctrl.onRightCandidateSelected("ke guan", 2)
+        assertFalse("ke guan should be partial commit (shengmu match)", result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
     }
 
     // ── 辅助方法 ──

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
@@ -1,0 +1,1122 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * 右侧候选选词消费计算 单元测试 + 集成测试（bug4 场景）。
+ *
+ * 覆盖：
+ * - computeConsumedDigitsFromPinyin / computeRightCommitConsumption 纯函数
+ * - onRightCandidateSelected 在 SELECTION 态下的 full/partial commit 判定
+ */
+class T9RightCommitHandlerTest {
+
+    // ── 消费计算 纯函数测试 ──
+
+    @Test
+    fun `computeConsumedDigitsFromPinyin returns letter count when candidatePinyin has letters`() {
+        assertEquals(2, computeConsumedDigitsFromPinyin("54482", "ji"))
+        assertEquals(5, computeConsumedDigitsFromPinyin("54482", "ji hua"))
+        assertEquals(1, computeConsumedDigitsFromPinyin("54482", "j"))
+    }
+
+    @Test
+    fun `computeConsumedDigitsFromPinyin falls back to first syllable when candidatePinyin is empty`() {
+        val result = computeConsumedDigitsFromPinyin("54482", "")
+        assertTrue("Should return first syllable digitLength", result == 1 || result == 2)
+    }
+
+    @Test
+    fun `computeConsumedDigitsFromPinyin falls back to first syllable when candidatePinyin is null`() {
+        val result = computeConsumedDigitsFromPinyin("54482", null)
+        assertTrue("Should return first syllable digitLength", result == 1 || result == 2)
+    }
+
+    @Test
+    fun `computeConsumedDigitsFromPinyin returns 0 for empty segment`() {
+        assertEquals(0, computeConsumedDigitsFromPinyin("", null))
+    }
+
+    // ── bug4 集成测试：SELECTION 态下纯字母 buffer 右选 ──
+
+    @Test
+    fun `bug4 - pure letter buffer in selection state should not full commit when comment covers whole buffer`() {
+        val ctrl = createController()
+        // 步骤1-4: 输入 23744 → 右选"策" → 左选"pi" → 左选"h"
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected("ce")
+        assertEquals("744", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
+        assertEquals("pi'4", ctrl.bufferString)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
+        assertEquals("pih", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("h", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 右选"皮"（RIME comment="pi h"，字母数=3=buffer长度）
+        // 修复前：effectiveLetterCount(3) >= inputBuffer.length(3) → full commit → 策皮上屏
+        // 修复后：candidateTextLength=1（"皮"1字）< commentSyllableCount=2 → partial commit
+        val result = ctrl.onRightCandidateSelected("pi h", 1)
+        assertFalse("Should be partial commit — selected 'h' must be preserved", result)
+        assertEquals("h", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("h", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+        assertPinyins(ctrl, "g", "h", "i")
+    }
+
+    @Test
+    fun `bug4 - pure letter buffer with no-space comment also partial commit`() {
+        // RIME comment 可能是 "pih"（无空格），字母数同样=3
+        val ctrl = createController()
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected("ce")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
+        assertEquals("pih", ctrl.bufferString)
+
+        val result = ctrl.onRightCandidateSelected("pih", 1)
+        assertFalse("Should be partial commit", result)
+        assertEquals("h", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `bug4 - pure letter buffer with short comment still partial commit`() {
+        // RIME comment 是精确的 "pi"（雾凇九键风格），字母数=2<3，走已有分支
+        val ctrl = createController()
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected("ce")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
+        assertEquals("pih", ctrl.bufferString)
+
+        val result = ctrl.onRightCandidateSelected("pi")
+        assertFalse("Should be partial commit", result)
+        assertEquals("h", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `bug4 - multi-syllable pure letter buffer in selection state partial commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("ligub", ctrl.bufferString)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+
+        val result = ctrl.onRightCandidateSelected("li gu b", 2)
+        assertFalse("Should be partial commit — selected 'b' must be preserved", result)
+        assertEquals("b", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+    }
+
+    @Test
+    fun `bug4 - full commit still works when candidate covers entire buffer without selection`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        val result = ctrl.onRightCandidateSelected("ji hua")
+        assertTrue("Full commit when candidate covers entire input", result)
+        assertEquals("", ctrl.bufferString)
+    }
+
+    @Test
+    fun `bug4 - partial commit without selection when candidate covers part of buffer`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        val result = ctrl.onRightCandidateSelected("ji")
+        assertFalse("Partial commit when candidate covers part of input", result)
+        assertEquals("482", ctrl.bufferString)
+    }
+
+    @Test
+    fun `bug4 - null candidatePinyin in selection state should partial commit by consuming first syllable of non-selected part`() {
+        // 用户报告的场景6：输入 23744 → 右选"策" → 左选 pi → 左选 h → 右选"皮"
+        // 但在 Xime 的 T9 方案中"皮"的 comment 可能为空（无拼音注释），
+        // candidatePinyin=null 时应防御性地仅消费非选中部分的首音节。
+        val ctrl = createController()
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        ctrl.onRightCandidateSelected("ce")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
+        assertEquals("pih", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("h", 1), ctrl.selectedOption)
+
+        // candidatePinyin=null 模拟 RIME 未产生 comment
+        val result = ctrl.onRightCandidateSelected(null)
+        assertFalse("Should be partial commit when candidatePinyin=null in SELECTION", result)
+        assertEquals("h", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("h", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+        assertPinyins(ctrl, "g", "h", "i")
+    }
+
+    // ── 场景14：简拼混合输入，SELECTION 态下右选候选词不应全量提交 ──
+    //
+    // 操作流程（来自 .trae/docs/异常输入流程.md 场景14）：
+    // 1. 输入 5143 → buffer="j'43", leftColumnLocked
+    // 2. 左选 k → buffer="k'43", unlocked
+    // 3. 左选 g → buffer="kg'3", SELECTION(g, "4")
+    // 4. 左选 d → buffer="kgd", SELECTION(d, "3")
+    // 5. 右选"控股 kong gu"(candidatePinyin="kong gu", textLength=2) →
+    //    预期：partial commit, buffer="3", SELECTION(d, "3") 保留, 左侧候选区显示 [d,e,f]
+    //    修复前：isFullCommit=true → buffer="", IDLE态, 丢失d筛选机会
+
+    @Test
+    fun `scenario 14 - right candidate in selection state preserves non-selected part digits`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143 → buffer="j'43"
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k → buffer="k'43"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 g → buffer="kg'3", SELECTION(g, "4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+
+        // 步骤4: 左选 d → buffer="kgd", SELECTION(d, "3")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("kgd", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("d", 1), ctrl.selectedOption)
+        assertEquals("3", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 右选"控股 kong gu"(comment="kong gu", textLength=2)
+        // 修复前：candidateTextLength(2) >= commentSyllables.size(2) → isFullCommit=true → buffer=""
+        // 修复后：SELECTION 态下非选中部分非空 → isFullCommit=false → partial commit
+        val result = ctrl.onRightCandidateSelected("kong gu", 2)
+        assertFalse("Should be partial commit — selected 'd'(digit 3) must be preserved", result)
+        assertEquals("d", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("d", 1), ctrl.selectedOption)
+        assertEquals("3", ctrl.selectionCandidateDigits)
+        // 左侧候选区应显示 digit 3 对应的拼音 [e, d, f]（"e" 是精确拼音匹配，"d"/"f" 是字母回退）
+        assertPinyins(ctrl, "e", "d", "f")
+        // 问题二修复：右选后左侧候选区中已选项 d 的选中态 UI 标记必须保留
+        assertTrue(
+            "scenario 14: selected 'd' should remain highlighted after right candidate commit",
+            ctrl.isSelectedOptionInCurrentCandidates()
+        )
+    }
+
+    @Test
+    fun `scenario 14 - right candidate pinyin shorter than non-selected part still partial commit`() {
+        // 变体：候选词拼音仅覆盖部分非选中部分
+        val ctrl = createController()
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("kgd", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 右选"看"(comment="k", textLength=1) → 消费 "k"(5)
+        // 与 scenario 16 设计一致：partial commit 后保留未消费部分为字母形式
+        val result = ctrl.onRightCandidateSelected("k", 1)
+        assertFalse("Should be partial commit", result)
+        // "k"被消费移除，剩余 "g"(非选中) + "d"(选中项) = "gd"
+        assertEquals("gd", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("d", 1), ctrl.selectedOption)
+        assertEquals("3", ctrl.selectionCandidateDigits)
+    }
+
+    @Test
+    fun `scenario 14 - right candidate full commit when buffer equals selected option only`() {
+        // 验证：当 buffer 完全由选中部分构成时，isFullCommit 仍应正常工作
+        val ctrl = createController()
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("li", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        ctrl.onRightCandidateSelected("li")
+        ctrl.onRightCandidateSelected("gu")
+        // 与 scenario 16 step 8 设计一致：partial commit 后保留选中项字母形式
+        assertEquals("b", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+
+        // 右选"并"(comment="bing", textLength=1) → buffer="b"=选中部分 → full commit
+        val result = ctrl.onRightCandidateSelected("bing", 1)
+        assertTrue("Should be full commit when buffer equals selected option only", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ── 场景15：全拼输入，混合左侧候选区选择简拼与右侧候选词混合筛选定词 ──
+    //
+    // 操作流程（来自 .trae/docs/异常输入流程.md 场景15）：
+    // 1. 输入 54482 → buffer="j'4482", INPUT
+    // 2. 左选 j → buffer="j'4482", SELECTION(j, "5")
+    // 3. 左选 g → buffer="jg'482", SELECTION(g, "4")
+    // 4. 左选 hu → buffer="jghu'2", SELECTION(hu, "48")
+    // 5. 右选"价格 jia ge"(candidatePinyin="jia ge", textLength=2) →
+    //    预期：partial commit, buffer="hu'2", SELECTION(hu, "48") 保留
+    //    修复前：apostrophe 分支消费了整个 confirmedPinyin("jghu")+"2" → buffer="", IDLE态
+    //    修复后：SELECTION 态下仅消费非选中部分"jg"→ 保留"hu'2"
+
+    @Test
+    fun `scenario 15 - right candidate in selection state with apostrophe buffer preserves selected option`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
+
+        // 步骤2: 左选 j → buffer="j'4482", SELECTION(j, "5")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+
+        // 步骤3: 左选 g → buffer="jg'482", SELECTION(g, "4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+
+        // 步骤4: 左选 hu → buffer="jghu'2", SELECTION(hu, "48")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        assertEquals("jghu'2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hu", 2), ctrl.selectedOption)
+        assertEquals("48", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 右选"价格 jia ge"(candidatePinyin="jia ge", textLength=2)
+        // 修复前：apostrophe 分支消费了整个 confirmedPinyin"jghu"(4)+"2"(1) → buffer="", IDLE
+        // 修复后：SELECTION 态下仅消费非选中部分"jg"(2), 保留"hu'2"
+        val result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertFalse("Should be partial commit — selected 'hu'(digits 48) must be preserved", result)
+        assertEquals("hu'2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hu", 2), ctrl.selectedOption)
+        assertEquals("48", ctrl.selectionCandidateDigits)
+        // 左侧候选区应显示 digit 2 对应的拼音 [a, b, c]
+        assertPinyins(ctrl, "a", "b", "c")
+    }
+
+    @Test
+    fun `scenario 15 - after selecting c then right candidate preserves c highlight`() {
+        val ctrl = createController()
+
+        // 输入 54482
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
+
+        // 左选 j → g → hu → c（对应场景15操作步骤6）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))  // j'4482
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))  // jg'482
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2)) // jghu'2
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("c", 1))  // jghuc, SELECTION(c,"2")
+        assertEquals("jghuc", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("c", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+
+        // 右选"价格 jia ge"
+        val result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertFalse("Should be partial commit — selected 'c'(digit 2) must be preserved", result)
+        // 右选后应保留 hu + c：hu 是已确认拼音，c 是选中项
+        // 纯字母 buffer 不带分隔符，由 sendToRime 为 RIME 重建 "hu'c"
+        assertEquals("huc", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("c", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+        // 左侧候选区应显示 digit 2 对应的拼音 [a, b, c]
+        assertPinyins(ctrl, "a", "b", "c")
+        // 问题二修复：右选后左侧候选区中已选项 c 的选中态 UI 标记必须保留
+        assertTrue(
+            "scenario 15: selected 'c' should remain highlighted after right candidate commit",
+            ctrl.isSelectedOptionInCurrentCandidates()
+        )
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4右选修复：验证右选覆盖全部选择+剩余时触发full commit
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 g → buffer="kg'3", SELECTION(g, "4")
+    //   4. 右选"空格的"(comment="kong ge de", textLength=3)
+    //      预期：full commit → buffer清空, IDLE态
+    //      旧行为：SELECTION保护只消费"k"，buffer变"g'3"，需再次点击
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4 rc - right candidate full commit covers selected option and remaining digits`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 g → buffer="kg'3", SELECTION(g, "4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 右选"空格的"(comment="kong ge de", textLength=3)
+        // 候选覆盖了 nonSelected("k") + selected("g") + remaining("3")
+        val result = ctrl.onRightCandidateSelected("kong ge de", 3)
+        assertTrue("Should be full commit — 'kong ge de' covers k+g+3", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ── 场景16：全拼输入，左侧候选区选择变为纯简拼，右侧候选词混合筛选定词 ──
+    //
+    // 操作流程（来自 .trae/docs/异常输入流程.md 场景16）：
+    // 1. 输入 54482 → buffer="j'4482", INPUT
+    // 2. 左选 j → buffer="j'4482", SELECTION(j, "5")
+    // 3. 左选 g → buffer="jg'482", SELECTION(g, "4")
+    // 4. 左选 g → buffer="jgg'82", SELECTION(g, "4")
+    // 5. 左选 t → buffer="jggt'2", SELECTION(t, "8")
+    // 6. 左选 b → buffer="jggtb", SELECTION(b, "2")
+    // 7. 右选"价格 jia ge"(candidatePinyin="jia ge", textLength=2) →
+    //    预期：partial commit, buffer="482"(g=4,t=8,b=2), SELECTION(b,"2")保留
+    //    修复前：consumedCount=4(过估)→"all consumed"→buffer="2"(仅选中部分), 丢失"gt"(48)
+    //    修复后：consumedCount=2(正确)→partial consumption→buffer="48"+"2"="482"
+
+    @Test
+    fun `scenario 16 - pure letter buffer with single-char selections and right candidate preserves remaining letters`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
+
+        // 步骤2-6: 逐步左选 j, g, g, t, b
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))  // j'4482
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))  // jg'482
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))  // jgg'82
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("t", 1))  // jggt'2
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))  // jggtb
+
+        // 验证步骤6后的状态
+        assertEquals("jggtb", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+
+        // 步骤7: 右选"价格 jia ge"(candidatePinyin="jia ge", textLength=2)
+        // 预期：partial commit — "jia ge"消费j+g(2个确认字母), 剩余g+t+b作为独立简拼字母保留
+        val result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertFalse("Should be partial commit — 'jia ge' consumes j+g, leaving g+t+b", result)
+        assertEquals("gtb", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+        // 左侧候选区应显示 digit 2 对应的拼音 [a, b, c]
+        assertPinyins(ctrl, "a", "b", "c")
+        // 问题二修复：右选后左侧候选区中已选项 b 的选中态 UI 标记必须保留
+        assertTrue(
+            "scenario 16: selected 'b' should remain highlighted after right candidate commit",
+            ctrl.isSelectedOptionInCurrentCandidates()
+        )
+    }
+
+    @Test
+    fun `scenario 16 step 8 - second right candidate after gt b preserves b`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("8"); ctrl.onDigitPressed("2")
+
+        // 步骤2-6: 逐步左选 j, g, g, t, b
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("t", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jggtb", ctrl.bufferString)
+
+        // 步骤7: 右选"价格 jia ge"
+        val step7Result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertFalse("Step 7 should be partial commit", step7Result)
+        assertEquals("gtb", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+
+        // 步骤8: 右选"共同 gong tong"(candidatePinyin="gong tong", textLength=2)
+        // 预期：partial commit — "gong tong"消费"gt"(g=4,t=8→"48"), 保留"b"(2)
+        val step8Result = ctrl.onRightCandidateSelected("gong tong", 2)
+        assertFalse("Step 8 should be partial commit — 'gong tong' consumes 'gt', leaving 'b'", step8Result)
+        assertEquals("b", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+        assertPinyins(ctrl, "a", "b", "c")
+        assertTrue(
+            "scenario 16 step 8: selected 'b' should remain highlighted",
+            ctrl.isSelectedOptionInCurrentCandidates()
+        )
+    }
+
+    // ── 场景4.1：简拼和全拼混合输入后，通过候选词列表完成完整上屏 ──
+    //
+    // 操作流程（来自 .trae/docs/回退测试.md 场景4.1）：
+    // 1. 输入序列：5143，预编辑文本：j'ge，左侧候选区：【j，k，l】(简拼5对应的拼音字母映射)
+    // 2. 点击左侧候选区：k，预编辑文本更新为：k' he，左侧候选区更新为：【ge，he，g，h，i】（输入序列：43的有效拼音和字母组合）
+    // 3. 继续点击左侧候选区中："ge"，预编辑文本更新为：k' ge，左侧候选区进入选择态，候选词列表显示为【看个，开个，空格，凯歌，，，，】；
+    // 4. 此时：点击："空格"，预编辑文本："空格ge"，候选词列表更新：【隔，个，哥，，，】
+    //    预期结果：系统判定输入序列5143已被完整消费，"空格"一词直接上屏，预编辑文本、候选词列表/内页、左侧候选区全部清空并进入空闲态
+    //    实际结果（修复前）：预编辑文本"空格ge"，"ge"残留
+    //
+    // 根因：buffer="kge"（T9编码"543"）与候选项"kong ge"（T9编码"566443"）的数字编码不匹配，
+    // 因为"k"是"kong"的声母，声母扩展导致T9编码变化。letter SELECTION分支的全量检查仅用数字编码
+    // 比较，无法处理声母扩展，退化为partial commit。修复后在数字编码比较之外增加音节级匹配检查。
+
+    @Test
+    fun `scenario 4-1 - mixed shorthand and full pinyin input full commit via right candidate`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+
+        // 步骤2: 左选 k → buffer="k'43", SELECTION(k, "5")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 ge → buffer="kge", SELECTION(ge, "43")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ge", 2))
+        assertEquals("kge", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("ge", 2), ctrl.selectedOption)
+        assertEquals("43", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 右选"空格 kong ge"(candidatePinyin="kong ge", textLength=2)
+        // 修复前：数字编码"543"!="566443"→退化为partial commit→buffer="43"
+        // 修复后：音节级匹配("ge"=="ge")→full commit→buffer=""
+        val result = ctrl.onRightCandidateSelected("kong ge", 2)
+        assertTrue("Should be full commit — 'kong ge' covers entire input 5143", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull("No option should be selected after full commit", ctrl.selectedOption)
+        assertNull("No candidate digits after full commit", ctrl.selectionCandidateDigits)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.2：验证候选词声母回退匹配（Tier 2）
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 he → buffer="khe", SELECTION(he, "43")
+    //   4. 右选"可恨"(comment="ke hen", textLength=2)
+    //      预期：声母回退 → partial commit
+    //      "ke"消费nonSelected"k"(digit5), "hen"声母"h"消费选中项"4"(digit from "43")
+    //      buffer="h'3", SELECTION(h, "4")
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario42 - right commit ke hen triggers shengmu fallback to h with remaining 3`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 he → buffer="khe", SELECTION(he, "43")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
+        assertEquals("khe", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("he", 2), ctrl.selectedOption)
+        assertEquals("43", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 右选"可恨"(comment="ke hen", textLength=2)
+        // "hen"不精确匹配"he"，但声母"h"匹配 → 声母回退
+        val result = ctrl.onRightCandidateSelected("ke hen", 2)
+        assertFalse("Should be partial commit — hen only matches initial h of he", result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull("声母回退后选中项应为null（进入INPUT态）", ctrl.selectedOption)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4变体：声母回退后左选→右选完整流程
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 ge → buffer="kge", SELECTION(ge, "43")
+    //   4. 右选"课改"(comment="ke gai", textLength=2) → 声母回退 → buffer="3", INPUT
+    //   5. 左选 f → buffer="f", SELECTION(f, "3")
+    //   6. 右选"非"(comment="fei", textLength=1) → full commit → buffer="", IDLE
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4 variant - shengmu fallback then left select f then right commit fei full commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 ge → buffer="kge", SELECTION(ge, "43")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ge", 2))
+        assertEquals("kge", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤4: 右选"课改"(ke gai) → 声母回退 → buffer="3", INPUT
+        val step4Result = ctrl.onRightCandidateSelected("ke gai", 2)
+        assertFalse("ke gai should be shengmu fallback (partial)", step4Result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 步骤5: 左选 f (digit 3)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("f", 1))
+        assertEquals("f", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("f", 1), ctrl.selectedOption)
+        assertEquals("3", ctrl.selectionCandidateDigits)
+
+        // 步骤6: 右选"非"(fei) → full commit
+        val step6Result = ctrl.onRightCandidateSelected("fei", 1)
+        assertTrue("fei should be full commit on buffer f", step6Result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4全简拼无候选：验证空格/右选直接上屏预编辑文本
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 i（简拼）→ buffer="ki'3", SELECTION(i, "4")
+    //   4. 调用 onRightCandidateSelected(null) → 模拟RIME 0候选时的空格/右选
+    //      预期：全简拼连通 → 直接上屏预编辑文本（等同换行键）, buffer清空, IDLE
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4 all abbrev - right commit with null candidate triggers enter like commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k（简拼）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 i（简拼）→ buffer="ki'3", SELECTION(i, "4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("i", 1))
+        assertEquals("ki'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("i", 1), ctrl.selectedOption)
+
+        // 步骤4: 模拟空格/右选（candidatePinyin=null），应触发 enter-like 提交
+        val result = ctrl.onRightCandidateSelected(null)
+        assertTrue("全简拼无候选时应直接上屏预编辑文本", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.4：简拼+全拼混合输入后右选"客观"→应partial commit保留剩余数字
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 g（简拼）→ buffer="kg'3", SELECTION(g, "4")
+    //   4. 右选"客观"(comment="ke guan", textLength=2)
+    //      预期：partial commit（非full commit），
+    //      "ke"消费nonSelected"k"(digit 5)，"guan"声母"g"匹配选中项"g"(digit 4)
+    //      剩余数字"3"应保留 → buffer="3", INPUT（不保持SELECTION）
+    //
+    // 注意与场景4.2的区别：
+    //   场景4.2第三步左选"he"（全拼），"hen"声母"h"匹配"he"首字母
+    //   场景4.4第三步左选"g"（简拼），"guan"声母"g"匹配"g"首字母
+    //   两者都应触发声母级消费，但场景4.4走apostrophe路径（有unassigned"3"），
+    //   场景4.2走letterBuffer路径（unassigned为空）
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 44 - right commit ke guan on shorthand g should partial commit with remaining 3`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k（简拼）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 g（简拼）→ buffer="kg'3", SELECTION(g, "4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 右选"客观"(comment="ke guan", textLength=2)
+        // "ke"匹配nonSelected"k"，"guan"的声母"g"匹配选中项"g"(digit 4)
+        // 应完全消费两个选择，剩余数字"3"
+        val result = ctrl.onRightCandidateSelected("ke guan", 2)
+        assertFalse("Should be partial commit — remaining '3' unchanged", result)
+        assertEquals("剩余数字3应保留", "3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull("声母匹配消费后选中项应为null（进入INPUT态）", ctrl.selectedOption)
+        assertNull("声母匹配消费后selectionCandidateDigits应为null", ctrl.selectionCandidateDigits)
+        assertTrue("声母匹配消费后选择历史应清空", ctrl.selectionHistory.isEmpty())
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.5：简拼+右选"客观"后左选d/f，再右选/空格应full commit
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario45 - after ke guan partial commit selecting d then duo full commits`() {
+        val ctrl = createController()
+
+        // 步骤1-3: 5143 → k → g
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤4: 右选"客观"(ke guan) → partial commit, buffer="3", INPUT
+        val step4Result = ctrl.onRightCandidateSelected("ke guan", 2)
+        assertFalse("ke guan should be partial commit", step4Result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+
+        // 步骤5: 左选 d
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("d", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("d", 1), ctrl.selectedOption)
+
+        // 步骤6: 右选"多"(duo) → full commit
+        val step6Result = ctrl.onRightCandidateSelected("duo", 1)
+        assertTrue("duo should full commit on selected d", step6Result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+    }
+
+    @Test
+    fun `scenario45 - after ke guan partial commit selecting f then fei full commits`() {
+        val ctrl = createController()
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onRightCandidateSelected("ke guan", 2)
+
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("f", 1))
+        assertEquals("f", ctrl.bufferString)
+
+        val result = ctrl.onRightCandidateSelected("fei", 1)
+        assertTrue("fei should full commit on selected f", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.5 backspace回退：左选k+g，右选"客观"(ke guan)后左选d，8步回退
+    //
+    // 回退顺序：undo d → undo 客观RC → delete 3 → undo g →
+    //           delete 4 → undo k → undo separator → delete 5
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario45 - backspace after ke guan partial commit with d selection restores correctly`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 g → buffer="kg'3"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤4: 右选"客观"(comment="ke guan", textLength=2) → 声母回退
+        val result = ctrl.onRightCandidateSelected("ke guan", 2)
+        assertFalse("ke guan should be partial commit", result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+
+        // 步骤5: 左选 d
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("d", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // ── backspace 回退（8步）──
+
+        // bs1: undo d → buffer="3", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs2: undo "客观" RightCommit → 恢复为 kg'3（remainingDigitCount=3，可安全撤销）
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.onDeleted())
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+
+        // bs3: delete digit 3 → buffer="kg'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("kg'", ctrl.bufferString)
+
+        // bs4: undo g → buffer="k'4", SELECTION
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("k'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+
+        // bs5: delete digit 4 → buffer="k'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("k'", ctrl.bufferString)
+
+        // bs6: undo k → buffer="5", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("5", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs7: undo separator → buffer="5"
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("5", ctrl.bufferString)
+
+        // bs8: delete digit 5 → buffer=""
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+
+        // 无更多操作
+        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.onDeleted())
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4变体：左选k+he，右选"跨行"(kua hang)后左选d，backspace回退
+    //
+    // 回退顺序（8步）：undo d → undo 跨行RC → undo he → delete 3 →
+    //           delete 4 → undo k → undo separator → delete 5
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4variant - backspace after kua hang partial commit with d selection restores correctly`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 he → buffer="khe"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
+        assertEquals("khe", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤4: 右选"跨行"(comment="kua hang", textLength=2) → 声母回退
+        val result = ctrl.onRightCandidateSelected("kua hang", 2)
+        assertFalse("kua hang should be partial commit", result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+
+        // 步骤5: 左选 d
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("d", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // ── backspace 回退（8步）──
+
+        // bs1: undo d → buffer="3", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs2: undo "跨行" RightCommit → 恢复为 khe（remainingDigitCount=1，可安全撤销）
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.onDeleted())
+        assertEquals("khe", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("he", 2), ctrl.selectedOption)
+        assertEquals("43", ctrl.selectionCandidateDigits)
+
+        // bs3: undo he → buffer="k'43"
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("k'43", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+
+        // bs4: delete digit 3 → buffer="k'4"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("k'4", ctrl.bufferString)
+
+        // bs5: delete digit 4 → buffer="k'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("k'", ctrl.bufferString)
+
+        // bs6: undo k → buffer="5", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("5", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs7: undo separator → buffer="5"
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("5", ctrl.bufferString)
+
+        // bs8: delete digit 5 → buffer=""
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+
+        // 无更多操作
+        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.onDeleted())
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景6 backspace回退：输入23744 → 右选"策" → 左选pi → 左选h → 8步回退
+    //
+    // digitSegment模式RC后，回退需先删除所有unassigned数字才能撤销RC。
+    // 修复前bug：(1)9步而非8步 (2)bs4提前触发RC撤销导致跳到ceshi
+    //
+    // 回退顺序：undo h → delete 4 → undo pi → delete 4 → delete 7 →
+    //           undo 策RC → delete 3 → delete 2
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario6 - backspace after ce partial commit with pi and h selection restores correctly`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 23744
+        for (d in listOf("2", "3", "7", "4", "4")) ctrl.onDigitPressed(d)
+        assertEquals("23744", ctrl.bufferString)
+
+        // 步骤2: 右选"策"(comment="ce") → digitSegment模式partial commit
+        val result = ctrl.onRightCandidateSelected("ce")
+        assertFalse("ce should be partial commit", result)
+        assertEquals("744", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 步骤3: 左选 pi(2) → 从unassigned "744"中选择
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
+        assertEquals("pi'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("pi", 2), ctrl.selectedOption)
+
+        // 步骤4: 左选 h(1) → 从unassigned "4"中选择
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
+        assertEquals("pih", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("h", 1), ctrl.selectedOption)
+
+        // ── backspace 回退（8步）──
+
+        // bs1: undo h → buffer="pi'4", SELECTION(pi)
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("pi'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("pi", 2), ctrl.selectedOption)
+
+        // bs2: delete 4 → buffer="pi", SELECTION(pi)
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("pi", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("pi", 2), ctrl.selectedOption)
+
+        // bs3: undo pi → buffer="74", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("74", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs4: delete 4（倒数第二个4）→ buffer="7", INPUT
+        // 修复前：提前触发RC撤销，buffer跳到"ceshi"或"23744"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("7", ctrl.bufferString)
+
+        // bs5: delete 7 → zombie状态：digitSequence="23", consumedCount=2
+        // 僵尸RC处理：进入SELECTION态，高亮已提交拼音ce，左侧候选区显示[ce,a,b,c...]
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("ce", 2), ctrl.selectedOption)
+        assertTrue("bs5 left candidates should contain ce", ctrl.firstOptions.any { it.pinyin == "ce" })
+
+        // bs6: undo 策RC → buffer="23", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.onDeleted())
+        assertEquals("23", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs7: delete 3 → buffer="2"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("2", ctrl.bufferString)
+
+        // bs8: delete 2 → buffer=""
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+
+        // 无更多操作
+        assertEquals(T9InputController.DeleteResult.NOT_CONSUMED, ctrl.onDeleted())
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景8 backspace回退：多RC叠加的僵尸状态
+    //
+    // 输入546946423744 → 右选"进行"(7位) → 右选"策"(2位) → 左选pi → 左选h
+    // 回退时bs5删除最后一个未分配数字后，应进入SELECTION态显示栈顶RC("策")的候选[ce,...]
+    // 而非全部consumed数字的候选[jin,lin,...]
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario8 - zombie state with stacked RCs shows top RC candidates`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 546946423744
+        for (d in listOf("5", "4", "6", "9", "4", "6", "4", "2", "3", "7", "4", "4"))
+            ctrl.onDigitPressed(d)
+        assertEquals("546946423744", ctrl.bufferString)
+
+        // 步骤2: 右选"进行"(comment="jin xing") → digitSegment模式partial commit, 消费7位
+        val result1 = ctrl.onRightCandidateSelected("jin xing", 2)
+        assertFalse("进行 should be partial commit", result1)
+        assertEquals("23744", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 步骤3: 右选"策"(comment="ce") → digitSegment模式partial commit, 消费2位
+        val result2 = ctrl.onRightCandidateSelected("ce", 1)
+        assertFalse("策 should be partial commit", result2)
+        assertEquals("744", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 步骤4: 左选 pi(2) → 从unassigned "744"中选择
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("pi", 2))
+        assertEquals("pi'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤5: 左选 h(1) → 从unassigned "4"中选择
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("h", 1))
+        assertEquals("pih", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("h", 1), ctrl.selectedOption)
+
+        // ── backspace 回退 ──
+
+        // bs1: undo h
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("pi'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // bs2: delete 4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("pi", ctrl.bufferString)
+
+        // bs3: undo pi
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.onDeleted())
+        assertEquals("74", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs4: delete 4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("7", ctrl.bufferString)
+
+        // bs5: delete 7 → 僵尸RC状态（多RC叠加）
+        // 应进入SELECTION态显示栈顶RC("策")消费的"23"的候选[ce,a,b,c]
+        // 而非全部consumed数字段"546946423"的候选[jin,lin,...]
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("ce", 2), ctrl.selectedOption)
+        assertTrue("bs5 should show ce from top RC", ctrl.firstOptions.any { it.pinyin == "ce" })
+        assertFalse("bs5 should NOT show jin from earlier RC", ctrl.firstOptions.any { it.pinyin == "jin" })
+
+        // bs6: undo 策RC → buffer="23", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.onDeleted())
+        assertEquals("23", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs7: delete 3 → buffer="2"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("2", ctrl.bufferString)
+
+        // bs8: delete 2 → 僵尸RC状态（"进行"RC，7位consumed）
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        // 栈顶RC现在是"进行"，其消费的数字段前缀应以"546"开头
+        assertTrue("bs8 should show jin from 进行 RC", ctrl.firstOptions.any { it.pinyin == "jin" })
+
+        // bs9: undo 进行RC → buffer恢复
+        assertEquals(T9InputController.DeleteResult.UNDO_COMMIT, ctrl.onDeleted())
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 继续删除剩余数字
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 6
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 9
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 6
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 4
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.onDeleted()) // 5
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ── 辅助方法 ──
+
+    private fun createController(): T9InputController {
+        return T9InputController(onReplaceFullPinyin = { /* no-op */ })
+    }
+
+    private fun assertPinyins(controller: T9InputController, vararg expected: String) {
+        assertEquals(expected.toList(), controller.firstOptions.map { it.pinyin })
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RimeBridgeTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RimeBridgeTest.kt
@@ -1,0 +1,184 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * T9RimeBridge 单元测试
+ *
+ * 覆盖 RIME 通信桥接的缓存管理、常量定义和回调机制。
+ */
+class T9RimeBridgeTest {
+
+    private fun createBridge(
+        onReplaceFullPinyin: (String) -> Unit = {},
+        onQueryRimeComposition: (() -> RimeComposition)? = null,
+        onRightCommitUndone: ((Int) -> Unit)? = null,
+    ) = T9RimeBridge(onReplaceFullPinyin, onQueryRimeComposition, onRightCommitUndone)
+
+    // ── 常量 ──
+
+    @Test
+    fun `CLEAR_COMPOSITION_ONLY is defined`() {
+        assertNotNull(T9RimeBridge.CLEAR_COMPOSITION_ONLY)
+        assertTrue(T9RimeBridge.CLEAR_COMPOSITION_ONLY.contains("CLEAR_COMPOSITION_ONLY"))
+    }
+
+    @Test
+    fun `CLEAR_ALL is defined`() {
+        assertNotNull(T9RimeBridge.CLEAR_ALL)
+        assertTrue(T9RimeBridge.CLEAR_ALL.contains("CLEAR_ALL"))
+    }
+
+    // ── lastRimeInput 缓存 ──
+
+    @Test
+    fun `initial lastRimeInput is null`() {
+        val bridge = createBridge()
+        assertNull(bridge.getLastRimeInput())
+    }
+
+    @Test
+    fun `setLastRimeInput stores and getLastRimeInput returns`() {
+        val bridge = createBridge()
+        bridge.setLastRimeInput("54482")
+        assertEquals("54482", bridge.getLastRimeInput())
+    }
+
+    @Test
+    fun `setLastRimeInput null clears cache`() {
+        val bridge = createBridge()
+        bridge.setLastRimeInput("54482")
+        bridge.setLastRimeInput(null)
+        assertNull(bridge.getLastRimeInput())
+    }
+
+    // ── forceSendToRime ──
+
+    @Test
+    fun `forceSendToRime clears lastRimeInput`() {
+        val bridge = createBridge()
+        bridge.setLastRimeInput("54482")
+        bridge.forceSendToRime()
+        assertNull(bridge.getLastRimeInput())
+    }
+
+    // ── replaceFullPinyin ──
+
+    @Test
+    fun `replaceFullPinyin invokes callback`() {
+        var received: String? = null
+        val bridge = createBridge(onReplaceFullPinyin = { received = it })
+        bridge.replaceFullPinyin("54482")
+        assertEquals("54482", received)
+    }
+
+    // ── queryRimeComposition ──
+
+    @Test
+    fun `queryRimeComposition returns null when callback is null`() {
+        val bridge = createBridge(onQueryRimeComposition = null)
+        assertNull(bridge.queryRimeComposition())
+    }
+
+    @Test
+    fun `queryRimeComposition invokes callback`() {
+        val composition = RimeComposition(
+            input = "54482",
+            preedit = "li hua",
+            committedText = "",
+            candidates = arrayOf(RimeCandidate("梨花", "li hua")),
+            hasNextPage = false,
+            hasPrevPage = false,
+            isAsciiMode = false,
+        )
+        val bridge = createBridge(onQueryRimeComposition = { composition })
+        assertEquals(composition, bridge.queryRimeComposition())
+    }
+
+    // ── undoRightCommit ──
+
+    @Test
+    fun `undoRightCommit invokes callback with count`() {
+        var receivedCount: Int? = null
+        val bridge = createBridge(onRightCommitUndone = { receivedCount = it })
+        bridge.undoRightCommit(3)
+        assertEquals(3, receivedCount)
+    }
+
+    @Test
+    fun `undoRightCommit default count is 1`() {
+        var receivedCount: Int? = null
+        val bridge = createBridge(onRightCommitUndone = { receivedCount = it })
+        bridge.undoRightCommit()
+        assertEquals(1, receivedCount)
+    }
+
+    @Test
+    fun `undoRightCommit does not throw when callback is null`() {
+        val bridge = createBridge(onRightCommitUndone = null)
+        bridge.undoRightCommit(1) // should not throw
+    }
+
+    // ── clearRimeAndResend ──
+
+    @Test
+    fun `clearRimeAndResend invokes undo and clears input`() {
+        var undoCount: Int? = null
+        var replaceInput: String? = null
+        val bridge = createBridge(
+            onRightCommitUndone = { undoCount = it },
+            onReplaceFullPinyin = { replaceInput = it },
+        )
+        bridge.setLastRimeInput("54482")
+        bridge.clearRimeAndResend()
+        assertEquals(1, undoCount)
+        assertEquals("", replaceInput)
+        assertNull(bridge.getLastRimeInput())
+    }
+
+    // ── inferFirstSyllableFromRime ──
+
+    @Test
+    fun `inferFirstSyllableFromRime returns null when composition is null`() {
+        val bridge = createBridge(onQueryRimeComposition = null)
+        // Falls back to firstSyllableOptions; with empty digits, returns null
+        assertNull(bridge.inferFirstSyllableFromRime(""))
+    }
+
+    @Test
+    fun `inferFirstSyllableFromRime uses RIME comment to infer syllable`() {
+        val composition = RimeComposition(
+            input = "54482",
+            preedit = "li hua",
+            committedText = "",
+            candidates = arrayOf(RimeCandidate("梨花", "li hua")),
+            hasNextPage = false,
+            hasPrevPage = false,
+            isAsciiMode = false,
+        )
+        val bridge = createBridge(onQueryRimeComposition = { composition })
+        val result = bridge.inferFirstSyllableFromRime("54482")
+        assertNotNull(result)
+        assertEquals("li", result!!.pinyin)
+        assertEquals(2, result.digitLength)
+    }
+
+    @Test
+    fun `inferFirstSyllableFromRime falls back when comment does not match digits`() {
+        val composition = RimeComposition(
+            input = "54482",
+            preedit = "li hua",
+            committedText = "",
+            candidates = arrayOf(RimeCandidate("梨花", "jia hua")), // comment starts with "jia"
+            hasNextPage = false,
+            hasPrevPage = false,
+            isAsciiMode = false,
+        )
+        val bridge = createBridge(onQueryRimeComposition = { composition })
+        // "jia" → digit code "542", doesn't start with "54482", so falls back
+        val result = bridge.inferFirstSyllableFromRime("54482")
+        // Falls back to local firstSyllableOptions("54482")
+        assertNotNull(result)
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9SeparatorTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9SeparatorTest.kt
@@ -1,0 +1,426 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * 分词键（1键）行为专项测试。
+ *
+ * 覆盖：
+ * - 分词键后 RIME 输入正确性
+ * - 分词键+左选+退格完整序列
+ */
+class T9SeparatorTest {
+
+    private fun createController(): T9InputController {
+        return T9InputController(onReplaceFullPinyin = { /* no-op */ })
+    }
+
+    private fun T9InputController.delete(): T9InputController.DeleteResult = onDeleted()
+
+    private fun assertPinyins(controller: T9InputController, vararg expected: String) {
+        assertEquals(expected.toList(), controller.firstOptions.map { it.pinyin })
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4：简拼和全拼混合输入，分词键+左选后退格完整序列
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION
+    //   3. 左选 ge → buffer="kge", SELECTION(ge, "43")
+    //   4. 退格6次清空
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4 separator - backspace sequence after separator and choices takes 6 steps`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入5 → 按分词键(1) → 4 → 3
+        ctrl.onDigitPressed("5")
+        assertEquals("5", ctrl.bufferString)
+        ctrl.onDigitPressed("1")
+        assertEquals("j'", ctrl.bufferString)
+        assertTrue(ctrl.leftColumnLocked)
+        ctrl.onDigitPressed("4")
+        assertEquals("j'4", ctrl.bufferString)
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 左选ge
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ge", 2))
+        assertEquals("kge", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("ge", 2), ctrl.selectedOption)
+        assertEquals("43", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 退格6次清空
+        // 预期回退顺序: ge点击, 3, 4, k点击, 1(分词键), 5
+
+        // bs1: 撤销ge → buffer="k'43", SELECTION(k)
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("k'43", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // bs2: 删除3 → buffer="k'4"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("k'4", ctrl.bufferString)
+
+        // bs3: 删除4 → buffer="k'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("k'", ctrl.bufferString)
+
+        // bs4: 撤销k → buffer="5", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs5: 撤销分词键(1) → buffer="5", Separator弹出
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+
+        // bs6: 删除5 → buffer="", IDLE
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 验证：分词键后 sendToRime 发送正确输入
+    // 按5 → 按1(分词键)后，RIME应收到"j'"而非"5"（保留音节边界信息）
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4 separator - sendToRime sends pinyin after separator`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        ctrl.onDigitPressed("5")
+        rimeCalls.clear() // 清除按5时的RIME调用
+
+        ctrl.onDigitPressed("1")
+        // 分词键后 RIME 应收到拼音（而非纯数字）
+        // 注：toPreeditString 在全拼选择后不加 '，RIME syllabifier 会消费尾随分隔符，候选相同
+        val separatorCall = rimeCalls.firstOrNull()
+        assertNotNull("分词键后应有RIME调用", separatorCall)
+        assertTrue("分词键后RIME应收到'j'而非纯数字'5'，实际=$separatorCall",
+            separatorCall != null && separatorCall!!.contains("j"))
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景2：简拼和全拼混合输入并执行退格流程
+    //
+    // 操作流程：
+    //   1. 输入序列：5143 → 预编辑文本："j'43"
+    //   2. 执行backspace清空：按4次
+    // 预期回退顺序：【3, 4, 1(分词键), 5】
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario2 separator - simple backspace after separator takes 4 steps`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5 → 按分词键(1) → 4 → 3
+        ctrl.onDigitPressed("5")
+        assertEquals("5", ctrl.bufferString)
+        ctrl.onDigitPressed("1")
+        assertEquals("j'", ctrl.bufferString)
+        assertTrue(ctrl.leftColumnLocked)
+        ctrl.onDigitPressed("4")
+        assertEquals("j'4", ctrl.bufferString)
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 退格4次清空
+        // 预期回退顺序: 3, 4, 1(分词键), 5
+
+        // bs1: 删除3 → buffer="j'4"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("j'4", ctrl.bufferString)
+
+        // bs2: 删除4 → buffer="j'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("j'", ctrl.bufferString)
+
+        // bs3: 撤销分词键(1) → buffer="5", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs4: 删除5 → buffer="", IDLE
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.3：简拼+全拼混合输入，筛选层切换+同位数替换后退格序列
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 ge → buffer="kge", SELECTION(ge, "43")
+    //   4. 左选 g（筛选层切换）→ buffer="kg'3", SELECTION(g, "4")
+    //   5. 左选 d（同位数替换）→ buffer="kgd", SELECTION(d, "3")
+    //   6. 退格7次清空
+    // 预期回退顺序: d(撤销), 3, g(部分撤销 → k'4), 4, k(撤销), 1(分词键), 5
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario43 separator - backspace after selection layer switch and same digit replacement`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5 → 按分词键(1) → 4 → 3
+        ctrl.onDigitPressed("5")
+        assertEquals("5", ctrl.bufferString)
+        ctrl.onDigitPressed("1")
+        assertEquals("j'", ctrl.bufferString)
+        ctrl.onDigitPressed("4")
+        assertEquals("j'4", ctrl.bufferString)
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 左选 ge
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ge", 2))
+        assertEquals("kge", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("ge", 2), ctrl.selectedOption)
+        assertEquals("43", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 左选 g（筛选层切换，替换ge）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 左选 d（同位数替换，替换g）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("kgd", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("d", 1), ctrl.selectedOption)
+        assertEquals("3", ctrl.selectionCandidateDigits)
+
+        // 步骤6: 退格7次清空
+        // 预期回退顺序: d撤销, 3删除, g部分撤销(→k'4), 4删除, k撤销, 1分词键, 5删除
+
+        // bs1: 撤销d → buffer="kg'3", SELECTION(g, "4")
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // bs2: 删除3 → buffer="kg'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("kg'", ctrl.bufferString)
+
+        // bs3: 部分撤销g → buffer="k'4", SELECTION(k, "5")
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("k'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // bs4: 删除4 → buffer="k'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("k'", ctrl.bufferString)
+
+        // bs5: 撤销k → buffer="5", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs6: 撤销分词键(1) → buffer="5"
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+
+        // bs7: 删除5 → buffer="", IDLE
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.3b：简拼+全拼混合输入，直接左选（无ge中介）+同位数替换后退格序列
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 左选 g（直接，跳过ge）→ buffer="kg'3", SELECTION(g, "4")
+    //   4. 左选 d（同位数替换）→ buffer="kgd", SELECTION(d, "3")
+    //   5. 退格7次清空
+    // 预期回退顺序: d(撤销), 3, g(部分撤销 → k'4), 4, k(撤销), 1(分词键), 5
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario43b separator - backspace after direct g selection and same digit replacement`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5 → 按分词键(1) → 4 → 3
+        ctrl.onDigitPressed("5")
+        assertEquals("5", ctrl.bufferString)
+        ctrl.onDigitPressed("1")
+        assertEquals("j'", ctrl.bufferString)
+        ctrl.onDigitPressed("4")
+        assertEquals("j'4", ctrl.bufferString)
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 左选 g（直接，跳过ge）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 左选 d（同位数替换）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("d", 1))
+        assertEquals("kgd", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("d", 1), ctrl.selectedOption)
+        assertEquals("3", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 退格7次清空
+        // 预期回退顺序: d撤销, 3删除, g部分撤销(→k'4), 4删除, k撤销, 1分词键, 5删除
+
+        // bs1: 撤销d → buffer="kg'3", SELECTION(g, "4")
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("kg'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // bs2: 删除3 → buffer="kg'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("kg'", ctrl.bufferString)
+
+        // bs3: 部分撤销g → buffer="k'4", SELECTION(k, "5")
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("k'4", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // bs4: 删除4 → buffer="k'"
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("k'", ctrl.bufferString)
+
+        // bs5: 撤销k → buffer="5", INPUT
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // bs6: 撤销分词键(1) → buffer="5"
+        assertEquals(T9InputController.DeleteResult.UNDO_CHOICE, ctrl.delete())
+        assertEquals("5", ctrl.bufferString)
+
+        // bs7: 删除5 → buffer="", IDLE
+        assertEquals(T9InputController.DeleteResult.DELETED, ctrl.delete())
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4.1：验证选择 ge 后 RIME 收到带分隔符的拼音
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", RIME收到"k'43"
+    //   3. 左选 ge → buffer="kge", SELECTION(ge, "43")
+    //   4. 验证 RIME 收到的是"k'ge"（带分隔符），而非"kge"
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario41 separator - sendToRime sends k'ge with apostrophe after selecting ge`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 步骤1: 输入 5 → 按分词键(1) → 4 → 3
+        ctrl.onDigitPressed("5")
+        ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k，RIME 应收到"k'43"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+        rimeCalls.clear()
+
+        // 步骤3: 左选 ge，RIME 应收到"k'ge"（带分隔符）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ge", 2))
+        assertEquals("kge", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 验证 RIME 最后收到的是 "k'ge"（带分隔符），而非 "kge"
+        val lastCall = rimeCalls.lastOrNull()
+        assertNotNull("选择ge后应有RIME调用", lastCall)
+        assertEquals("选择ge后RIME应收到'k'ge'，实际=$lastCall",
+            "k'ge", lastCall)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景4扩展：验证简拼 i 选择后 RIME 收到带分隔符的连续简拼
+    //
+    // 操作流程：
+    //   1. 输入 5 → 按分词键(1) → 4 → 3 → buffer="j'43"
+    //   2. 左选 l → buffer="l'43", RIME收到"l'43"
+    //   3. 左选 i（简拼）→ buffer="li'3", RIME 应收到"l'i'3"（连续简拼需分隔）
+    //   4. 验证 RIME 收到的是"l'i'3"，而非"li'3"
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario4 li - sendToRime sends l'i'3 with apostrophe between abbrevs`() {
+        val rimeCalls = mutableListOf<String>()
+        val ctrl = T9InputController(onReplaceFullPinyin = { rimeCalls.add(it) })
+
+        // 步骤1: 输入 5 → 按分词键(1) → 4 → 3
+        ctrl.onDigitPressed("5")
+        ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4")
+        ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 l，RIME 应收到"l'43"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("l", 1))
+        assertEquals("l'43", ctrl.bufferString)
+        rimeCalls.clear()
+
+        // 步骤3: 左选 i（简拼），RIME 应收到"l'i'3"（连续简拼需分隔）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("i", 1))
+        assertEquals("li'3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("i", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 验证 RIME 最后收到的是 "l'i'3"（简拼间分隔），而非 "li'3"
+        val lastCall = rimeCalls.lastOrNull()
+        assertNotNull("选择i后应有RIME调用", lastCall)
+        assertEquals("选择i后RIME应收到'l'i'3'，实际=$lastCall",
+            "l'i'3", lastCall)
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9StateMachineTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9StateMachineTest.kt
@@ -1,0 +1,179 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * T9StateMachine 单元测试
+ *
+ * 覆盖三态状态机（IDLE/INPUT/SELECTION）的所有状态转换规则。
+ */
+class T9StateMachineTest {
+
+    private fun createMachine() = T9StateMachine()
+
+    // ── 初始状态 ──
+
+    @Test
+    fun `initial state is IDLE`() {
+        val sm = createMachine()
+        assertEquals(T9StateMachine.State.IDLE, sm.state)
+        assertTrue(sm.isIdle)
+        assertFalse(sm.isInput)
+        assertFalse(sm.isSelection)
+        assertFalse(sm.hasSelection)
+    }
+
+    // ── enterInput ──
+
+    @Test
+    fun `enterInput transitions IDLE to INPUT`() {
+        val sm = createMachine()
+        sm.enterInput()
+        assertEquals(T9StateMachine.State.INPUT, sm.state)
+        assertTrue(sm.isInput)
+        assertFalse(sm.isIdle)
+        assertFalse(sm.isSelection)
+        assertNull(sm.selectedOption)
+        assertNull(sm.selectionCandidateDigits)
+    }
+
+    @Test
+    fun `enterInput from INPUT stays INPUT`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterInput()
+        assertEquals(T9StateMachine.State.INPUT, sm.state)
+    }
+
+    // ── enterSelection ──
+
+    @Test
+    fun `enterSelection transitions to SELECTION with option and digits`() {
+        val sm = createMachine()
+        sm.enterInput()
+        val option = T9PinyinMap.SyllableOption("ji", 2)
+        sm.enterSelection(option, "54")
+        assertEquals(T9StateMachine.State.SELECTION, sm.state)
+        assertTrue(sm.isSelection)
+        assertTrue(sm.hasSelection)
+        assertEquals(option, sm.selectedOption)
+        assertEquals("54", sm.selectionCandidateDigits)
+    }
+
+    @Test
+    fun `enterSelection replaces previous selection`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54")
+        val newOption = T9PinyinMap.SyllableOption("li", 2)
+        sm.enterSelection(newOption, "54")
+        assertEquals(newOption, sm.selectedOption)
+        assertEquals("54", sm.selectionCandidateDigits)
+    }
+
+    // ── exitSelection ──
+
+    @Test
+    fun `exitSelection transitions SELECTION to INPUT`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54")
+        sm.exitSelection()
+        assertEquals(T9StateMachine.State.INPUT, sm.state)
+        assertNull(sm.selectedOption)
+        assertNull(sm.selectionCandidateDigits)
+        assertFalse(sm.hasSelection)
+    }
+
+    @Test
+    fun `exitSelection from INPUT is no-op`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.exitSelection()
+        assertEquals(T9StateMachine.State.INPUT, sm.state)
+    }
+
+    // ── enterIdle ──
+
+    @Test
+    fun `enterIdle transitions any state to IDLE`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54")
+        sm.enterIdle()
+        assertEquals(T9StateMachine.State.IDLE, sm.state)
+        assertNull(sm.selectedOption)
+        assertNull(sm.selectionCandidateDigits)
+    }
+
+    @Test
+    fun `enterIdle from INPUT transitions to IDLE`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterIdle()
+        assertEquals(T9StateMachine.State.IDLE, sm.state)
+    }
+
+    // ── reset ──
+
+    @Test
+    fun `reset returns to IDLE from any state`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54")
+        sm.reset()
+        assertEquals(T9StateMachine.State.IDLE, sm.state)
+        assertNull(sm.selectedOption)
+        assertNull(sm.selectionCandidateDigits)
+    }
+
+    // ── snapshot / restore ──
+
+    @Test
+    fun `snapshot captures current state`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54")
+        val snap = sm.snapshot()
+        assertEquals(T9StateMachine.State.SELECTION, snap.state)
+        assertEquals("ji", snap.selectedOption?.pinyin)
+        assertEquals("54", snap.selectionCandidateDigits)
+    }
+
+    @Test
+    fun `restore recovers state from snapshot`() {
+        val sm = createMachine()
+        sm.enterInput()
+        sm.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54")
+        val snap = sm.snapshot()
+        sm.enterIdle()
+        sm.restore(snap)
+        assertEquals(T9StateMachine.State.SELECTION, sm.state)
+        assertEquals("ji", sm.selectedOption?.pinyin)
+        assertEquals("54", sm.selectionCandidateDigits)
+    }
+
+    @Test
+    fun `restoreFrom recovers state from raw values`() {
+        val sm = createMachine()
+        sm.enterIdle()
+        val option = T9PinyinMap.SyllableOption("gua", 3)
+        sm.restoreFrom(T9StateMachine.State.SELECTION, option, "482")
+        assertEquals(T9StateMachine.State.SELECTION, sm.state)
+        assertEquals("gua", sm.selectedOption?.pinyin)
+        assertEquals("482", sm.selectionCandidateDigits)
+    }
+
+    // ── 便捷查询 ──
+
+    @Test
+    fun `hasSelection false when SELECTION but no selectedOption`() {
+        val sm = createMachine()
+        sm.enterInput()
+        // 直接设置 state 为 SELECTION 但不设置 selectedOption
+        sm.restoreFrom(T9StateMachine.State.SELECTION, null, null)
+        assertTrue(sm.isSelection)
+        assertFalse(sm.hasSelection)
+    }
+}

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9UndoManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9UndoManagerTest.kt
@@ -1,0 +1,117 @@
+package com.kingzcheung.xime.rime
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/** T9UndoManager 单元测试 — 命令模式（Phase 3）。 */
+class T9UndoManagerTest {
+
+    private fun mgr() = T9UndoManager()
+    private fun sm() = T9StateMachine()
+    private fun ctx(buf: T9Buffer = T9Buffer.EMPTY, machine: T9StateMachine = sm()) = T9Command.Ctx(
+        buffer = buf, leftColumnLocked = false, separatorConsumedDigits = null,
+        lastChoiceConsumedDigits = null,
+        stateMachine = machine, onRestored = {},
+    )
+
+    @Test fun `initial empty`() {
+        val m = mgr()
+        assertTrue(m.isEmpty()); assertEquals(0, m.size); assertNull(m.peek())
+        assertFalse(m.topIsRightCommit)
+    }
+
+    @Test fun `push digit command`() {
+        val m = mgr()
+        m.push(T9Command.DigitPressed("5"))
+        assertEquals(1, m.size); assertTrue(m.peek() is T9Command.DigitPressed)
+    }
+
+    @Test fun `multiple pushes stack`() {
+        val m = mgr()
+        m.push(T9Command.DigitPressed("5")); m.push(T9Command.DigitPressed("4"))
+        assertEquals(2, m.size)
+    }
+
+    @Test fun `pop returns top command`() {
+        val m = mgr()
+        m.push(T9Command.DigitPressed("5"))
+        assertEquals(T9Command.DigitPressed("5"), m.pop())
+        assertEquals(0, m.size)
+    }
+
+    @Test fun `pop null when empty`() {
+        assertNull(mgr().pop())
+    }
+
+    @Test fun `digit undo removes last char`() {
+        val m = mgr(); val s = sm(); s.enterInput()
+        val c = ctx(buf = T9Buffer(digitSequence = "54"))
+        m.push(T9Command.DigitPressed("4"))
+        m.popAndUndo(c)
+        assertEquals("5", c.buffer.toBufferString())
+    }
+
+    @Test fun `leftChoice undo restores full state`() {
+        val m = mgr(); val s = sm()
+        s.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54", "")
+        val c = ctx(
+            buf = T9Buffer(digitSequence = "54482", selections = listOf(T9Buffer.Selection("ji", 2)), consumedCount = 2),
+            machine = s,
+        )
+        m.push(T9Command.LeftChoice(
+            prevBuffer = T9Buffer(digitSequence = "54482"),
+            prevSeparatorConsumedDigits = null, prevLeftColumnLocked = false,
+            prevSelectedOption = null, prevSelectionCandidateDigits = null,
+            prevConfirmedPinyin = "", prevSelectionHistory = emptyList(),
+        ))
+        m.popAndUndo(c)
+        assertEquals("54482", c.buffer.toBufferString())
+        assertEquals(T9StateMachine.State.INPUT, s.state)
+    }
+
+    @Test fun `rightCommit undo rebuilds buffer from stateMachine`() {
+        val m = mgr(); val s = sm()
+        s.enterSelection(T9PinyinMap.SyllableOption("ji", 2), "54", "")
+        val c = ctx(buf = T9Buffer(digitSequence = "54482"), machine = s)
+        m.push(T9Command.RightCommit(
+            prevBuffer = T9Buffer(
+                digitSequence = "54482",
+                selections = listOf(T9Buffer.Selection("ji", 2)),
+                consumedCount = 2,
+                totalDigitsEntered = 5,
+            ),
+            prevSeparatorConsumedDigits = null, prevLastChoiceConsumedDigits = null,
+            prevLeftColumnLocked = false, prevSelectedOption = null, prevSelectionCandidateDigits = null,
+            prevConfirmedPinyin = "", prevSelectionHistory = s.selectionHistory.toList(),
+        ))
+        m.popAndUndo(c)
+        // undo 后：stateMachine 恢复到 INPUT 态，selectionHistory = [ji(2)]
+        // T9Buffer：digitSequence="54482", selections=[ji(2)], consumedCount=2 → "ji'482"
+        assertEquals("ji'482", c.buffer.toBufferString())
+        assertEquals(T9StateMachine.State.INPUT, s.state)
+    }
+
+    @Test fun `clear removes all`() {
+        val m = mgr()
+        m.push(T9Command.DigitPressed("5"))
+        m.clear()
+        assertTrue(m.isEmpty())
+    }
+
+    @Test fun `topIsRightCommit`() {
+        val m = mgr()
+        m.push(T9Command.RightCommit(T9Buffer.EMPTY, null, null, false, null, null))
+        assertTrue(m.topIsRightCommit); assertTrue(m.hasPendingRightCommit())
+    }
+
+    @Test fun `separator undo restores buffer`() {
+        val m = mgr(); val s = sm()
+        val c = ctx(
+            buf = T9Buffer(digitSequence = "54", selections = listOf(T9Buffer.Selection("j", 1)), consumedCount = 1),
+            machine = s,
+        )
+        m.push(T9Command.Separator(prevBuffer = T9Buffer(digitSequence = "54"), prevSeparatorConsumedDigits = null))
+        m.popAndUndo(c)
+        assertEquals("54", c.buffer.toBufferString())
+    }
+}


### PR DESCRIPTION
## 关联
- 解决方案 #378 
- 修复#353
- 修复#336
- 复测通过：#326

## 主要变更
1. 将 T9 输入重构为三态状态机架构（IDLE / INPUT / SELECTION），职责拆分为 T9BufferManager、T9StateMachine、T9UndoManager、T9RimeBridge、T9DisplayHelper、T9RightCommitHandler。
2. 修复 T9 右选候选词在简拼/全拼场景下消费输入序列错误：
   - `computeConsumedDigitsFromPinyin` 改为逐音节数字码匹配，正确处理 RIME 补全韵母的简拼场景。
   - `handleApostropheRightCommit` 扩展为简拼声母匹配 + 全拼精确数字码匹配双模式。
3. 已同步并基于 upstream 最新主线（PR #380）。
4. 详细变更见issue提出解决方案：#378
5. 雾凇九键用户注意：`t9.schema.yaml` 需要： `filters`: 中新增：`- lua_filter@*t9_preedit` ,后续性能优化阶段会考虑其他解决方案，此为过渡阶段方案。

## 测试
- 全部单元测试通过（包含T9）
- `./gradlew assembleDebug --quiet` 构建成功

## 影响范围
- T9 输入控制器、右侧候选词提交、左侧候选区状态机
- 未影响其他键盘模式与设置模块