### PR TITLE
feat(schema): 添加方案清单管理系统支持

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 53
-        versionName = "2.5.0-beta10"
+        versionCode = 54
+        versionName = "2.5.0-beta11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -8,6 +8,7 @@ import com.kingzcheung.xime.settings.SchemaManifestManager
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SettingsPreferences
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.io.File
 import java.io.FileOutputStream
@@ -35,7 +36,6 @@ object RimeConfigHelper {
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
         // 确保个人词库和自定义短语文件存在，并为所有方案打补丁
         PersonalDictManager.ensureAllPackFilesExist(context)
-        PersonalDictManager.ensureCustomPhraseFileExists(context)
         PersonalDictManager.ensureSchemaPacks(context)
 
         Log.d(TAG, "Checking for missing schema files...")
@@ -72,8 +72,7 @@ object RimeConfigHelper {
         // F1: 同步初始化路径也写回 default.yaml 的 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
         PersonalDictManager.ensureAllPackFilesExist(context)
-        PersonalDictManager.ensureCustomPhraseFileExists(context)
-        PersonalDictManager.ensureSchemaPacks(context)
+        runBlocking { PersonalDictManager.ensureSchemaPacks(context) }
         checkAndCleanBuildDir(rimeDir)
         listFilesRecursively(rimeDir, TAG)
         

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.kingzcheung.xime.settings.PersonalDictManager
 import com.kingzcheung.xime.settings.SchemaConfigHelper
+import com.kingzcheung.xime.settings.SchemaManifestManager
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SettingsPreferences
 import kotlinx.coroutines.TimeoutCancellationException
@@ -21,6 +22,9 @@ object RimeConfigHelper {
         
         // 迁移旧目录结构 (rime/shared/ + rime/user/) → 单一 rime/ 目录
         migrateOldStructure(context, rimeDir)
+        
+        // 迁移旧版 market 目录（rime/market/ → market/）
+        migrateOldMarketDir(context)
         
         if (!rimeDir.exists()) {
             rimeDir.mkdirs()
@@ -45,6 +49,9 @@ object RimeConfigHelper {
         } catch (e: TimeoutCancellationException) {
             Log.w(TAG, "Schema download timed out, continuing with existing files")
         }
+
+        // 迁移旧版方案到清单系统（创建遗留清单）
+        SchemaManifestManager.migrateLegacySchemas(context)
         
         checkAndCleanBuildDir(rimeDir)
         listFilesRecursively(rimeDir, TAG)
@@ -283,6 +290,32 @@ object RimeConfigHelper {
         oldUserDir.deleteRecursively()
         
         Log.i(TAG, "Migration complete")
+    }
+
+    /** 迁移旧版 market 目录（rime/market/ → market/）。 */
+    private fun migrateOldMarketDir(context: Context) {
+        val oldMarket = File(context.filesDir, "rime/market")
+        if (!oldMarket.exists()) return
+
+        val newMarket = SchemaManager.getMarketDir(context)
+        if (!newMarket.exists()) {
+            // 新位置不存在，直接重命名
+            if (oldMarket.renameTo(newMarket)) {
+                Log.i(TAG, "Migrated rime/market/ -> market/")
+            } else {
+                Log.w(TAG, "Failed to rename rime/market/ to market/")
+            }
+        } else {
+            // 新位置已存在，逐项合并
+            oldMarket.listFiles()?.forEach { sub ->
+                val target = File(newMarket, sub.name)
+                if (!target.exists()) {
+                    sub.renameTo(target)
+                }
+            }
+            oldMarket.deleteRecursively()
+            Log.i(TAG, "Merged rime/market/ into market/")
+        }
     }
 
     private fun listFilesRecursively(dir: File, tag: String, prefix: String = "") {

--- a/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
@@ -30,8 +30,34 @@ use_preset_vocabulary: false
     fun getPackFile(context: Context, schemaId: String): File =
         File(SchemaManager.getRimeDir(context), packFileName(schemaId))
 
-    fun getCustomPhraseFile(context: Context): File =
-        File(SchemaManager.getRimeDir(context), CUSTOM_PHRASE_FILE)
+    fun getCustomPhraseFile(context: Context, schemaId: String? = null): File {
+        val rimeDir = SchemaManager.getRimeDir(context)
+        val dictName = if (schemaId != null) getCustomPhraseDictName(rimeDir, schemaId)
+                       else CUSTOM_PHRASE_FILE.removeSuffix(".txt")
+        return File(rimeDir, "$dictName.txt")
+    }
+
+    /**
+     * 从方案的 .custom.yaml 中读取 `custom_phrase.user_dict` 定义的文件名。
+     * 例如 `user_dict: custom_phrase_double` → 对应 `custom_phrase_double.txt`。
+     * 若无声明则返回默认的 `custom_phrase`。
+     */
+    internal fun getCustomPhraseDictName(rimeDir: File, schemaId: String): String {
+        val customFile = File(rimeDir, "${schemaId}.custom.yaml")
+        if (!customFile.exists()) return CUSTOM_PHRASE_FILE.removeSuffix(".txt")
+        val text = customFile.readText(Charsets.UTF_8)
+        for (cpKey in listOf("\"custom_phrase\"", "'custom_phrase'", "custom_phrase:")) {
+            val idx = text.indexOf(cpKey)
+            if (idx < 0) continue
+            val after = text.substring(idx)
+            val udIdx = after.indexOf("user_dict")
+            if (udIdx < 0) continue
+            val line = after.substring(udIdx).lineSequence().firstOrNull() ?: continue
+            val value = line.substringAfter(":").trim().substringBefore(" #").substringBefore("\n")
+            if (value.isNotBlank()) return value
+        }
+        return CUSTOM_PHRASE_FILE.removeSuffix(".txt")
+    }
 
     fun ensureAllPackFilesExist(context: Context) {
         for (sid in listOf("pinyin_simp", "t9_pinyin", "wubi86")) {
@@ -43,8 +69,8 @@ use_preset_vocabulary: false
         }
     }
 
-    fun ensureCustomPhraseFileExists(context: Context) {
-        val file = getCustomPhraseFile(context)
+    fun ensureCustomPhraseFileExists(context: Context, schemaId: String? = null) {
+        val file = getCustomPhraseFile(context, schemaId)
         if (!file.exists()) {
             file.parentFile?.mkdirs()
             file.writeText("""# Rime table
@@ -56,28 +82,44 @@ use_preset_vocabulary: false
         }
     }
 
-    // ── 方案配置补丁 ──
-    //
-    // 词库扩展包 (packs) 依赖 prism 中存在对应的编码。
-    // 有 speller/algebra 的方案（如拼音），algebra 展开后所有有效编码都在 prism 中，
-    // packs 可以自由添加新词条。
-    // 无 speller/algebra 的方案（如五笔），prism 只包含词典条目中实际出现的编码，
-    // 需用 import_tables 合并词典，将个人词库编码一并编入 prism。
+    fun loadCustomPhrases(context: Context, schemaId: String? = null): List<DictEntry> {
+        val file = getCustomPhraseFile(context, schemaId)
+        if (!file.exists()) return emptyList()
+        return try {
+            parseStableDbEntries(file.readText(Charsets.UTF_8))
+        } catch (_: Exception) { emptyList() }
+    }
 
-    fun ensureSchemaPacks(context: Context) {
-        val rimeDir = SchemaManager.getRimeDir(context)
-        val enabledSchemas = SchemaManager.getEnabledSchemas(context)
-        for (schemaId in enabledSchemas) {
-            ensureSchemaPackInner(rimeDir, schemaId)
+    fun saveCustomPhrases(context: Context, schemaId: String? = null, entries: List<DictEntry>) {
+        val file = getCustomPhraseFile(context, schemaId)
+        file.parentFile?.mkdirs()
+        file.writeText(buildStableDbText(STABLEDB_HEADER, entries), Charsets.UTF_8)
+    }
+
+    /** 清理 custom_phrase 文件（仅当文件为空时删除，避免丢失用户数据）。 */
+    fun removeCustomPhraseFile(context: Context, schemaId: String? = null) {
+        val file = getCustomPhraseFile(context, schemaId)
+        if (file.exists() && file.readText(Charsets.UTF_8).lineSequence().count { it.isNotBlank() && !it.startsWith('#') } == 0) {
+            file.delete()
         }
     }
 
-    fun ensureSchemaPack(context: Context, schemaId: String) {
+    // ── 方案配置补丁 ──
+
+    suspend fun ensureSchemaPacks(context: Context) {
         val rimeDir = SchemaManager.getRimeDir(context)
-        ensureSchemaPackInner(rimeDir, schemaId)
+        val enabledSchemas = SchemaManager.getEnabledSchemas(context)
+        for (schemaId in enabledSchemas) {
+            ensureSchemaPackInner(rimeDir, context, schemaId)
+        }
     }
 
-    private fun ensureSchemaPackInner(rimeDir: java.io.File, schemaId: String) {
+    suspend fun ensureSchemaPack(context: Context, schemaId: String) {
+        val rimeDir = SchemaManager.getRimeDir(context)
+        ensureSchemaPackInner(rimeDir, context, schemaId)
+    }
+
+    private suspend fun ensureSchemaPackInner(rimeDir: java.io.File, context: Context, schemaId: String) {
         val schemaFile = java.io.File(rimeDir, "${schemaId}.schema.yaml")
         if (!schemaFile.exists()) return
         if (hasReverseLookupTranslator(schemaFile)) {
@@ -87,7 +129,21 @@ use_preset_vocabulary: false
         } else {
             applyMergedDictConfig(rimeDir, schemaId)
         }
-        applyCustomPhraseTranslator(rimeDir, schemaId)
+        val dictName = getCustomPhraseDictName(rimeDir, schemaId)
+        val phraseFile = File(rimeDir, "$dictName.txt")
+        if (!phraseFile.exists()) {
+            phraseFile.parentFile?.mkdirs()
+            phraseFile.writeText("""# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
+#
+""", Charsets.UTF_8)
+        }
+        // 有实际条目时才注入翻译器，避免 Rime 因空 .table.bin 报错
+        if (phraseFile.readText(Charsets.UTF_8).lineSequence().count { it.isNotBlank() && !it.startsWith('#') } > 0) {
+            applyCustomPhraseTranslator(rimeDir, schemaId, dictName)
+        }
     }
 
     internal fun hasReverseLookupTranslator(schemaFile: java.io.File): Boolean {
@@ -96,7 +152,7 @@ use_preset_vocabulary: false
     }
 
     // 为方案添加 custom_phrase 翻译器（独立于主词典音节表）
-    internal fun applyCustomPhraseTranslator(rimeDir: java.io.File, schemaId: String) {
+    internal fun applyCustomPhraseTranslator(rimeDir: java.io.File, schemaId: String, dictName: String) {
         val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
         if (customFile.exists()) {
             val text = customFile.readText(Charsets.UTF_8)
@@ -106,7 +162,7 @@ use_preset_vocabulary: false
     - table_translator@custom_phrase
   "custom_phrase":
     dictionary: ""
-    user_dict: custom_phrase
+    user_dict: $dictName
     db_class: stabledb
     enable_completion: false
     enable_sentence: false
@@ -237,24 +293,6 @@ import_tables:
         val start = norm.indexOf("...\n")
         if (start >= 0) return norm.substring(0, start + 4)
         return defaultH
-    }
-
-    // ── 自定义短语 ──
-    // custom_phrase.txt 通过独立的 table_translator 加载（db_class: stabledb），
-    // 不走主词典音节表，任意编码在所有方案中均可使用。
-
-    fun loadCustomPhrases(context: Context): List<DictEntry> {
-        val file = getCustomPhraseFile(context)
-        if (!file.exists()) return emptyList()
-        return try {
-            parseStableDbEntries(file.readText(Charsets.UTF_8))
-        } catch (_: Exception) { emptyList() }
-    }
-
-    fun saveCustomPhrases(context: Context, entries: List<DictEntry>) {
-        val file = getCustomPhraseFile(context)
-        file.parentFile?.mkdirs()
-        file.writeText(buildStableDbText(STABLEDB_HEADER, entries), Charsets.UTF_8)
     }
 
     private const val STABLEDB_HEADER = """# Rime table

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -64,6 +64,23 @@ object SchemaManager {
     fun getRimeDir(context: Context): File =
         File(context.filesDir, "rime")
 
+    /** 清空 rime/ 目录除 default.yaml、xime.yaml 及受保护文件之外的所有文件。 */
+    fun cleanRimeDir(context: Context) {
+        val rimeDir = getRimeDir(context)
+        if (!rimeDir.exists()) return
+        rimeDir.listFiles()?.forEach { file ->
+            val name = file.name
+            if (name == "default.yaml" || name == "xime.yaml") return@forEach
+            if (isProtectedImportName(name)) return@forEach
+            if (file.isDirectory) {
+                file.deleteRecursively()
+            } else {
+                file.delete()
+            }
+        }
+        Log.i(TAG, "rime/ directory cleaned")
+    }
+
     /** market 根目录（与 rime/ 同级，不属于 Rime 数据）。 */
     fun getMarketDir(context: Context): File =
         File(context.filesDir, "market")
@@ -440,8 +457,8 @@ object SchemaManager {
         val base = name.substringAfterLast('/')
         return base == "default.yaml" ||
                base == "xime.yaml" ||
-               name.startsWith(".registry") ||
-               name.startsWith(".manifests")
+               base == "custom_phrase.txt" ||
+               name.startsWith(".registry")
     }
 
     /** macOS Apple Double 资源分支文件（__MACOSX/ 或 ._ 前缀），应当在解压时跳过。 */
@@ -663,21 +680,31 @@ object SchemaManager {
 
     suspend fun importSchemaFile(context: Context, uri: Uri): Boolean {
         return withContext(Dispatchers.IO) {
+            val importId = generateImportId()
+            val pkgDir = getMarketDir(context, importId)
             try {
-                val displayName = getFileName(context, uri) ?: return@withContext false
-                val importId = generateImportId()
-                val pkgDir = getMarketDir(context, importId)
+                val displayName = getFileName(context, uri) ?: run {
+                    pkgDir.deleteRecursively(); return@withContext false
+                }
                 pkgDir.mkdirs()
-
                 val archiveFile = File(pkgDir, displayName)
-                context.contentResolver.openInputStream(uri)?.use { input ->
+
+                val inputStream = when (uri.scheme) {
+                    "file" -> java.io.FileInputStream(uri.path!!)
+                    else -> context.contentResolver.openInputStream(uri)
+                }
+                inputStream?.use { input ->
                     archiveFile.outputStream().use { output -> input.copyTo(output) }
-                } ?: return@withContext false
+                } ?: run {
+                    pkgDir.deleteRecursively()
+                    return@withContext false
+                }
 
                 Log.i(TAG, "Imported $displayName -> $importId (not installed yet)")
                 true
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to import schema file", e)
+                try { if (pkgDir.exists()) pkgDir.deleteRecursively() } catch (_: Exception) {}
                 false
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -61,15 +61,15 @@ object SchemaManager {
     fun getRimeDir(context: Context): File =
         File(context.filesDir, "rime")
 
-    /** market 根目录。 */
+    /** market 根目录（与 rime/ 同级，不属于 Rime 数据）。 */
     fun getMarketDir(context: Context): File =
-        File(getRimeDir(context), "market")
+        File(context.filesDir, "market")
 
-    /** 每个方案在 market 下的独立子目录：rime/market/{schemeId}/ */
+    /** 每个方案在 market 下的独立子目录：market/{schemeId}/ */
     fun getMarketDir(context: Context, schemeId: String): File =
         File(getMarketDir(context), schemeId)
 
-    /** 检查方案的压缩包是否已下载。 */
+    /** 检查方案的压缩包是否已下载（market/{schemeId}/ 存在且包含文件）。 */
     fun isSchemeDownloaded(context: Context, schemeId: String): Boolean {
         val dir = getMarketDir(context, schemeId)
         return dir.exists() && (dir.listFiles()?.any { it.isFile } == true)
@@ -266,10 +266,13 @@ object SchemaManager {
         MessageDigest.getInstance("SHA-256").digest(bytes)
             .joinToString("") { "%02x".format(it.toInt() and 0xff) }
 
-    /** 导入归档时禁止覆盖 default.yaml（保护用户配置）。 */
+    /** 导入归档时禁止覆盖系统文件（保护应用核心配置与系统元数据）。 */
     fun isProtectedImportName(name: String): Boolean {
         val base = name.substringAfterLast('/')
-        return base == "default.yaml"
+        return base == "default.yaml" ||
+               base == "xime.yaml" ||
+               name.startsWith(".registry") ||
+               name.startsWith(".manifests")
     }
 
     /** macOS Apple Double 资源分支文件（__MACOSX/ 或 ._ 前缀），应当在解压时跳过。 */
@@ -461,19 +464,32 @@ object SchemaManager {
         return schemaId in getEnabledSchemas(context)
     }
 
-    fun deleteSchemaFiles(context: Context, schemaId: String) {
-        val rimeDir = getRimeDir(context)
-        val schemaFile = File(rimeDir, "$schemaId.schema.yaml")
-        if (schemaFile.exists()) schemaFile.delete()
+    suspend fun deleteSchemaFiles(context: Context, schemaId: String): Boolean {
+        // 优先使用清单系统精准卸载
+        val result = SchemaManifestManager.uninstallWithManifest(context, schemaId)
+        if (result.manifestExisted) {
+            if (result.success) {
+                Log.i(TAG, "Manifest-based uninstall for $schemaId: ${result.message}")
+            } else {
+                Log.w(TAG, "Manifest-based uninstall for $schemaId failed: ${result.message}")
+            }
+        } else {
+            // 降级到传统逻辑（无清单的旧方案）
+            val rimeDir = getRimeDir(context)
+            val schemaFile = File(rimeDir, "$schemaId.schema.yaml")
+            if (schemaFile.exists()) schemaFile.delete()
+            val dictName = getReferencedDictName(context, schemaId) ?: schemaId
+            val dictFile = File(rimeDir, "$dictName.dict.yaml")
+            if (dictFile.exists()) dictFile.delete()
+            Log.i(TAG, "Legacy uninstall for $schemaId (dict=$dictName)")
+        }
 
-        val dictName = getReferencedDictName(context, schemaId) ?: schemaId
-        val dictFile = File(rimeDir, "$dictName.dict.yaml")
-        if (dictFile.exists()) dictFile.delete()
-
+        // 从已安装市场列表和启用列表中移除
+        SettingsPreferences.removeInstalledMarketId(context, schemaId)
         val enabled = getEnabledSchemas(context).toMutableList()
         enabled.remove(schemaId)
         setEnabledSchemas(context, enabled)
-        Log.i(TAG, "Deleted schema files for: $schemaId (dict=$dictName)")
+        return true
     }
 
     suspend fun importSchemaFile(context: Context, uri: Uri): Boolean {
@@ -483,25 +499,53 @@ object SchemaManager {
                 if (!rimeDir.exists()) rimeDir.mkdirs()
 
                 val displayName = getFileName(context, uri) ?: return@withContext false
+                val importId = "import_" + sha256Hex(displayName.toByteArray()).take(12)
 
+                val targetFiles: List<String>
                 if (displayName.endsWith(".zip", ignoreCase = true)) {
-                    return@withContext importZip(context, uri, rimeDir)
+                    targetFiles = importZipWithFileList(context, uri, rimeDir)
+                } else {
+                    val targetFile = File(rimeDir, displayName)
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        FileOutputStream(targetFile).use { output ->
+                            input.copyTo(output)
+                        }
+                    } ?: return@withContext false
+                    targetFiles = listOf(displayName)
                 }
 
-                val targetFile = File(rimeDir, displayName)
-                context.contentResolver.openInputStream(uri)?.use { input ->
-                    FileOutputStream(targetFile).use { output ->
-                        input.copyTo(output)
-                    }
-                } ?: return@withContext false
+                SchemaManifestManager.createManifest(
+                    context = context,
+                    schemeId = importId,
+                    displayName = displayName.removeSuffix(".zip").removeSuffix(".tar.gz").removeSuffix(".tgz"),
+                    version = "",
+                    fromMarket = false,
+                    extractedFiles = targetFiles,
+                )
 
-                Log.i(TAG, "Imported: $displayName")
-
+                Log.i(TAG, "Imported: $displayName ($importId)")
                 true
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to import schema file", e)
                 false
             }
+        }
+    }
+
+    /**
+     * 从 URI 导入 zip，返回解压后的文件列表。
+     */
+    private fun importZipWithFileList(context: Context, uri: Uri, targetDir: File): List<String> {
+        val tempFile = File.createTempFile("import_", ".zip", targetDir)
+        try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                tempFile.outputStream().use { output -> input.copyTo(output) }
+            } ?: return emptyList()
+            val files = listArchiveTargetFiles(tempFile)
+            importZipFromFile(tempFile, targetDir)
+            return files
+        } finally {
+            tempFile.delete()
         }
     }
 
@@ -782,8 +826,21 @@ object SchemaManager {
                         return@withContext false
                     }
                 }
+                // 解压前列出目标文件
+                val targetFiles = listArchiveTargetFiles(archiveFile)
                 // 解压到 rime 目录
                 if (isZip) importZipFromFile(archiveFile, rimeDir) else importTarGzFromFile(archiveFile, rimeDir)
+
+                // 为导入创建清单（自动分配 ID）
+                val importId = "import_" + sha256Hex(url.toByteArray()).take(12)
+                SchemaManifestManager.createManifest(
+                    context = context,
+                    schemeId = importId,
+                    displayName = archiveFile.nameWithoutExtension,
+                    version = "",
+                    fromMarket = false,
+                    extractedFiles = targetFiles,
+                )
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to import from URL: $url", e)

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -247,6 +247,14 @@ object SchemaManager {
             SettingsPreferences.addInstalledMarketId(context, packageId)
         }
 
+        // 至少启用一个新方案，避免 RimeEngine 因 schema_list 为空而挂起
+        val firstSchema = newIds.firstOrNull()
+            ?: targetFiles.firstOrNull { it.endsWith(".schema.yaml") }
+                ?.removeSuffix(".schema.yaml")
+        if (firstSchema != null) {
+            setEnabledSchemas(context, listOf(firstSchema))
+        }
+
         InstallFromDirResult(success = true, newSchemaIds = newIds, unresolvedDeps = unresolved)
     }
 
@@ -343,7 +351,7 @@ object SchemaManager {
         return allOk
     }
 
-    private fun getBuildDir(context: Context): File =
+    internal fun getBuildDir(context: Context): File =
         File(getRimeDir(context), "build")
 
     private fun getCustomYamlFile(context: Context): File =

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -23,6 +23,9 @@ import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
@@ -91,6 +94,160 @@ object SchemaManager {
         if (!dir.exists()) return emptyList()
         val files = dir.listFiles()?.filter { it.isFile } ?: return emptyList()
         return files.flatMap { listArchiveTargetFiles(it) }
+    }
+
+    /**
+     * 计算市场包中每个目标文件的 sha256（用于冲突检测）。
+     * 与 [listInstallTargetFiles] 对应，返回值是相同结构的目标文件名 → sha256。
+     */
+    suspend fun computeTargetSha256Map(context: Context, schemeId: String): Map<String, String> = withContext(Dispatchers.IO) {
+        val dir = getMarketDir(context, schemeId)
+        if (!dir.exists()) return@withContext emptyMap()
+        val files = dir.listFiles()?.filter { it.isFile } ?: return@withContext emptyMap()
+        val result = mutableMapOf<String, String>()
+
+        for (file in files) {
+            when {
+                file.name.endsWith(".zip", ignoreCase = true) -> {
+                    val entryNames = mutableListOf<String>()
+                    ZipFile(file).use { zip ->
+                        zip.entries().asSequence().forEach { entry ->
+                            if (!entry.isDirectory && !isAppleDouble(entry.name)) {
+                                entryNames.add(entry.name)
+                            }
+                        }
+                    }
+                    val baseDir = findSchemaBaseDir(entryNames)
+                    ZipFile(file).use { zip ->
+                        zip.entries().asSequence().forEach { entry ->
+                            val originalName = entry.name
+                            if (entry.isDirectory || isAppleDouble(originalName)) return@forEach
+                            val name = originalName.removePrefix(baseDir)
+                            if (isProtectedImportName(name)) return@forEach
+                            val bytes = zip.getInputStream(entry).readBytes()
+                            result[name] = sha256Hex(bytes)
+                        }
+                    }
+                }
+
+                file.name.endsWith(".tar.gz", ignoreCase = true) || file.name.endsWith(".tgz", ignoreCase = true) -> {
+                    val entryNames = mutableListOf<String>()
+                    file.inputStream().buffered().use { input ->
+                        TarArchiveInputStream(GzipCompressorInputStream(input)).use { tarIn ->
+                            var entry = tarIn.nextEntry
+                            while (entry != null) {
+                                if (!entry.isDirectory && !isAppleDouble(entry.name)) {
+                                    entryNames.add(entry.name)
+                                }
+                                entry = tarIn.nextEntry
+                            }
+                        }
+                    }
+                    val baseDir = findSchemaBaseDir(entryNames)
+                    file.inputStream().buffered().use { input ->
+                        TarArchiveInputStream(GzipCompressorInputStream(input)).use { tarIn ->
+                            var entry = tarIn.nextEntry
+                            while (entry != null) {
+                                val originalName = entry.name
+                                if (entry.isDirectory || isAppleDouble(originalName)) {
+                                    entry = tarIn.nextEntry
+                                    continue
+                                }
+                                val name = originalName.removePrefix(baseDir)
+                                if (isProtectedImportName(name)) {
+                                    entry = tarIn.nextEntry
+                                    continue
+                                }
+                                val bytes = tarIn.readBytes()
+                                result[name] = sha256Hex(bytes)
+                                entry = tarIn.nextEntry
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    if (!isProtectedImportName(file.name)) {
+                        result[file.name] = sha256Hex(file.readBytes())
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    data class InstallFromDirResult(
+        val success: Boolean,
+        val conflicts: List<FileConflictInfo> = emptyList(),
+        val newSchemaIds: List<String> = emptyList(),
+        val unresolvedDeps: List<String> = emptyList(),
+        val failureReason: String? = null,
+    )
+
+    /**
+     * 从 market/{packageId}/ 执行统一安装：冲突检测 → 解压 → 清单创建。
+     * 所有导入路径（市场/文件/URL）最终都汇聚于此。
+     */
+    suspend fun installPackageFromMarketDir(
+        context: Context,
+        packageId: String,
+        displayName: String,
+        version: String = "",
+        fromMarket: Boolean = false,
+        dependencies: List<String> = emptyList(),
+        resolveDepUrl: (String) -> String? = { null },
+    ): InstallFromDirResult = withContext(Dispatchers.IO) {
+        val dir = getMarketDir(context, packageId)
+        if (!dir.exists() || dir.listFiles()?.none { it.isFile } != false) {
+            return@withContext InstallFromDirResult(success = false, failureReason = "压缩包不存在")
+        }
+
+        val targetFiles = listInstallTargetFiles(context, packageId)
+        if (targetFiles.isEmpty()) {
+            return@withContext InstallFromDirResult(success = false, failureReason = "归档中没有文件")
+        }
+
+        val sha256Map = computeTargetSha256Map(context, packageId)
+        val conflicts = SchemaManifestManager.detectConflicts(context, packageId, targetFiles, sha256Map)
+        if (conflicts.isNotEmpty()) {
+            return@withContext InstallFromDirResult(success = false, conflicts = conflicts)
+        }
+
+        val before = discoverSchemas(context).map { it.schemaId }.toSet()
+        val ok = installFromMarketToRime(context, packageId)
+        if (!ok) return@withContext InstallFromDirResult(success = false, failureReason = "安装失败")
+
+        val after = discoverSchemas(context).map { it.schemaId }.toSet()
+        val newIds = (after - before).toList()
+
+        var unresolved = emptyList<String>()
+        var dependencyIds = emptyList<String>()
+        if (dependencies.isNotEmpty()) {
+            val completion = RimeDependencyResolver.complete(
+                context = context,
+                schemaId = newIds.firstOrNull() ?: packageId,
+                dependencies = dependencies,
+                resolveUrl = resolveDepUrl,
+            )
+            unresolved = (completion.unresolved + completion.stillMissingFiles).distinct()
+            dependencyIds = completion.downloaded
+        }
+
+        SchemaManifestManager.createManifest(
+            context = context,
+            schemeId = packageId,
+            displayName = displayName,
+            version = version,
+            fromMarket = fromMarket,
+            extractedFiles = targetFiles,
+            dependencyIds = dependencyIds,
+        )
+
+        if (fromMarket) {
+            SettingsPreferences.addInstalledMarketId(context, packageId)
+        }
+
+        InstallFromDirResult(success = true, newSchemaIds = newIds, unresolvedDeps = unresolved)
     }
 
     /** 解析单个归档（或普通文件）将被释放到 rime/ 的目标文件名列表。 */
@@ -265,6 +422,10 @@ object SchemaManager {
     fun sha256Hex(bytes: ByteArray): String =
         MessageDigest.getInstance("SHA-256").digest(bytes)
             .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+
+    /** 生成基于当前时间的导入 ID，如 import_20260712_015947。 */
+    fun generateImportId(): String =
+        "import_" + SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
 
     /** 导入归档时禁止覆盖系统文件（保护应用核心配置与系统元数据）。 */
     fun isProtectedImportName(name: String): Boolean {
@@ -495,35 +656,17 @@ object SchemaManager {
     suspend fun importSchemaFile(context: Context, uri: Uri): Boolean {
         return withContext(Dispatchers.IO) {
             try {
-                val rimeDir = getRimeDir(context)
-                if (!rimeDir.exists()) rimeDir.mkdirs()
-
                 val displayName = getFileName(context, uri) ?: return@withContext false
-                val importId = "import_" + sha256Hex(displayName.toByteArray()).take(12)
+                val importId = generateImportId()
+                val pkgDir = getMarketDir(context, importId)
+                pkgDir.mkdirs()
 
-                val targetFiles: List<String>
-                if (displayName.endsWith(".zip", ignoreCase = true)) {
-                    targetFiles = importZipWithFileList(context, uri, rimeDir)
-                } else {
-                    val targetFile = File(rimeDir, displayName)
-                    context.contentResolver.openInputStream(uri)?.use { input ->
-                        FileOutputStream(targetFile).use { output ->
-                            input.copyTo(output)
-                        }
-                    } ?: return@withContext false
-                    targetFiles = listOf(displayName)
-                }
+                val archiveFile = File(pkgDir, displayName)
+                context.contentResolver.openInputStream(uri)?.use { input ->
+                    archiveFile.outputStream().use { output -> input.copyTo(output) }
+                } ?: return@withContext false
 
-                SchemaManifestManager.createManifest(
-                    context = context,
-                    schemeId = importId,
-                    displayName = displayName.removeSuffix(".zip").removeSuffix(".tar.gz").removeSuffix(".tgz"),
-                    version = "",
-                    fromMarket = false,
-                    extractedFiles = targetFiles,
-                )
-
-                Log.i(TAG, "Imported: $displayName ($importId)")
+                Log.i(TAG, "Imported $displayName -> $importId (not installed yet)")
                 true
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to import schema file", e)
@@ -767,9 +910,6 @@ object SchemaManager {
         onProgress: (Long, Long) -> Unit = { _, _ -> },
     ): Boolean = withContext(Dispatchers.IO) {
         try {
-            val rimeDir = getRimeDir(context)
-            if (!rimeDir.exists()) rimeDir.mkdirs()
-
             val isZip = url.endsWith(".zip", ignoreCase = true)
             val isTarGz = url.endsWith(".tar.gz", ignoreCase = true) || url.endsWith(".tgz", ignoreCase = true)
             if (!isZip && !isTarGz) {
@@ -777,15 +917,15 @@ object SchemaManager {
                 return@withContext false
             }
 
-            // 确定压缩包保存路径
             val ext = when {
                 isZip -> ".zip"
                 url.endsWith(".tgz", ignoreCase = true) -> ".tgz"
                 else -> ".tar.gz"
             }
-            val marketDir = getMarketDir(context)
-            if (!marketDir.exists()) marketDir.mkdirs()
-            val archiveFile = File(marketDir, archiveName ?: (url.substringAfterLast("/").takeIf { it.isNotBlank() } ?: "download$ext"))
+            val importId = generateImportId()
+            val pkgDir = getMarketDir(context, importId)
+            pkgDir.mkdirs()
+            val archiveFile = File(pkgDir, archiveName ?: (url.substringAfterLast("/").takeIf { it.isNotBlank() } ?: "download$ext"))
 
             val client = OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
@@ -795,11 +935,11 @@ object SchemaManager {
             client.newCall(Request.Builder().url(url).build()).execute().use { response ->
                 if (!response.isSuccessful) {
                     Log.e(TAG, "Download failed: ${response.code} $url")
+                    pkgDir.deleteRecursively()
                     return@withContext false
                 }
                 val body = response.body ?: return@withContext false
 
-                // 下载到 market 目录的压缩包文件，边写边算 SHA-256
                 val totalBytes = body.contentLength()
                 var downloadedBytes = 0L
                 val md = MessageDigest.getInstance("SHA-256")
@@ -822,25 +962,13 @@ object SchemaManager {
                     val actual = md.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
                     if (!actual.equals(expectedSha256.trim(), ignoreCase = true)) {
                         Log.e(TAG, "sha256 mismatch for $url: expected=${expectedSha256.trim()} actual=$actual")
-                        archiveFile.delete()
+                        pkgDir.deleteRecursively()
                         return@withContext false
                     }
                 }
-                // 解压前列出目标文件
-                val targetFiles = listArchiveTargetFiles(archiveFile)
-                // 解压到 rime 目录
-                if (isZip) importZipFromFile(archiveFile, rimeDir) else importTarGzFromFile(archiveFile, rimeDir)
 
-                // 为导入创建清单（自动分配 ID）
-                val importId = "import_" + sha256Hex(url.toByteArray()).take(12)
-                SchemaManifestManager.createManifest(
-                    context = context,
-                    schemeId = importId,
-                    displayName = archiveFile.nameWithoutExtension,
-                    version = "",
-                    fromMarket = false,
-                    extractedFiles = targetFiles,
-                )
+                Log.i(TAG, "Downloaded $url -> $importId (not installed yet)")
+                true
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to import from URL: $url", e)

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -295,6 +295,14 @@ object SchemaManifestManager {
                 if (file.exists()) {
                     file.delete()
                 }
+                // 清理对应的编译缓存
+                if (fn.endsWith(".schema.yaml")) {
+                    val schemaId = fn.removeSuffix(".schema.yaml")
+                    val buildDir = SchemaManager.getBuildDir(context)
+                    buildDir.listFiles { f ->
+                        f.name.startsWith(schemaId + ".")
+                    }?.forEach { it.delete() }
+                }
                 // 从注册表中移除该文件的所有记录
                 allFiles.remove(fn)
                 deletedCount++
@@ -336,13 +344,46 @@ object SchemaManifestManager {
      * 为旧版已安装方案创建/合并遗留清单。
      * v1 → v2：把旧版单条 per-schema 清单合并成一个 `builtin` 包。
      */
+    /**
+     * 确保 market/builtin/ 目录存在，若不存在则从已安装的内置方案文件创建。
+     * 仅在首次或目录缺失时执行。
+     */
+    private suspend fun ensureBuiltinBackup(context: Context) {
+        withContext(Dispatchers.IO) {
+            val builtinDir = SchemaManager.getMarketDir(context, BUILTIN_PACKAGE_ID)
+            if (builtinDir.exists() && builtinDir.listFiles()?.isNotEmpty() == true) return@withContext
+            try {
+                val rimeDir = SchemaManager.getRimeDir(context)
+                builtinDir.mkdirs()
+                val manifestFile = getManifestFile(context, BUILTIN_PACKAGE_ID)
+                if (!manifestFile.exists()) return@withContext
+                val manifest = JSONObject(manifestFile.readText())
+                val files = manifest.optJSONObject("files") ?: return@withContext
+                val keys = files.keys()
+                while (keys.hasNext()) {
+                    val fn = keys.next() as String
+                    val src = File(rimeDir, fn)
+                    if (src.exists()) {
+                        src.copyTo(File(builtinDir, fn), overwrite = true)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "failed to backup builtin", e)
+            }
+        }
+    }
+
     suspend fun migrateLegacySchemas(context: Context) {
         val prefs = SettingsPreferences.getPrefsPublic(context)
         val prevVersion = prefs.getInt(KEY_MIGRATION_VERSION, 0)
-        if (prevVersion >= MIGRATION_VERSION_CURRENT) return
 
         withContext(Dispatchers.IO) {
             try {
+                // 确保 market/builtin/ 存在（迁移前没有此目录的旧版本会在此补齐）
+                ensureBuiltinBackup(context)
+
+                if (prevVersion >= MIGRATION_VERSION_CURRENT) return@withContext
+
                 val rimeDir = SchemaManager.getRimeDir(context)
                 getManifestsDir(context).mkdirs()
                 var changed = false
@@ -378,6 +419,8 @@ object SchemaManifestManager {
                         if (dictFile.exists()) allYamlFiles.add("$dictName.dict.yaml")
                     }
 
+                    val builtinDir = SchemaManager.getMarketDir(context, BUILTIN_PACKAGE_ID)
+                    builtinDir.mkdirs()
                     for (fn in allYamlFiles) {
                         val file = File(rimeDir, fn)
                         if (!file.exists()) continue
@@ -386,6 +429,7 @@ object SchemaManifestManager {
                             put("sha256", sha256)
                             put("size", file.length())
                         })
+                        file.copyTo(File(builtinDir, fn), overwrite = true)
                     }
 
                     val manifest = JSONObject().apply {

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -127,15 +127,18 @@ object SchemaManifestManager {
     /**
      * 检测待安装方案与已安装方案的文件冲突。
      * 仅报告真正冲突（同名不同内容）；同内容视为共享依赖自动放行。
+     *
+     * @param newFileSha256 待安装方案中各目标文件的 sha256 映射。
+     *   从市场包的归档内容计算得到，而非从 rime/ 目录下已有文件计算。
      */
     suspend fun detectConflicts(
         context: Context,
         schemeId: String,
         targetFiles: List<String>,
+        newFileSha256: Map<String, String> = emptyMap(),
     ): List<FileConflictInfo> = withContext(Dispatchers.IO) {
         val registry = loadRegistry(context)
         val files = registry.optJSONObject("files") ?: return@withContext emptyList()
-        val rimeDir = SchemaManager.getRimeDir(context)
         val conflicts = mutableListOf<FileConflictInfo>()
 
         for (fileName in targetFiles) {
@@ -145,10 +148,7 @@ object SchemaManifestManager {
             if (jsonArrayToList(claimants).any { it == schemeId }) continue
 
             val existingSha256 = entry.optString("sha256", "")
-            val targetFile = File(rimeDir, fileName)
-            if (!targetFile.exists()) continue
-
-            val newSha256 = fileSha256(targetFile) ?: continue
+            val newSha256 = newFileSha256[fileName] ?: continue
             if (existingSha256 != newSha256) {
                 conflicts.add(FileConflictInfo(
                     fileName = fileName,

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -1,0 +1,474 @@
+package com.kingzcheung.xime.settings
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+data class FileConflictInfo(
+    val fileName: String,
+    val existingSha256: String,
+    val newSha256: String,
+    val claimedBy: List<String>,
+) {
+    val isRealConflict: Boolean get() = existingSha256 != newSha256
+}
+
+data class UninstallResult(
+    val success: Boolean,
+    val deletedFiles: Int = 0,
+    val manifestExisted: Boolean = true,
+    val message: String = "",
+)
+
+/**
+ * 方案文件清单管理系统：
+ * - 全局注册表 (.registry.json)：记录 rime/ 下每个文件被哪些方案声明拥有
+ * - 方案清单 (.manifests/{schemeId}.json)：记录单个方案安装的全部文件
+ *
+ * 用于文件冲突检测、精准卸载、依赖共享追踪。
+ */
+object SchemaManifestManager {
+    private const val TAG = "SchemaManifestManager"
+    private const val REGISTRY_FILE = ".registry.json"
+    private const val MANIFESTS_DIR = ".manifests"
+    private const val REGISTRY_VERSION = 1
+
+    fun getRegistryFile(context: Context): File =
+        File(SchemaManager.getRimeDir(context), REGISTRY_FILE)
+
+    fun getManifestsDir(context: Context): File =
+        File(SchemaManager.getRimeDir(context), MANIFESTS_DIR)
+
+    fun getManifestFile(context: Context, schemeId: String): File =
+        File(getManifestsDir(context), "$schemeId.json")
+
+    // ── Registry ──
+
+    suspend fun loadRegistry(context: Context): JSONObject = withContext(Dispatchers.IO) {
+        val file = getRegistryFile(context)
+        if (!file.exists()) {
+            JSONObject().apply {
+                put("version", REGISTRY_VERSION)
+                put("files", JSONObject())
+            }
+        } else {
+            try {
+                JSONObject(file.readText())
+            } catch (e: Exception) {
+                Log.w(TAG, "registry corrupted, resetting", e)
+                JSONObject().apply {
+                    put("version", REGISTRY_VERSION)
+                    put("files", JSONObject())
+                }
+            }
+        }
+    }
+
+    private suspend fun saveRegistry(context: Context, registry: JSONObject) {
+        withContext(Dispatchers.IO) {
+            val file = getRegistryFile(context)
+            file.parentFile?.mkdirs()
+            file.writeText(registry.toString(2))
+        }
+    }
+
+    // ── Per-scheme Manifest ──
+
+    suspend fun loadManifest(context: Context, schemeId: String): JSONObject? = withContext(Dispatchers.IO) {
+        val file = getManifestFile(context, schemeId)
+        if (!file.exists()) return@withContext null
+        try {
+            JSONObject(file.readText())
+        } catch (e: Exception) {
+            Log.w(TAG, "manifest for $schemeId corrupted", e)
+            null
+        }
+    }
+
+    private suspend fun saveManifest(context: Context, schemeId: String, manifest: JSONObject) {
+        withContext(Dispatchers.IO) {
+            val file = getManifestFile(context, schemeId)
+            file.parentFile?.mkdirs()
+            file.writeText(manifest.toString(2))
+        }
+    }
+
+    suspend fun deleteManifest(context: Context, schemeId: String) {
+        withContext(Dispatchers.IO) {
+            getManifestFile(context, schemeId).delete()
+        }
+    }
+
+    // ── SHA256 helper ──
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes)
+            .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+
+    private fun fileSha256(file: File): String? {
+        return try {
+            sha256Hex(file.readBytes())
+        } catch (e: Exception) {
+            Log.w(TAG, "sha256 failed for ${file.name}", e)
+            null
+        }
+    }
+
+    // ── Conflict Detection ──
+
+    /**
+     * 检测待安装方案与已安装方案的文件冲突。
+     * 仅报告真正冲突（同名不同内容）；同内容视为共享依赖自动放行。
+     */
+    suspend fun detectConflicts(
+        context: Context,
+        schemeId: String,
+        targetFiles: List<String>,
+    ): List<FileConflictInfo> = withContext(Dispatchers.IO) {
+        val registry = loadRegistry(context)
+        val files = registry.optJSONObject("files") ?: return@withContext emptyList()
+        val rimeDir = SchemaManager.getRimeDir(context)
+        val conflicts = mutableListOf<FileConflictInfo>()
+
+        for (fileName in targetFiles) {
+            val entry = files.optJSONObject(fileName) ?: continue
+            val claimants = entry.optJSONArray("claimedBy") ?: continue
+            // 同一方案重新安装/升级：不视为冲突
+            if (jsonArrayToList(claimants).any { it == schemeId }) continue
+
+            val existingSha256 = entry.optString("sha256", "")
+            val targetFile = File(rimeDir, fileName)
+            if (!targetFile.exists()) continue
+
+            val newSha256 = fileSha256(targetFile) ?: continue
+            if (existingSha256 != newSha256) {
+                conflicts.add(FileConflictInfo(
+                    fileName = fileName,
+                    existingSha256 = existingSha256,
+                    newSha256 = newSha256,
+                    claimedBy = jsonArrayToList(claimants),
+                ))
+            }
+        }
+        conflicts
+    }
+
+    // ── Create Manifest After Installation ──
+
+    /**
+     * 安装成功后，为方案创建文件清单并更新全局注册表。
+     * @param extractedFiles 安装到 rime/ 的文件相对路径列表
+     */
+    suspend fun createManifest(
+        context: Context,
+        schemeId: String,
+        displayName: String,
+        version: String = "",
+        fromMarket: Boolean = true,
+        extractedFiles: List<String>,
+        dependencyIds: List<String> = emptyList(),
+    ): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val rimeDir = SchemaManager.getRimeDir(context)
+            val fileEntries = JSONObject()
+
+            for (fileName in extractedFiles) {
+                val file = File(rimeDir, fileName)
+                if (!file.exists()) continue
+                val sha256 = fileSha256(file) ?: continue
+                fileEntries.put(fileName, JSONObject().apply {
+                    put("sha256", sha256)
+                    put("size", file.length())
+                })
+            }
+
+            val manifest = JSONObject().apply {
+                put("schemeId", schemeId)
+                put("displayName", displayName)
+                put("version", version)
+                put("installedAt", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).format(Date()))
+                put("fromMarket", fromMarket)
+                put("legacy", false)
+                put("files", fileEntries)
+                if (dependencyIds.isNotEmpty()) {
+                    put("dependencies", JSONArray(dependencyIds))
+                }
+            }
+            saveManifest(context, schemeId, manifest)
+
+            // 更新全局注册表
+            val registry = loadRegistry(context)
+            val allFiles = registry.optJSONObject("files") ?: JSONObject()
+            val keysIt = fileEntries.keys()
+            while (keysIt.hasNext()) {
+                val fn = keysIt.next() as String
+                val fe = fileEntries.getJSONObject(fn)
+                val existing = allFiles.optJSONObject(fn)
+                if (existing != null) {
+                    val claimants = existing.optJSONArray("claimedBy") ?: JSONArray()
+                    if (!jsonArrayToList(claimants).contains(schemeId)) {
+                        claimants.put(schemeId)
+                    }
+                    existing.put("claimedBy", claimants)
+                } else {
+                    allFiles.put(fn, JSONObject().apply {
+                        put("sha256", fe.getString("sha256"))
+                        put("size", fe.getLong("size"))
+                        put("claimedBy", JSONArray(listOf(schemeId)))
+                    })
+                }
+            }
+            registry.put("files", allFiles)
+            saveRegistry(context, registry)
+
+            Log.i(TAG, "manifest created for $schemeId: ${fileEntries.length()} files")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "failed to create manifest for $schemeId", e)
+            false
+        }
+    }
+
+    /** 在安装依赖后，把依赖包 id 追加到主方案的清单中。 */
+    suspend fun appendDependencies(
+        context: Context,
+        schemeId: String,
+        depIds: List<String>,
+    ) {
+        if (depIds.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            try {
+                val manifest = loadManifest(context, schemeId) ?: return@withContext
+                val existing = mutableListOf<String>()
+                val depsArray = manifest.optJSONArray("dependencies")
+                if (depsArray != null) {
+                    for (i in 0 until depsArray.length()) {
+                        existing.add(depsArray.getString(i))
+                    }
+                }
+                val merged = (existing + depIds).distinct()
+                manifest.put("dependencies", JSONArray(merged))
+                saveManifest(context, schemeId, manifest)
+            } catch (e: Exception) {
+                Log.e(TAG, "appendDependencies failed for $schemeId", e)
+            }
+        }
+    }
+
+    // ── Uninstall Using Manifest ──
+
+    /**
+     * 基于清单卸载方案，整体删除方案所属的所有文件（不保留共享文件）。
+     */
+    suspend fun uninstallWithManifest(
+        context: Context,
+        schemeId: String,
+    ): UninstallResult = withContext(Dispatchers.IO) {
+        val manifest = loadManifest(context, schemeId)
+        if (manifest == null) {
+            return@withContext UninstallResult(
+                success = false,
+                manifestExisted = false,
+                message = "清单不存在，请使用传统方式删除",
+            )
+        }
+
+        try {
+            val files = manifest.optJSONObject("files") ?: JSONObject()
+            val rimeDir = SchemaManager.getRimeDir(context)
+            val registry = loadRegistry(context)
+            val allFiles = registry.optJSONObject("files") ?: JSONObject()
+
+            var deletedCount = 0
+            val keysIt = files.keys()
+            while (keysIt.hasNext()) {
+                val fn = keysIt.next() as String
+                val file = File(rimeDir, fn)
+                if (file.exists()) {
+                    file.delete()
+                }
+                // 从注册表中移除该文件的所有记录
+                allFiles.remove(fn)
+                deletedCount++
+            }
+
+            registry.put("files", allFiles)
+            saveRegistry(context, registry)
+            getManifestFile(context, schemeId).delete()
+
+            Log.i(TAG, "uninstalled $schemeId: $deletedCount files removed")
+            UninstallResult(
+                success = true,
+                deletedFiles = deletedCount,
+                message = "已删除 $deletedCount 个文件",
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "uninstall failed for $schemeId", e)
+            UninstallResult(success = false, message = "卸载失败: ${e.message}")
+        }
+    }
+
+    /** 检查一个文件是否列入受保护列表（不被方案覆盖和追踪）。 */
+    fun isProtectedSystemFile(name: String): Boolean {
+        val base = name.substringAfterLast('/')
+        return base == "default.yaml" ||
+               base == "xime.yaml" ||
+               name.startsWith(".registry") ||
+               name.startsWith(".manifests") ||
+               name.startsWith("build/")
+    }
+
+    // ── Migration ──
+
+    private const val KEY_MIGRATION_VERSION = "manifest_migration_version"
+    private const val MIGRATION_VERSION_CURRENT = 2
+    private const val BUILTIN_PACKAGE_ID = "builtin"
+
+    /**
+     * 为旧版已安装方案创建/合并遗留清单。
+     * v1 → v2：把旧版单条 per-schema 清单合并成一个 `builtin` 包。
+     */
+    suspend fun migrateLegacySchemas(context: Context) {
+        val prefs = SettingsPreferences.getPrefsPublic(context)
+        val prevVersion = prefs.getInt(KEY_MIGRATION_VERSION, 0)
+        if (prevVersion >= MIGRATION_VERSION_CURRENT) return
+
+        withContext(Dispatchers.IO) {
+            try {
+                val rimeDir = SchemaManager.getRimeDir(context)
+                getManifestsDir(context).mkdirs()
+                var changed = false
+
+                // 清理旧的 per-schema 清单（非 market、非 import、非 builtin）
+                val manifestDir = getManifestsDir(context)
+                if (manifestDir.exists()) {
+                    manifestDir.listFiles { f -> f.name.endsWith(".json") }?.forEach { file ->
+                        try {
+                            val m = JSONObject(file.readText())
+                            val id = m.getString("schemeId")
+                            if (m.optBoolean("fromMarket", false)) return@forEach
+                            if (id == BUILTIN_PACKAGE_ID) return@forEach
+                            if (id.startsWith("import_")) return@forEach
+                            file.delete()
+                            changed = true
+                        } catch (_: Exception) { }
+                    }
+                }
+
+                // 重新扫描所有 .schema.yaml，归入 builtin 包
+                val schemaFiles = rimeDir.listFiles { f -> f.name.endsWith(".schema.yaml") }
+                    ?: emptyArray()
+                if (schemaFiles.isNotEmpty()) {
+                    val fileEntries = JSONObject()
+                    val allYamlFiles = mutableSetOf<String>()
+
+                    for (sf in schemaFiles) {
+                        val schemaId = sf.name.removeSuffix(".schema.yaml")
+                        allYamlFiles.add(sf.name)
+                        val dictName = SchemaManager.getReferencedDictName(context, schemaId) ?: schemaId
+                        val dictFile = File(rimeDir, "$dictName.dict.yaml")
+                        if (dictFile.exists()) allYamlFiles.add("$dictName.dict.yaml")
+                    }
+
+                    for (fn in allYamlFiles) {
+                        val file = File(rimeDir, fn)
+                        if (!file.exists()) continue
+                        val sha256 = fileSha256(file) ?: continue
+                        fileEntries.put(fn, JSONObject().apply {
+                            put("sha256", sha256)
+                            put("size", file.length())
+                        })
+                    }
+
+                    val manifest = JSONObject().apply {
+                        put("schemeId", BUILTIN_PACKAGE_ID)
+                        put("displayName", "系统内置方案")
+                        put("version", "")
+                        put("installedAt", SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).format(Date()))
+                        put("fromMarket", false)
+                        put("legacy", true)
+                        put("files", fileEntries)
+                    }
+                    saveManifest(context, BUILTIN_PACKAGE_ID, manifest)
+
+                    val registry = loadRegistry(context)
+                    val allFiles = registry.optJSONObject("files") ?: JSONObject()
+                    val keysIt = fileEntries.keys()
+                    while (keysIt.hasNext()) {
+                        val fn = keysIt.next() as String
+                        val fe = fileEntries.getJSONObject(fn)
+                        allFiles.put(fn, JSONObject().apply {
+                            put("sha256", fe.getString("sha256"))
+                            put("size", fe.getLong("size"))
+                            put("claimedBy", JSONArray(listOf(BUILTIN_PACKAGE_ID)))
+                        })
+                    }
+                    registry.put("files", allFiles)
+                    saveRegistry(context, registry)
+                    changed = true
+                }
+
+                if (changed) {
+                    Log.i(TAG, "migration v2: consolidated into '$BUILTIN_PACKAGE_ID'")
+                }
+
+                prefs.edit().putInt(KEY_MIGRATION_VERSION, MIGRATION_VERSION_CURRENT).apply()
+            } catch (e: Exception) {
+                Log.e(TAG, "legacy migration failed", e)
+            }
+        }
+    }
+
+    // ── Market Package Listing ──
+
+    data class MarketPackageInfo(
+        val packageId: String,
+        val displayName: String,
+        val version: String,
+        val schemaCount: Int,
+        val fileCount: Int,
+    )
+
+    /** 获取所有已安装方案的包信息（从清单目录读取）。 */
+    suspend fun getInstalledPackages(context: Context): List<MarketPackageInfo> = withContext(Dispatchers.IO) {
+        val manifestDir = getManifestsDir(context)
+        if (!manifestDir.exists()) return@withContext emptyList()
+
+        manifestDir.listFiles { f -> f.name.endsWith(".json") }
+            ?.mapNotNull { file ->
+                try {
+                    val manifest = JSONObject(file.readText())
+                    val files = manifest.optJSONObject("files") ?: JSONObject()
+                    val schemaCount = files.keys().asSequence().count { key ->
+                        (key as String).endsWith(".schema.yaml")
+                    }
+                    val id = manifest.getString("schemeId")
+                    MarketPackageInfo(
+                        packageId = id,
+                        displayName = manifest.optString("displayName", id),
+                        version = manifest.optString("version", ""),
+                        schemaCount = schemaCount,
+                        fileCount = files.length(),
+                    )
+                } catch (_: Exception) { null }
+            }?.sortedBy { it.displayName } ?: emptyList()
+    }
+
+    // ── Utilities ──
+
+    private fun jsonArrayToList(arr: JSONArray): List<String> {
+        val result = mutableListOf<String>()
+        for (i in 0 until arr.length()) {
+            result.add(arr.getString(i))
+        }
+        return result
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -42,10 +42,10 @@ object SchemaManifestManager {
     private const val REGISTRY_VERSION = 1
 
     fun getRegistryFile(context: Context): File =
-        File(SchemaManager.getRimeDir(context), REGISTRY_FILE)
+        File(context.filesDir, REGISTRY_FILE)
 
     fun getManifestsDir(context: Context): File =
-        File(SchemaManager.getRimeDir(context), MANIFESTS_DIR)
+        File(context.filesDir, MANIFESTS_DIR)
 
     fun getManifestFile(context: Context, schemeId: String): File =
         File(getManifestsDir(context), "$schemeId.json")
@@ -287,25 +287,72 @@ object SchemaManifestManager {
             val registry = loadRegistry(context)
             val allFiles = registry.optJSONObject("files") ?: JSONObject()
 
-            var deletedCount = 0
+            // 收集清单中所有方案 ID，用于后续清理衍生文件
+            val schemaIds = mutableSetOf<String>()
             val keysIt = files.keys()
             while (keysIt.hasNext()) {
                 val fn = keysIt.next() as String
-                val file = File(rimeDir, fn)
-                if (file.exists()) {
-                    file.delete()
-                }
-                // 清理对应的编译缓存
                 if (fn.endsWith(".schema.yaml")) {
-                    val schemaId = fn.removeSuffix(".schema.yaml")
-                    val buildDir = SchemaManager.getBuildDir(context)
-                    buildDir.listFiles { f ->
-                        f.name.startsWith(schemaId + ".")
-                    }?.forEach { it.delete() }
+                    schemaIds.add(fn.removeSuffix(".schema.yaml"))
                 }
-                // 从注册表中移除该文件的所有记录
-                allFiles.remove(fn)
-                deletedCount++
+            }
+
+            // 在删除 .custom.yaml 之前，先读取每个方案的 custom_phrase dict 名
+            val customPhraseNames = schemaIds.associateWith { sid ->
+                PersonalDictManager.getCustomPhraseDictName(rimeDir, sid)
+            }
+
+            var deletedCount = 0
+
+            // 删除清单记录的文件（检查 registry claimedBy，多包共享时不删除）
+            val keysIt2 = files.keys()
+            while (keysIt2.hasNext()) {
+                val fn = keysIt2.next() as String
+                val claimEntry = allFiles.optJSONObject(fn)
+                val claimants = if (claimEntry != null) {
+                    val arr = claimEntry.optJSONArray("claimedBy")
+                    if (arr != null) jsonArrayToList(arr) else emptyList()
+                } else emptyList()
+
+                if (claimants.size <= 1 || (claimants.size == 1 && claimants[0] == schemeId)) {
+                    val file = File(rimeDir, fn)
+                    if (file.exists()) { file.delete(); deletedCount++ }
+                    allFiles.remove(fn)
+                } else {
+                    // 还有其他包声明该文件：仅移除当前包，保留文件
+                    val updated = claimants.filter { it != schemeId }
+                    claimEntry!!.put("claimedBy", JSONArray(updated))
+                }
+            }
+
+            // 清理每个方案由于 ensureSchemaPack 等生成的衍生文件
+            val buildDir = SchemaManager.getBuildDir(context)
+            for (sid in schemaIds) {
+                val customYaml = File(rimeDir, "$sid.custom.yaml")
+                if (customYaml.exists()) { customYaml.delete(); deletedCount++ }
+
+                val mergedDict = File(rimeDir, "${sid}_merged.dict.yaml")
+                if (mergedDict.exists()) { mergedDict.delete(); deletedCount++ }
+
+                val dictName = customPhraseNames[sid] ?: "custom_phrase"
+                val phraseFile = File(rimeDir, "$dictName.txt")
+                if (phraseFile.exists()) {
+                    // 检查 registry 确认没有其他包声明这个短语文件
+                    val pfEntry = allFiles.optJSONObject("$dictName.txt")
+                    val pfClaimants = if (pfEntry != null) {
+                        val arr = pfEntry.optJSONArray("claimedBy")
+                        if (arr != null) jsonArrayToList(arr) else emptyList()
+                    } else emptyList()
+                    val otherClaimants = pfClaimants.filter { it != schemeId }
+                    if (otherClaimants.isEmpty()) {
+                        phraseFile.delete(); deletedCount++
+                    }
+                }
+
+                if (buildDir.exists()) {
+                    buildDir.listFiles { f -> f.name.startsWith("$sid.") }
+                        ?.forEach { it.delete(); deletedCount++ }
+                }
             }
 
             registry.put("files", allFiles)
@@ -329,15 +376,13 @@ object SchemaManifestManager {
         val base = name.substringAfterLast('/')
         return base == "default.yaml" ||
                base == "xime.yaml" ||
-               name.startsWith(".registry") ||
-               name.startsWith(".manifests") ||
                name.startsWith("build/")
     }
 
     // ── Migration ──
 
     private const val KEY_MIGRATION_VERSION = "manifest_migration_version"
-    private const val MIGRATION_VERSION_CURRENT = 2
+    private const val MIGRATION_VERSION_CURRENT = 3
     private const val BUILTIN_PACKAGE_ID = "builtin"
 
     /**
@@ -373,12 +418,44 @@ object SchemaManifestManager {
         }
     }
 
+    /** 迁移 .manifests/ 和 .registry.json 从 rime/ 到 filesDir/。 */
+    private suspend fun migrateManifestsLocation(context: Context) = withContext(Dispatchers.IO) {
+        val rimeDir = SchemaManager.getRimeDir(context)
+        val oldManifests = File(rimeDir, MANIFESTS_DIR)
+        val oldRegistry = File(rimeDir, REGISTRY_FILE)
+        val newManifests = getManifestsDir(context)
+        val newRegistry = getRegistryFile(context)
+
+        try {
+            if (oldManifests.exists() && !newManifests.exists()) {
+                oldManifests.renameTo(newManifests)
+                Log.i(TAG, "Migrated .manifests/ from rime/ to filesDir/")
+            } else if (oldManifests.exists()) {
+                oldManifests.deleteRecursively()
+                Log.i(TAG, "Removed old rime/.manifests/ (already at new location)")
+            }
+
+            if (oldRegistry.exists() && !newRegistry.exists()) {
+                oldRegistry.renameTo(newRegistry)
+                Log.i(TAG, "Migrated .registry.json from rime/ to filesDir/")
+            } else if (oldRegistry.exists()) {
+                oldRegistry.delete()
+                Log.i(TAG, "Removed old rime/.registry.json (already at new location)")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to migrate manifests location", e)
+        }
+    }
+
     suspend fun migrateLegacySchemas(context: Context) {
         val prefs = SettingsPreferences.getPrefsPublic(context)
         val prevVersion = prefs.getInt(KEY_MIGRATION_VERSION, 0)
 
         withContext(Dispatchers.IO) {
             try {
+                // v3: 把 .manifests/ 和 .registry.json 从 rime/ 移到 filesDir/
+                migrateManifestsLocation(context)
+
                 // 确保 market/builtin/ 存在（迁移前没有此目录的旧版本会在此补齐）
                 ensureBuiltinBackup(context)
 
@@ -404,24 +481,20 @@ object SchemaManifestManager {
                     }
                 }
 
-                // 重新扫描所有 .schema.yaml，归入 builtin 包
-                val schemaFiles = rimeDir.listFiles { f -> f.name.endsWith(".schema.yaml") }
-                    ?: emptyArray()
-                if (schemaFiles.isNotEmpty()) {
+                // 扫描 rime/ 下所有文件，归入 builtin 包（排除系统文件与 build/）
+                val allFilesInRime = mutableSetOf<String>()
+                rimeDir.walkTopDown().forEach { f ->
+                    if (!f.isFile) return@forEach
+                    val relPath = f.toRelativeString(rimeDir).replace('\\', '/')
+                    if (isProtectedSystemFile(relPath)) return@forEach
+                    allFilesInRime.add(relPath)
+                }
+                if (allFilesInRime.isNotEmpty()) {
                     val fileEntries = JSONObject()
-                    val allYamlFiles = mutableSetOf<String>()
-
-                    for (sf in schemaFiles) {
-                        val schemaId = sf.name.removeSuffix(".schema.yaml")
-                        allYamlFiles.add(sf.name)
-                        val dictName = SchemaManager.getReferencedDictName(context, schemaId) ?: schemaId
-                        val dictFile = File(rimeDir, "$dictName.dict.yaml")
-                        if (dictFile.exists()) allYamlFiles.add("$dictName.dict.yaml")
-                    }
 
                     val builtinDir = SchemaManager.getMarketDir(context, BUILTIN_PACKAGE_ID)
                     builtinDir.mkdirs()
-                    for (fn in allYamlFiles) {
+                    for (fn in allFilesInRime) {
                         val file = File(rimeDir, fn)
                         if (!file.exists()) continue
                         val sha256 = fileSha256(file) ?: continue
@@ -431,6 +504,8 @@ object SchemaManifestManager {
                         })
                         file.copyTo(File(builtinDir, fn), overwrite = true)
                     }
+
+                    if (fileEntries.length() == 0) return@withContext
 
                     val manifest = JSONObject().apply {
                         put("schemeId", BUILTIN_PACKAGE_ID)
@@ -472,6 +547,15 @@ object SchemaManifestManager {
     }
 
     // ── Market Package Listing ──
+
+    /** 从注册表查询指定 schemaId 所属的包 ID。 */
+    suspend fun getPackageIdForSchema(context: Context, schemaId: String): String? = withContext(Dispatchers.IO) {
+        val registry = loadRegistry(context)
+        val files = registry.optJSONObject("files") ?: return@withContext null
+        val entry = files.optJSONObject("$schemaId.schema.yaml") ?: return@withContext null
+        val claimants = entry.optJSONArray("claimedBy") ?: return@withContext null
+        return@withContext if (claimants.length() > 0) claimants.getString(0) else null
+    }
 
     data class MarketPackageInfo(
         val packageId: String,

--- a/app/src/main/java/com/kingzcheung/xime/settings/WirelessImportHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/WirelessImportHelper.kt
@@ -132,54 +132,32 @@ class WirelessImportHelper(private val context: Context) {
                                 val contentStart = raf.filePointer
                                 val contentLen = partEnd - contentStart
 
-                                when {
-                                    name.endsWith(".zip", ignoreCase = true) ||
-                                    name.endsWith(".tar.gz", ignoreCase = true) ||
-                                    name.endsWith(".tgz", ignoreCase = true) -> {
-                                        val isTarGz = name.endsWith(".tar.gz", ignoreCase = true) || name.endsWith(".tgz", ignoreCase = true)
-                                        val istream = object : java.io.InputStream() {
-                                            var remaining = contentLen
-                                            var buf8 = ByteArray(8192)
-                                            override fun read(): Int {
-                                                if (remaining <= 0) return -1
-                                                val n = raf.read(buf8, 0, 1)
-                                                if (n <= 0) return -1
-                                                remaining--
-                                                return buf8[0].toInt() and 0xff
-                                            }
-                                            override fun read(b: ByteArray, off: Int, len: Int): Int {
-                                                if (remaining <= 0) return -1
-                                                val cnt = if (remaining < len) remaining.toInt() else len
-                                                val n = raf.read(b, off, cnt)
-                                                if (n <= 0) return -1
-                                                remaining -= n
-                                                return n
-                                            }
-                                            override fun available() = minOf(remaining, Int.MAX_VALUE.toLong()).toInt()
-                                        }
-                                        val ok = if (isTarGz)
-                                            SchemaManager.importTarGzFromStream(istream, rimeDir)
-                                        else
-                                            SchemaManager.importZipFromStream(istream, rimeDir)
-                                        if (ok) {
-                                            saved = true
-                                            _uploadResults.trySend(UploadResult(fileName = name, success = true))
-                                        } else {
-                                            _uploadResults.trySend(UploadResult(fileName = name, success = false, error = "解压失败"))
-                                        }
-                                    }
-                                    name.endsWith(".yaml") || name.endsWith(".schema.yaml") || name.endsWith(".dict.yaml") -> {
-                                        raf.seek(contentStart)
-                                        val data = ByteArray(contentLen.toInt())
-                                        raf.readFully(data)
-                                        File(rimeDir, name).writeBytes(data)
-                                        saved = true
-                                        _uploadResults.trySend(UploadResult(fileName = name, success = true))
-                                    }
-                                    else -> {
-                                        _uploadResults.trySend(UploadResult(fileName = name, success = false, error = "不支持的文件类型"))
-                                    }
-                                }
+                when {
+                    name.endsWith(".zip", ignoreCase = true) ||
+                    name.endsWith(".tar.gz", ignoreCase = true) ||
+                    name.endsWith(".tgz", ignoreCase = true) ||
+                    name.endsWith(".yaml") || name.endsWith(".schema.yaml") || name.endsWith(".dict.yaml") -> {
+                        // 保存到 market/{importId}/，不直接解压到 rime/
+                        val importId = SchemaManager.generateImportId()
+                        val pkgDir = if (name.endsWith(".yaml") || name.endsWith(".schema.yaml") || name.endsWith(".dict.yaml"))
+                            SchemaManager.getMarketDir(context, importId)
+                        else
+                            SchemaManager.getMarketDir(context, importId)
+                        pkgDir.mkdirs()
+                        val targetFile = File(pkgDir, name)
+
+                        raf.seek(contentStart)
+                        val data = ByteArray(contentLen.toInt())
+                        raf.readFully(data)
+                        targetFile.writeBytes(data)
+
+                        saved = true
+                        _uploadResults.trySend(UploadResult(fileName = name, success = true))
+                    }
+                    else -> {
+                        _uploadResults.trySend(UploadResult(fileName = name, success = false, error = "不支持的文件类型"))
+                    }
+                }
                                 pos = nextB + 2
                             }
                         }

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -181,7 +181,7 @@ object XimeIndexSource {
 
     /**
      * 从 market 目录安装已下载的方案到 rime 目录（解压/复制 + 依赖补齐）。
-     * 安装前扫描冲突文件并记录日志，安装仍然正常进行。
+     * 安装前检测文件冲突（同名且内容不同），发现真正冲突则阻止安装。
      */
     suspend fun installFromMarket(
         context: Context,
@@ -192,12 +192,15 @@ object XimeIndexSource {
             return@withContext InstallResult(false, failureReason = "压缩包不存在，请先下载")
         }
 
-        // 安装前检测冲突（仅警告，不阻止安装）
+        // 安装前检测真正的文件冲突（同名且内容不同），阻止安装
         val targetFiles = SchemaManager.listInstallTargetFiles(context, scheme.id)
-        val rimeDir = SchemaManager.getRimeDir(context)
-        val conflicts = targetFiles.filter { File(rimeDir, it).exists() }
-        if (conflicts.isNotEmpty()) {
-            Log.w(TAG, "installFromMarket ${scheme.id}: 以下文件将被覆盖：${conflicts.joinToString("、")}")
+        val realConflicts = SchemaManifestManager.detectConflicts(context, scheme.id, targetFiles)
+        if (realConflicts.isNotEmpty()) {
+            val details = realConflicts.joinToString("、") {
+                "${it.fileName}（已被 ${it.claimedBy.joinToString("、")} 使用）"
+            }
+            Log.w(TAG, "installFromMarket ${scheme.id}: 文件冲突：$details")
+            return@withContext InstallResult(false, failureReason = "文件冲突，无法安装：$details")
         }
 
         val before = SchemaManager.discoverSchemas(context).map { it.schemaId }.toSet()
@@ -227,6 +230,20 @@ object XimeIndexSource {
         )
         val unresolved = (completion.unresolved + completion.stillMissingFiles).distinct()
         if (unresolved.isNotEmpty()) Log.w(TAG, "installFromMarket ${scheme.id}: unresolved=$unresolved")
+
+        // 创建文件清单并注册到全局注册表
+        SchemaManifestManager.createManifest(
+            context = context,
+            schemeId = scheme.id,
+            displayName = scheme.name,
+            version = scheme.currentVersion,
+            fromMarket = true,
+            extractedFiles = targetFiles,
+            dependencyIds = completion.downloaded,
+        )
+
+        // 记录到已安装列表
+        SettingsPreferences.addInstalledMarketId(context, scheme.id)
 
         InstallResult(success = true, unresolvedDeps = unresolved)
     }

--- a/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/XimeIndexSource.kt
@@ -191,60 +191,21 @@ object XimeIndexSource {
         if (!SchemaManager.isSchemeDownloaded(context, scheme.id)) {
             return@withContext InstallResult(false, failureReason = "压缩包不存在，请先下载")
         }
-
-        // 安装前检测真正的文件冲突（同名且内容不同），阻止安装
-        val targetFiles = SchemaManager.listInstallTargetFiles(context, scheme.id)
-        val realConflicts = SchemaManifestManager.detectConflicts(context, scheme.id, targetFiles)
-        if (realConflicts.isNotEmpty()) {
-            val details = realConflicts.joinToString("、") {
-                "${it.fileName}（已被 ${it.claimedBy.joinToString("、")} 使用）"
-            }
-            Log.w(TAG, "installFromMarket ${scheme.id}: 文件冲突：$details")
-            return@withContext InstallResult(false, failureReason = "文件冲突，无法安装：$details")
-        }
-
-        val before = SchemaManager.discoverSchemas(context).map { it.schemaId }.toSet()
-        val ok = SchemaManager.installFromMarketToRime(context, scheme.id)
-        if (!ok) return@withContext InstallResult(false, failureReason = "安装失败")
-
-        val after = SchemaManager.discoverSchemas(context).map { it.schemaId }.toSet()
-        val newIds = after - before
-        val installedSchemaId = when {
-            scheme.id in newIds -> scheme.id
-            newIds.size == 1 -> newIds.first()
-            newIds.isNotEmpty() -> {
-                Log.w(TAG, "installFromMarket ${scheme.id}: multiple new schemas detected: $newIds, using ${newIds.first()}")
-                newIds.first()
-            }
-            else -> {
-                Log.w(TAG, "installFromMarket ${scheme.id}: no new schema detected, falling back to market id")
-                scheme.id
-            }
-        }
-
-        val completion = RimeDependencyResolver.complete(
+        val result = SchemaManager.installPackageFromMarketDir(
             context = context,
-            schemaId = installedSchemaId,
-            dependencies = scheme.dependencies,
-            resolveUrl = resolveDepUrl,
-        )
-        val unresolved = (completion.unresolved + completion.stillMissingFiles).distinct()
-        if (unresolved.isNotEmpty()) Log.w(TAG, "installFromMarket ${scheme.id}: unresolved=$unresolved")
-
-        // 创建文件清单并注册到全局注册表
-        SchemaManifestManager.createManifest(
-            context = context,
-            schemeId = scheme.id,
+            packageId = scheme.id,
             displayName = scheme.name,
             version = scheme.currentVersion,
             fromMarket = true,
-            extractedFiles = targetFiles,
-            dependencyIds = completion.downloaded,
+            dependencies = scheme.dependencies,
+            resolveDepUrl = resolveDepUrl,
         )
-
-        // 记录到已安装列表
-        SettingsPreferences.addInstalledMarketId(context, scheme.id)
-
-        InstallResult(success = true, unresolvedDeps = unresolved)
+        if (!result.success) {
+            val reason = result.failureReason ?: result.conflicts.joinToString("、") { c ->
+                "${c.fileName}（已被 ${c.claimedBy.joinToString("、")} 使用）"
+            }
+            return@withContext InstallResult(false, failureReason = reason)
+        }
+        InstallResult(success = true, unresolvedDeps = result.unresolvedDeps)
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/DictionarySettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/DictionarySettingsScreen.kt
@@ -43,7 +43,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -61,6 +63,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.kingzcheung.xime.settings.DictEntry
+import com.kingzcheung.xime.viewmodel.CustomPhraseUiState
+import com.kingzcheung.xime.viewmodel.CustomPhraseViewModel
 import com.kingzcheung.xime.viewmodel.PersonalDictUiState
 import com.kingzcheung.xime.viewmodel.PersonalDictViewModel
 
@@ -71,10 +75,11 @@ fun DictionarySettingsContent(
 ) {
     val viewModel: PersonalDictViewModel = viewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    var showPersonalDict by remember { mutableStateOf(true) }
+    var selectedDictTab by remember { mutableIntStateOf(0) }
     var showSchemaMenu by remember { mutableStateOf(false) }
-
+    val customPhraseVM: CustomPhraseViewModel = viewModel(key = "dict_custom_phrase")
+    val customPhraseState by customPhraseVM.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(uiState.selectedSchema) { customPhraseVM.setSchema(uiState.selectedSchema) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -117,9 +122,12 @@ fun DictionarySettingsContent(
             )
         },
         floatingActionButton = {
-            if (showPersonalDict) {
+            if (selectedDictTab == 0 || selectedDictTab == 1) {
                 FloatingActionButton(
-                    onClick = { viewModel.showAddDialog() },
+                    onClick = {
+                        if (selectedDictTab == 0) viewModel.showAddDialog()
+                        else customPhraseVM.showAddDialog()
+                    },
                     containerColor = MaterialTheme.colorScheme.primary
                 ) {
                     Icon(Icons.Default.Add, contentDescription = "添加", tint = MaterialTheme.colorScheme.onPrimary)
@@ -129,14 +137,16 @@ fun DictionarySettingsContent(
     ) { innerPadding ->
         Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
             Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
-                TabButton("个人词库", selected = showPersonalDict, onClick = { showPersonalDict = true }, modifier = Modifier.weight(1f))
+                TabButton("个人词库", selected = selectedDictTab == 0, onClick = { selectedDictTab = 0 }, modifier = Modifier.weight(1f))
                 Spacer(modifier = Modifier.width(8.dp))
-                TabButton("方案词库", selected = !showPersonalDict, onClick = { showPersonalDict = false }, modifier = Modifier.weight(1f))
+                TabButton("自定义短语", selected = selectedDictTab == 1, onClick = { selectedDictTab = 1 }, modifier = Modifier.weight(1f))
+                Spacer(modifier = Modifier.width(8.dp))
+                TabButton("方案词库", selected = selectedDictTab == 2, onClick = { selectedDictTab = 2 }, modifier = Modifier.weight(1f))
             }
-            if (showPersonalDict) {
-                SchemaDictContent(viewModel = viewModel, uiState = uiState)
-            } else {
-                SchemaDictBrowserPanel()
+            when (selectedDictTab) {
+                0 -> SchemaDictContent(viewModel = viewModel, uiState = uiState)
+                 1 -> CustomPhraseTabContent(viewModel = customPhraseVM, uiState = customPhraseState)
+                2 -> SchemaDictBrowserPanel()
             }
         }
     }
@@ -333,5 +343,149 @@ private fun UsageHint() {
         Text("个人词库与自定义短语的区别 → 查看使用说明",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.primary)
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun CustomPhraseTabContent(
+    viewModel: CustomPhraseViewModel,
+    uiState: CustomPhraseUiState,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Spacer(Modifier.height(12.dp))
+        Surface(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            shape = RoundedCornerShape(28.dp),
+            tonalElevation = 2.dp,
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Search, contentDescription = null,
+                    tint = if (uiState.searchQuery.isNotEmpty()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(22.dp))
+                Spacer(Modifier.width(12.dp))
+                BasicTextField(value = uiState.searchQuery, onValueChange = { viewModel.setSearchQuery(it) },
+                    modifier = Modifier.weight(1f), singleLine = true,
+                    textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                    decorationBox = { innerTextField ->
+                        Box { if (uiState.searchQuery.isEmpty()) Text("搜索", color = MaterialTheme.colorScheme.onSurfaceVariant); innerTextField() }
+                    })
+                if (uiState.searchQuery.isNotEmpty()) {
+                    Spacer(Modifier.width(8.dp))
+                    IconButton(onClick = { viewModel.clearSearch() }, modifier = Modifier.size(24.dp)) {
+                        Icon(Icons.Default.Clear, contentDescription = "清除搜索", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else if (uiState.entries.isEmpty()) {
+            UsageHint()
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                itemsIndexed(uiState.filteredEntries, key = { i, _ -> "cp_$i" }) { i, entry ->
+                    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(entry.word, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                                Spacer(Modifier.height(2.dp))
+                                Text(entry.code, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.outline)
+                                if (entry.weight != null) {
+                                    Text("权重: ${entry.weight}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.outline)
+                                }
+                            }
+                            IconButton(onClick = {
+                                viewModel.setEditing(i, entry)
+                                viewModel.showEditDialog()
+                            }, modifier = Modifier.size(36.dp)) {
+                                Icon(Icons.Default.Edit, contentDescription = "编辑", modifier = Modifier.size(18.dp))
+                            }
+                            IconButton(onClick = { viewModel.deleteEntry(i) }, modifier = Modifier.size(36.dp)) {
+                                Icon(Icons.Default.Delete, contentDescription = "删除", tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(18.dp))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (uiState.showAddDialog) {
+        PhraseEditDialog(
+            title = "添加快捷短语",
+            word = uiState.editWord,
+            code = uiState.editCode,
+            weight = uiState.editWeight,
+            onWordChange = viewModel::setEditWord,
+            onCodeChange = viewModel::setEditCode,
+            onWeightChange = viewModel::setEditWeight,
+            onConfirm = { viewModel.addEntry(uiState.editWord, uiState.editCode, uiState.editWeight.toIntOrNull()); viewModel.hideAddDialog() },
+            onDismiss = viewModel::hideAddDialog,
+        )
+    }
+    if (uiState.showEditDialog) {
+        PhraseEditDialog(
+            title = "编辑快捷短语",
+            word = uiState.editWord,
+            code = uiState.editCode,
+            weight = uiState.editWeight,
+            onWordChange = viewModel::setEditWord,
+            onCodeChange = viewModel::setEditCode,
+            onWeightChange = viewModel::setEditWeight,
+            onConfirm = { viewModel.updateEntry(uiState.editIndex, uiState.editWord, uiState.editCode, uiState.editWeight.toIntOrNull()); viewModel.hideEditDialog() },
+            onDismiss = viewModel::hideEditDialog,
+        )
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun PhraseEditDialog(
+    title: String,
+    word: String,
+    code: String,
+    weight: String,
+    onWordChange: (String) -> Unit,
+    onCodeChange: (String) -> Unit,
+    onWeightChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(),
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 20.dp))
+            OutlinedTextField(value = word, onValueChange = onWordChange,
+                label = { Text("短语") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(value = code, onValueChange = onCodeChange,
+                label = { Text("编码") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(value = weight, onValueChange = onWeightChange,
+                label = { Text("权重（可选，越大越优先）") }, shape = RoundedCornerShape(12.dp), singleLine = true, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(24.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text("取消") }
+                Spacer(Modifier.width(8.dp))
+                Surface(
+                    modifier = Modifier.clickable(enabled = word.isNotBlank() && code.isNotBlank(), onClick = onConfirm),
+                    shape = RoundedCornerShape(10.dp), color = MaterialTheme.colorScheme.primary
+                ) {
+                    Text("确定", modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                        style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimary)
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+        }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaLocalScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaLocalScreen.kt
@@ -1,0 +1,272 @@
+package com.kingzcheung.xime.ui.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.kingzcheung.xime.viewmodel.LocalPackageItem
+import com.kingzcheung.xime.viewmodel.SchemaLocalViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SchemaLocalContent(
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val viewModel: SchemaLocalViewModel = viewModel()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState.toastMessage) {
+        uiState.toastMessage?.let { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            viewModel.clearToast()
+        }
+    }
+
+    if (uiState.conflictPackageId != null) {
+        AlertDialog(
+            onDismissRequest = { viewModel.cancelConflictInstall() },
+            title = { Text("文件冲突") },
+            text = {
+                Text("需要先卸载冲突方案：${uiState.conflictingSchemeIds.joinToString("、")}，是否继续？")
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.confirmInstallWithUninstall() }) {
+                    Text("确认卸载并安装")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.cancelConflictInstall() }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("本地方案") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.loadLocalPackages() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "刷新")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (uiState.packages.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            if (uiState.isLoading) "加载中…" else "暂无本地方案",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    item {
+                        Spacer(Modifier.height(4.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            val installedCount = uiState.packages.count { it.installed }
+                            val downloadedCount = uiState.packages.count { it.downloaded }
+                            Text(
+                                "共 ${uiState.packages.size} 个（已安装 $installedCount，可安装 ${downloadedCount - installedCount}）",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                        }
+                        Spacer(Modifier.height(8.dp))
+                    }
+                    items(uiState.packages, key = { it.packageId }) { item ->
+                        LocalPackageCard(
+                            item = item,
+                            installing = uiState.installingId == item.packageId,
+                            onInstall = { viewModel.installPackage(item) },
+                            onDelete = { viewModel.deleteDownloaded(item) },
+                            onUninstall = { viewModel.uninstall(item) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalPackageCard(
+    item: LocalPackageItem,
+    installing: Boolean,
+    onInstall: () -> Unit,
+    onDelete: () -> Unit,
+    onUninstall: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    item.displayName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                Spacer(Modifier.width(8.dp))
+                val tagColor = when {
+                    item.installed -> MaterialTheme.colorScheme.primary
+                    item.downloaded -> MaterialTheme.colorScheme.outline
+                    else -> MaterialTheme.colorScheme.error
+                }
+                TagText(
+                    if (item.installed) "已安装" else if (item.downloaded) "已下载" else "未知",
+                    tagColor,
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "ID: ${item.packageId}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+            if (item.version.isNotEmpty() || item.fileCount > 0) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    buildString {
+                        if (item.version.isNotEmpty()) append("版本: ${item.version}")
+                        if (item.fileCount > 0) {
+                            if (isNotEmpty()) append(" · ")
+                            append("${item.fileCount} 个文件")
+                        }
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                when {
+                    installing -> {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                            Spacer(Modifier.width(6.dp))
+                            Text("安装中…", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    item.installed -> {
+                        OutlinedButton(onClick = onUninstall) { Text("卸载") }
+                        Spacer(Modifier.width(8.dp))
+                        if (!item.isImport) {
+                            OutlinedButton(onClick = onUninstall, enabled = false) {
+                                Text("已从市场安装")
+                            }
+                        }
+                    }
+                    item.downloaded -> OutlinedButton(onClick = onInstall) { Text("安装") }
+                }
+                Spacer(Modifier.weight(1f))
+                if (item.downloaded) {
+                    IconButton(
+                        onClick = onDelete,
+                        modifier = Modifier.size(36.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "删除下载文件",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagText(text: String, color: androidx.compose.ui.graphics.Color) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = color.copy(alpha = 0.12f),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaLocalScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaLocalScreen.kt
@@ -228,17 +228,11 @@ private fun LocalPackageCard(
                     }
                     item.installed -> {
                         OutlinedButton(onClick = onUninstall) { Text("卸载") }
-                        Spacer(Modifier.width(8.dp))
-                        if (!item.isImport) {
-                            OutlinedButton(onClick = onUninstall, enabled = false) {
-                                Text("已从市场安装")
-                            }
-                        }
                     }
                     item.downloaded -> OutlinedButton(onClick = onInstall) { Text("安装") }
                 }
                 Spacer(Modifier.weight(1f))
-                if (item.downloaded) {
+                if (item.packageId != "builtin" && item.downloaded) {
                     IconButton(
                         onClick = onDelete,
                         modifier = Modifier.size(36.dp),

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaMarketScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -72,6 +73,7 @@ import com.kingzcheung.xime.viewmodel.SchemaMarketViewModel
 fun SchemaMarketContent(
     onBack: () -> Unit,
     onNavigateToDetail: (String) -> Unit = {},
+    onNavigateToLocal: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val viewModel: SchemaMarketViewModel = viewModel()
@@ -94,6 +96,10 @@ fun SchemaMarketContent(
                     }
                 },
                 actions = {
+                    TextButton(onClick = onNavigateToLocal) {
+                        Text("本地管理", style = MaterialTheme.typography.labelMedium)
+                    }
+                    Spacer(Modifier.width(4.dp))
                     IconButton(
                         onClick = { viewModel.loadSchemes(manual = true) },
                         enabled = !uiState.isLoading,
@@ -199,18 +205,12 @@ fun SchemaMarketContent(
                             item = item,
                             downloading = uiState.downloadingId == item.scheme.id,
                             downloadProgress = uiState.downloadProgress,
-                            extracting = uiState.extractingId == item.scheme.id,
                             downloaded = item.scheme.id in uiState.downloadedIds,
-                            installed = item.scheme.id in uiState.installedIds,
                             sha256Status = uiState.sha256Status[item.scheme.id],
-                            deploying = uiState.isDeploying,
                             selectedVersion = uiState.selectedVersions[item.scheme.id]
                                 ?: item.scheme.currentVersion,
                             onSelectVersion = { viewModel.selectVersion(item.scheme.id, it) },
                             onDownload = { viewModel.downloadScheme(item) },
-                            onInstall = { viewModel.installFromMarket(item) },
-                            onDeploy = { viewModel.deploy() },
-                            onDelete = { viewModel.deleteDownloadedScheme(item.scheme.id) },
                         )
                     }
                     item {
@@ -246,17 +246,11 @@ private fun SchemeCard(
     item: MarketSchemeItem,
     downloading: Boolean,
     downloadProgress: Float,
-    extracting: Boolean,
     downloaded: Boolean,
-    installed: Boolean,
     sha256Status: Boolean?,
-    deploying: Boolean,
     selectedVersion: String,
     onSelectVersion: (String) -> Unit,
     onDownload: () -> Unit,
-    onInstall: () -> Unit,
-    onDeploy: () -> Unit,
-    onDelete: () -> Unit = {},
 ) {
     val scheme = item.scheme
     Card(
@@ -382,18 +376,18 @@ private fun SchemeCard(
             val sizeLabel = if (totalBytes > 0) {
                 "%.1f MB".format(totalBytes / (1024.0 * 1024.0))
             } else null
+            if (sizeLabel != null) {
+                Text(
+                    "大小: $sizeLabel",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+            }
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (sizeLabel != null) {
-                    Text(
-                        "大小: $sizeLabel",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                }
-                Spacer(Modifier.weight(1f))
                 when {
                     downloading -> {
                         OutlinedButton(onClick = onDownload, enabled = false) {
@@ -405,49 +399,19 @@ private fun SchemeCard(
                         }
                     }
 
-                    extracting -> {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                            Spacer(Modifier.width(8.dp))
-                            Text("安装中…", style = MaterialTheme.typography.labelMedium)
-                        }
-                    }
-
                     !item.compatible -> OutlinedButton(onClick = {}, enabled = false) {
                         Text("需 App ≥ ${item.minAppVersion}")
                     }
 
-                    downloaded && !installed -> OutlinedButton(onClick = onInstall) {
-                        Text("安装")
-                    }
-
-                    installed -> {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            OutlinedButton(onClick = onDownload) { Text("重新下载") }
-                            Spacer(Modifier.width(4.dp))
-                            IconButton(
-                                onClick = onDelete,
-                                modifier = Modifier.size(36.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Delete,
-                                    contentDescription = "删除压缩包",
-                                    tint = MaterialTheme.colorScheme.error,
-                                    modifier = Modifier.size(20.dp),
-                                )
-                            }
-                            Spacer(Modifier.weight(1f))
+                    downloaded -> {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                "已下载",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
                             Spacer(Modifier.width(8.dp))
-                            if (deploying) {
-                                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                                Spacer(Modifier.width(8.dp))
-                                Text("部署中…", style = MaterialTheme.typography.labelMedium)
-                            } else {
-                                OutlinedButton(onClick = onDeploy) { Text("部署") }
-                            }
+                            OutlinedButton(onClick = onDownload) { Text("重新下载") }
                         }
                     }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
@@ -99,6 +99,10 @@ fun SchemaSettingsContent(
     var tabIndex by remember { mutableStateOf(0) }
     // F6: 从方案市场/导入返回时自动重扫描，新装方案立即出现
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.refresh(); localViewModel.loadLocalPackages() }
+    // 切 tab 时刷新对应列表，保持数据一致
+    LaunchedEffect(tabIndex) {
+        if (tabIndex == 0) viewModel.refresh() else localViewModel.loadLocalPackages()
+    }
     var showMenu by remember { mutableStateOf(false) }
     var showWirelessSheet by remember { mutableStateOf(false) }
     var showUrlDialog by remember { mutableStateOf(false) }
@@ -819,7 +823,7 @@ private fun LocalPackageItemCard(
                     item.downloaded -> OutlinedButton(onClick = onInstall) { Text("安装") }
                 }
                 Spacer(Modifier.weight(1f))
-                if (item.downloaded) {
+                if (item.packageId != "builtin" && item.downloaded) {
                     IconButton(
                         onClick = onDelete,
                         modifier = Modifier.size(36.dp),

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
@@ -103,6 +103,10 @@ fun SchemaSettingsContent(
     LaunchedEffect(tabIndex) {
         if (tabIndex == 0) viewModel.refresh() else localViewModel.loadLocalPackages()
     }
+    // 导入完成后刷新本地包列表
+    LaunchedEffect(Unit) {
+        viewModel.importCompleted.collect { localViewModel.loadLocalPackages() }
+    }
     var showMenu by remember { mutableStateOf(false) }
     var showWirelessSheet by remember { mutableStateOf(false) }
     var showUrlDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
@@ -47,7 +47,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -76,6 +80,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.SchemaMeta
 import com.kingzcheung.xime.settings.SettingsPreferences
+import com.kingzcheung.xime.viewmodel.LocalPackageItem
+import com.kingzcheung.xime.viewmodel.SchemaLocalViewModel
 import com.kingzcheung.xime.viewmodel.SchemaSettingsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -83,13 +89,16 @@ import com.kingzcheung.xime.viewmodel.SchemaSettingsViewModel
 fun SchemaSettingsContent(
     onBack: () -> Unit,
     onNavigateToMarket: () -> Unit = {},
-    onNavigateToRimeFileBrowser: () -> Unit = {}
+    onNavigateToRimeFileBrowser: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val viewModel: SchemaSettingsViewModel = viewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val localViewModel: SchemaLocalViewModel = viewModel()
+    val localUiState by localViewModel.uiState.collectAsStateWithLifecycle()
+    var tabIndex by remember { mutableStateOf(0) }
     // F6: 从方案市场/导入返回时自动重扫描，新装方案立即出现
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.refresh() }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.refresh(); localViewModel.loadLocalPackages() }
     var showMenu by remember { mutableStateOf(false) }
     var showWirelessSheet by remember { mutableStateOf(false) }
     var showUrlDialog by remember { mutableStateOf(false) }
@@ -374,6 +383,33 @@ fun SchemaSettingsContent(
         }
     }
 
+    LaunchedEffect(localUiState.toastMessage) {
+        localUiState.toastMessage?.let { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            localViewModel.clearToast()
+        }
+    }
+
+    if (localUiState.conflictPackageId != null) {
+        AlertDialog(
+            onDismissRequest = { localViewModel.cancelConflictInstall() },
+            title = { Text("文件冲突") },
+            text = {
+                Text("需要先卸载冲突方案：${localUiState.conflictingSchemeIds.joinToString("、")}，是否继续？")
+            },
+            confirmButton = {
+                TextButton(onClick = { localViewModel.confirmInstallWithUninstall() }) {
+                    Text("确认卸载并安装")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { localViewModel.cancelConflictInstall() }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -462,22 +498,6 @@ fun SchemaSettingsContent(
                                         modifier = Modifier.size(20.dp))
                                 }
                             )
-                            HorizontalDivider(
-                                modifier = Modifier.padding(horizontal = 12.dp),
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                            )
-                            DropdownMenuItem(
-                                text = { Text("卸载方案", color = MaterialTheme.colorScheme.error) },
-                                onClick = {
-                                    showMenu = false
-                                    viewModel.showUninstallDialog()
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Default.Delete, null,
-                                        tint = MaterialTheme.colorScheme.error,
-                                        modifier = Modifier.size(20.dp))
-                                }
-                            )
                         }
                     }
                 },
@@ -493,102 +513,149 @@ fun SchemaSettingsContent(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            item {
-                Text(
-                    text = "已启用",
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(top = 12.dp, bottom = 4.dp)
+            TabRow(selectedTabIndex = tabIndex) {
+                Tab(
+                    selected = tabIndex == 0,
+                    onClick = { tabIndex = 0 },
+                    text = { Text("已安装") },
+                )
+                Tab(
+                    selected = tabIndex == 1,
+                    onClick = { tabIndex = 1 },
+                    text = { Text("已下载/导入") },
                 )
             }
 
-            val enabledSchemas = uiState.allSchemas.filter { it.schemaId in uiState.enabledSchemas }
+            when (tabIndex) {
+                0 -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        item {
+                            Text(
+                                text = "已启用",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(top = 12.dp, bottom = 4.dp)
+                            )
+                        }
 
-            if (enabledSchemas.isEmpty()) {
-                item {
-                    Text(
-                        text = "暂未启用任何方案",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 8.dp)
-                    )
+                        val enabledSchemas = uiState.allSchemas.filter { it.schemaId in uiState.enabledSchemas }
+
+                        if (enabledSchemas.isEmpty()) {
+                            item {
+                                Text(
+                                    text = "暂未启用任何方案",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 8.dp)
+                                )
+                            }
+                        }
+
+                        items(enabledSchemas, key = { it.schemaId }) { schema ->
+                            SchemaToggleItem(
+                                schema = schema,
+                                enabled = true,
+                                isCompiled = SchemaManager.isSchemaCompiled(context, schema.schemaId),
+                                isCurrent = schema.schemaId == uiState.currentSchema,
+                                onToggle = { viewModel.toggleSchema(schema) },
+                                onSelect = { viewModel.selectSchema(schema) },
+                            )
+                        }
+
+                        item {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "添加输入方案后，需要点击一次「部署方案」进行部署",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
+
+                        val disabledSchemas = uiState.allSchemas.filter { it.schemaId !in uiState.enabledSchemas }
+
+                        if (disabledSchemas.isEmpty()) {
+                            item {
+                                Text(
+                                    text = "没有其他可用方案",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 8.dp)
+                                )
+                            }
+                        }
+
+                        items(disabledSchemas, key = { it.schemaId }) { schema ->
+                            SchemaToggleItem(
+                                schema = schema,
+                                enabled = false,
+                                isCompiled = SchemaManager.isSchemaCompiled(context, schema.schemaId),
+                                isCurrent = false,
+                                onToggle = { viewModel.toggleSchema(schema) },
+                                onSelect = { viewModel.selectSchema(schema) },
+                            )
+                        }
+                    }
+
+                    Button(
+                        onClick = { viewModel.deploySchema() },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                    ) {
+                        if (uiState.isDeploying) {
+                            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                            Spacer(Modifier.width(8.dp))
+                        }
+                        Text("部署方案")
+                    }
+                }
+
+                1 -> {
+                    val packages = localUiState.packages
+                    if (packages.isEmpty()) {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text(
+                                "暂无本地方案",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            item { Spacer(Modifier.height(4.dp)) }
+                            items(packages, key = { it.packageId }) { item ->
+                                LocalPackageItemCard(
+                                    item = item,
+                                    installing = localUiState.installingId == item.packageId,
+                                    onInstall = { localViewModel.installPackage(item) },
+                                    onDelete = { localViewModel.deleteDownloaded(item) },
+                                    onUninstall = { localViewModel.uninstall(item) },
+                                )
+                            }
+                            item {
+                                Spacer(Modifier.height(16.dp))
+                                Text(
+                                    "安装后需切到「已安装」tab 点击「部署方案」生效",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.padding(bottom = 16.dp),
+                                )
+                            }
+                        }
+                    }
                 }
             }
-
-            items(enabledSchemas, key = { it.schemaId }) { schema ->
-                SchemaToggleItem(
-                    schema = schema,
-                    enabled = true,
-                    isCompiled = SchemaManager.isSchemaCompiled(context, schema.schemaId),
-                    isCurrent = schema.schemaId == uiState.currentSchema,
-                    onToggle = { viewModel.toggleSchema(schema) },
-                    onSelect = { viewModel.selectSchema(schema) },
-                )
-            }
-
-            item {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "添加输入方案后，需要点击一次「部署方案」进行部署",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-
-            val disabledSchemas = uiState.allSchemas.filter { it.schemaId !in uiState.enabledSchemas }
-
-            if (disabledSchemas.isEmpty()) {
-                item {
-                    Text(
-                        text = "没有其他可用方案",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 8.dp)
-                    )
-                }
-            }
-
-            items(disabledSchemas, key = { it.schemaId }) { schema ->
-                SchemaToggleItem(
-                    schema = schema,
-                    enabled = false,
-                    isCompiled = SchemaManager.isSchemaCompiled(context, schema.schemaId),
-                    isCurrent = false,
-                    onToggle = { viewModel.toggleSchema(schema) },
-                    onSelect = { viewModel.selectSchema(schema) },
-                )
-            }
-        }
-
-        Button(
-            onClick = { viewModel.deploySchema() },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp)
-                .height(48.dp),
-            enabled = !uiState.isDeploying
-        ) {
-            if (uiState.isDeploying) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(20.dp),
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("正在部署...")
-            } else {
-                Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(20.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("部署方案")
-            }
-        }
         }
     }
 }
@@ -677,5 +744,110 @@ private fun SchemaToggleItem(
                 onCheckedChange = { onToggle() }
             )
         }
+    }
+}
+
+@Composable
+private fun LocalPackageItemCard(
+    item: LocalPackageItem,
+    installing: Boolean,
+    onInstall: () -> Unit,
+    onDelete: () -> Unit,
+    onUninstall: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    item.displayName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                Spacer(Modifier.width(8.dp))
+                val tagColor = when {
+                    item.installed -> MaterialTheme.colorScheme.primary
+                    item.downloaded -> MaterialTheme.colorScheme.outline
+                    else -> MaterialTheme.colorScheme.error
+                }
+                LocalPackageTag(
+                    if (item.installed) "已安装" else if (item.downloaded) "已下载" else "未知",
+                    tagColor,
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "ID: ${item.packageId}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+            if (item.version.isNotEmpty() || item.fileCount > 0) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    buildString {
+                        if (item.version.isNotEmpty()) append("版本: ${item.version}")
+                        if (item.fileCount > 0) {
+                            if (isNotEmpty()) append(" · ")
+                            append("${item.fileCount} 个文件")
+                        }
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                when {
+                    installing -> {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                            Spacer(Modifier.width(6.dp))
+                            Text("安装中…", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    item.installed -> {
+                        OutlinedButton(onClick = onUninstall) { Text("卸载") }
+                    }
+                    item.downloaded -> OutlinedButton(onClick = onInstall) { Text("安装") }
+                }
+                Spacer(Modifier.weight(1f))
+                if (item.downloaded) {
+                    IconButton(
+                        onClick = onDelete,
+                        modifier = Modifier.size(36.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "删除下载文件",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalPackageTag(text: String, color: androidx.compose.ui.graphics.Color) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = color.copy(alpha = 0.12f),
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SchemaSettingsScreen.kt
@@ -22,15 +22,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.CloudDownload
-import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Storefront
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.twotone.CloudDownload
 import androidx.compose.material.icons.twotone.Computer
@@ -60,6 +56,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -283,6 +280,84 @@ fun SchemaSettingsContent(
         )
     }
 
+    if (uiState.showUninstallDialog) {
+        val packages = uiState.marketPackages
+        val selectedIds = remember { mutableStateListOf<String>() }
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissUninstallDialog() },
+            title = { Text("卸载方案") },
+            text = {
+                if (packages.isEmpty()) {
+                    Text(
+                        "没有可卸载的方案",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Column {
+                        Text(
+                            "选择要卸载的方案：",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        packages.forEach { pkg ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        if (pkg.packageId in selectedIds) {
+                                            selectedIds.remove(pkg.packageId)
+                                        } else {
+                                            selectedIds.add(pkg.packageId)
+                                        }
+                                    }
+                                    .padding(vertical = 4.dp),
+                            ) {
+                                Checkbox(
+                                    checked = pkg.packageId in selectedIds,
+                                    onCheckedChange = { checked ->
+                                        if (checked) selectedIds.add(pkg.packageId)
+                                        else selectedIds.remove(pkg.packageId)
+                                    }
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Column {
+                                    Text(pkg.displayName, style = MaterialTheme.typography.bodyMedium)
+                                    Text(
+                                        "${pkg.schemaCount} 个输入方案 · ${pkg.fileCount} 个文件" +
+                                            if (pkg.version.isNotEmpty()) " · v${pkg.version}" else "",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        selectedIds.forEach { viewModel.uninstallPackage(it) }
+                    },
+                    enabled = selectedIds.isNotEmpty(),
+                ) {
+                    Text(
+                        "卸载 (${selectedIds.size})",
+                        color = if (selectedIds.isNotEmpty()) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissUninstallDialog() }) {
+                    Text("取消")
+                }
+            }
+        )
+    }
+
     // Auto-close dialog when download finishes
     LaunchedEffect(uiState.isDownloading) {
         if (wasDownloading && !uiState.isDownloading) {
@@ -387,6 +462,22 @@ fun SchemaSettingsContent(
                                         modifier = Modifier.size(20.dp))
                                 }
                             )
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 12.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                            )
+                            DropdownMenuItem(
+                                text = { Text("卸载方案", color = MaterialTheme.colorScheme.error) },
+                                onClick = {
+                                    showMenu = false
+                                    viewModel.showUninstallDialog()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.Delete, null,
+                                        tint = MaterialTheme.colorScheme.error,
+                                        modifier = Modifier.size(20.dp))
+                                }
+                            )
                         }
                     }
                 },
@@ -438,7 +529,6 @@ fun SchemaSettingsContent(
                     isCurrent = schema.schemaId == uiState.currentSchema,
                     onToggle = { viewModel.toggleSchema(schema) },
                     onSelect = { viewModel.selectSchema(schema) },
-                    onDelete = { viewModel.deleteSchema(schema) }
                 )
             }
 
@@ -473,7 +563,6 @@ fun SchemaSettingsContent(
                     isCurrent = false,
                     onToggle = { viewModel.toggleSchema(schema) },
                     onSelect = { viewModel.selectSchema(schema) },
-                    onDelete = { viewModel.deleteSchema(schema) }
                 )
             }
         }
@@ -512,36 +601,7 @@ private fun SchemaToggleItem(
     isCurrent: Boolean,
     onToggle: () -> Unit,
     onSelect: () -> Unit,
-    onDelete: () -> Unit = {}
 ) {
-    val context = LocalContext.current
-    var showDeleteConfirm by remember { mutableStateOf(false) }
-
-    if (showDeleteConfirm) {
-        AlertDialog(
-            onDismissRequest = { showDeleteConfirm = false },
-            title = { Text("删除方案") },
-            text = {
-                val msg = if (isCurrent) {
-                    "「${schema.name}」是当前默认输入方案，删除后将自动切换到其他方案。\n\n相关的 .schema.yaml 和 .dict.yaml 文件将被移除。"
-                } else {
-                    "确定删除「${schema.name}」吗？\n相关的 .schema.yaml 和 .dict.yaml 文件将被移除。"
-                }
-                Text(msg)
-            },
-            confirmButton = {
-                TextButton(onClick = { showDeleteConfirm = false; onDelete() }) {
-                    Text("删除", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDeleteConfirm = false }) {
-                    Text("取消")
-                }
-            }
-        )
-    }
-
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -616,17 +676,6 @@ private fun SchemaToggleItem(
                 checked = enabled,
                 onCheckedChange = { onToggle() }
             )
-            IconButton(
-                onClick = { showDeleteConfirm = true },
-                modifier = Modifier.size(32.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = "删除",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                    modifier = Modifier.size(18.dp)
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsMainScreen.kt
@@ -73,7 +73,6 @@ fun SettingsMainContent(
     onNavigateToKeyEffect: () -> Unit,
     onNavigateToLayoutDisplay: () -> Unit,
     onNavigateToDictionary: () -> Unit,
-    onNavigateToCustomPhrase: () -> Unit,
     onNavigateToPlugins: () -> Unit,
     onNavigateToSmartPrediction: () -> Unit,
     onNavigateToSpeechToText: () -> Unit,
@@ -231,20 +230,8 @@ fun SettingsMainContent(
                     SettingsItem(
                         icon = Icons.TwoTone.Ballot,
                         title = "词库管理",
-                        subtitle = "管理用户词库",
+                        subtitle = "管理个人词库和自定义短语",
                         onClick = onNavigateToDictionary,
-                        showArrow = true
-                    )
-                    HorizontalDivider(
-                        modifier = Modifier.padding(start = 56.dp),
-                        thickness = 0.5.dp,
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                    )
-                    SettingsItem(
-                        icon = Icons.TwoTone.TypeSpecimen,
-                        title = "自定义短语",
-                        subtitle = "管理自定义短语",
-                        onClick = onNavigateToCustomPhrase,
                         showArrow = true
                     )
                 })

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -22,6 +22,5 @@ object SettingsRoutes {
     const val LogViewer = "log_viewer"
     const val WebDav = "webdav"
     const val SchemaDictBrowser = "schema_dict_browser"
-    const val CustomPhrase = "custom_phrase"
     const val RimeFileBrowser = "rime_file_browser"
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsRoutes.kt
@@ -4,6 +4,7 @@ object SettingsRoutes {
     const val Main = "main"
     const val Schema = "schema"
     const val SchemaMarket = "schema_market"
+    const val SchemaLocal = "schema_local"
     const val SchemaMarketDetail = "schema_market_detail/{schemeId}"
     const val Theme = "theme"
     const val KeyEffect = "key_effect"

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -53,7 +53,7 @@ fun SettingsScreen(
                     onWizardBack()
                 },
                 onNavigateToMarket = { navController.navigate(SettingsRoutes.SchemaMarket) },
-                onNavigateToRimeFileBrowser = { navController.navigate(SettingsRoutes.RimeFileBrowser) }
+                onNavigateToRimeFileBrowser = { navController.navigate(SettingsRoutes.RimeFileBrowser) },
             )
         }
         composable(SettingsRoutes.SchemaMarket) {
@@ -62,6 +62,12 @@ fun SettingsScreen(
                 onNavigateToDetail = { schemeId ->
                     navController.navigate("schema_market_detail/$schemeId")
                 },
+                onNavigateToLocal = { navController.navigate(SettingsRoutes.SchemaLocal) },
+            )
+        }
+        composable(SettingsRoutes.SchemaLocal) {
+            SchemaLocalContent(
+                onBack = { navController.popBackStack() },
             )
         }
         composable(

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SettingsScreen.kt
@@ -31,7 +31,6 @@ fun SettingsScreen(
                 onNavigateToKeyEffect = { navController.navigate(SettingsRoutes.KeyEffect) },
                 onNavigateToLayoutDisplay = { navController.navigate(SettingsRoutes.LayoutDisplay) },
                 onNavigateToDictionary = { navController.navigate(SettingsRoutes.Dictionary) },
-                onNavigateToCustomPhrase = { navController.navigate(SettingsRoutes.CustomPhrase) },
                 onNavigateToPlugins = { navController.navigate(SettingsRoutes.Plugins) },
                 onNavigateToSmartPrediction = { navController.navigate(SettingsRoutes.SmartPrediction) },
                 onNavigateToSpeechToText = { navController.navigate(SettingsRoutes.SpeechToText) },
@@ -139,11 +138,6 @@ fun SettingsScreen(
         }
         composable(SettingsRoutes.SchemaDictBrowser) {
             SchemaDictBrowserContent(
-                onBack = { navController.popBackStack() }
-            )
-        }
-        composable(SettingsRoutes.CustomPhrase) {
-            CustomPhraseContent(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/CustomPhraseViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/CustomPhraseViewModel.kt
@@ -29,11 +29,14 @@ data class CustomPhraseUiState(
 
 class CustomPhraseViewModel(application: Application) : AndroidViewModel(application) {
     private val context = application.applicationContext
+    private var schemaId: String? = null
 
     private val _uiState = MutableStateFlow(CustomPhraseUiState())
     val uiState: StateFlow<CustomPhraseUiState> = _uiState.asStateFlow()
 
-    init {
+    fun setSchema(id: String?) {
+        if (schemaId == id) return
+        schemaId = id
         loadEntries()
     }
 
@@ -41,7 +44,7 @@ class CustomPhraseViewModel(application: Application) : AndroidViewModel(applica
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             val entries = withContext(Dispatchers.IO) {
-                PersonalDictManager.loadCustomPhrases(context)
+                PersonalDictManager.loadCustomPhrases(context, schemaId)
             }
             _uiState.update {
                 it.copy(
@@ -58,13 +61,10 @@ class CustomPhraseViewModel(application: Application) : AndroidViewModel(applica
         val trimmedWord = word.trim()
         val trimmedCode = code.trim()
         if (trimmedWord.isEmpty() || trimmedCode.isEmpty()) return
-
         viewModelScope.launch {
             val current = _uiState.value.entries
             val updated = current + DictEntry(trimmedWord, trimmedCode, weight)
-            withContext(Dispatchers.IO) {
-                PersonalDictManager.saveCustomPhrases(context, updated)
-            }
+            withContext(Dispatchers.IO) { PersonalDictManager.saveCustomPhrases(context, schemaId, updated) }
             _uiState.update {
                 val query = it.searchQuery
                 it.copy(entries = updated, filteredEntries = filterEntries(updated, query))
@@ -76,14 +76,11 @@ class CustomPhraseViewModel(application: Application) : AndroidViewModel(applica
         val trimmedWord = word.trim()
         val trimmedCode = code.trim()
         if (trimmedWord.isEmpty() || trimmedCode.isEmpty()) return
-
         viewModelScope.launch {
             val current = _uiState.value.entries.toMutableList()
             if (index < 0 || index >= current.size) return@launch
             current[index] = DictEntry(trimmedWord, trimmedCode, weight)
-            withContext(Dispatchers.IO) {
-                PersonalDictManager.saveCustomPhrases(context, current)
-            }
+            withContext(Dispatchers.IO) { PersonalDictManager.saveCustomPhrases(context, schemaId, current) }
             _uiState.update {
                 val query = it.searchQuery
                 it.copy(entries = current, filteredEntries = filterEntries(current, query))
@@ -96,9 +93,7 @@ class CustomPhraseViewModel(application: Application) : AndroidViewModel(applica
             val current = _uiState.value.entries.toMutableList()
             if (index < 0 || index >= current.size) return@launch
             current.removeAt(index)
-            withContext(Dispatchers.IO) {
-                PersonalDictManager.saveCustomPhrases(context, current)
-            }
+            withContext(Dispatchers.IO) { PersonalDictManager.saveCustomPhrases(context, schemaId, current) }
             _uiState.update {
                 val query = it.searchQuery
                 it.copy(entries = current, filteredEntries = filterEntries(current, query))

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
@@ -1,0 +1,179 @@
+package com.kingzcheung.xime.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.kingzcheung.xime.settings.FileConflictInfo
+import com.kingzcheung.xime.settings.SchemaManifestManager
+import com.kingzcheung.xime.settings.SchemaManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+data class LocalPackageItem(
+    val packageId: String,
+    val displayName: String,
+    val version: String,
+    val downloaded: Boolean,
+    val installed: Boolean,
+    val schemaCount: Int = 0,
+    val fileCount: Int = 0,
+) {
+    val isImport: Boolean get() = packageId.startsWith("import_")
+    val statusLabel: String
+        get() = when {
+            installed && downloaded -> "已安装"
+            installed -> "已安装"
+            downloaded -> "已下载"
+            else -> ""
+        }
+}
+
+data class SchemaLocalUiState(
+    val packages: List<LocalPackageItem> = emptyList(),
+    val isLoading: Boolean = false,
+    val installingId: String? = null,
+    val errorMessage: String? = null,
+    val toastMessage: String? = null,
+    val conflictPackageId: String? = null,
+    val conflictingSchemeIds: List<String> = emptyList(),
+)
+
+class SchemaLocalViewModel(application: Application) : AndroidViewModel(application) {
+    private val context = application.applicationContext
+
+    private val _uiState = MutableStateFlow(SchemaLocalUiState())
+    val uiState: StateFlow<SchemaLocalUiState> = _uiState.asStateFlow()
+
+    init {
+        loadLocalPackages()
+    }
+
+    fun loadLocalPackages() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            val installedPkgs = withContext(Dispatchers.IO) {
+                SchemaManifestManager.getInstalledPackages(context)
+            }
+            val downloadedIds = withContext(Dispatchers.IO) {
+                val marketDir = SchemaManager.getMarketDir(context)
+                if (!marketDir.exists()) emptySet()
+                else marketDir.listFiles()?.mapNotNull { sub ->
+                    if (sub.isDirectory && sub.listFiles()?.any { it.isFile } == true) sub.name
+                    else null
+                }?.toSet() ?: emptySet()
+            }
+            val installedMap = installedPkgs.associateBy { it.packageId }
+            val allIds = (downloadedIds + installedMap.keys).sorted()
+            val packages = allIds.map { id ->
+                val info = installedMap[id]
+                LocalPackageItem(
+                    packageId = id,
+                    displayName = info?.displayName ?: id,
+                    version = info?.version ?: "",
+                    downloaded = id in downloadedIds,
+                    installed = info != null,
+                    schemaCount = info?.schemaCount ?: 0,
+                    fileCount = info?.fileCount ?: 0,
+                )
+            }
+            _uiState.update { it.copy(packages = packages, isLoading = false) }
+        }
+    }
+
+    fun installPackage(item: LocalPackageItem) {
+        if (_uiState.value.installingId != null) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(installingId = item.packageId) }
+            val result = withContext(Dispatchers.IO) {
+                SchemaManager.installPackageFromMarketDir(
+                    context = context,
+                    packageId = item.packageId,
+                    displayName = item.displayName,
+                    version = item.version,
+                    fromMarket = !item.isImport,
+                )
+            }
+            _uiState.update { st -> st.copy(installingId = null) }
+            if (!result.success && result.conflicts.isNotEmpty()) {
+                val schemeIds = result.conflicts.flatMap { c: FileConflictInfo -> c.claimedBy }.distinct()
+                _uiState.update {
+                    it.copy(
+                        conflictPackageId = item.packageId,
+                        conflictingSchemeIds = schemeIds,
+                    )
+                }
+                return@launch
+            }
+            if (result.success) {
+                showToast("已安装「${item.displayName}」，点「部署」生效")
+            } else {
+                showToast(result.failureReason ?: "安装失败")
+            }
+            loadLocalPackages()
+        }
+    }
+
+    fun confirmInstallWithUninstall() {
+        if (_uiState.value.installingId != null) return
+        val pkgId = _uiState.value.conflictPackageId ?: return
+        val item = _uiState.value.packages.firstOrNull { it.packageId == pkgId } ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(conflictPackageId = null, installingId = pkgId) }
+            for (sid in _uiState.value.conflictingSchemeIds) {
+                withContext(Dispatchers.IO) {
+                    SchemaManifestManager.uninstallWithManifest(context, sid)
+                }
+            }
+            val result = withContext(Dispatchers.IO) {
+                SchemaManager.installPackageFromMarketDir(
+                    context = context,
+                    packageId = pkgId,
+                    displayName = item.displayName,
+                    version = item.version,
+                    fromMarket = !item.isImport,
+                )
+            }
+            _uiState.update { st -> st.copy(installingId = null, conflictingSchemeIds = emptyList()) }
+            if (result.success) {
+                showToast("已安装「${item.displayName}」，点「部署」生效")
+            } else {
+                showToast(result.failureReason ?: "安装失败")
+            }
+            loadLocalPackages()
+        }
+    }
+
+    fun cancelConflictInstall() {
+        _uiState.update { it.copy(conflictPackageId = null, conflictingSchemeIds = emptyList()) }
+    }
+
+    fun deleteDownloaded(item: LocalPackageItem) {
+        viewModelScope.launch {
+            val ok = withContext(Dispatchers.IO) {
+                val dir = SchemaManager.getMarketDir(context, item.packageId)
+                if (dir.exists()) { dir.deleteRecursively(); true } else false
+            }
+            showToast(if (ok) "已删除" else "删除失败")
+            loadLocalPackages()
+        }
+    }
+
+    fun uninstall(item: LocalPackageItem) {
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                SchemaManifestManager.uninstallWithManifest(context, item.packageId)
+            }
+            showToast(result.message)
+            loadLocalPackages()
+        }
+    }
+
+    fun clearToast() = _uiState.update { it.copy(toastMessage = null) }
+
+    private fun showToast(message: String) = _uiState.update { it.copy(toastMessage = message) }
+}

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
@@ -3,7 +3,6 @@ package com.kingzcheung.xime.viewmodel
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.kingzcheung.xime.settings.FileConflictInfo
 import com.kingzcheung.xime.settings.SchemaManifestManager
 import com.kingzcheung.xime.settings.SchemaManager
 import kotlinx.coroutines.Dispatchers
@@ -89,6 +88,29 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
         if (_uiState.value.installingId != null) return
         viewModelScope.launch {
             _uiState.update { it.copy(installingId = item.packageId) }
+
+            // 检查 rime/ 下是否已有其他方案（无论是否被清单追踪）
+            val hasSchemas = withContext(Dispatchers.IO) {
+                SchemaManager.discoverSchemas(context).isNotEmpty()
+            }
+            if (hasSchemas) {
+                _uiState.update { it.copy(installingId = null) }
+                val otherInstalled = withContext(Dispatchers.IO) {
+                    SchemaManifestManager.getInstalledPackages(context)
+                        .map { it.packageId }
+                        .filter { it != item.packageId }
+                }
+                val targetIds = if (otherInstalled.isNotEmpty()) otherInstalled else listOf("builtin")
+                _uiState.update {
+                    it.copy(
+                        conflictPackageId = item.packageId,
+                        conflictingSchemeIds = targetIds,
+                    )
+                }
+                return@launch
+            }
+
+            // 直接安装（后续由 UI 提示用户部署）
             val result = withContext(Dispatchers.IO) {
                 SchemaManager.installPackageFromMarketDir(
                     context = context,
@@ -99,16 +121,6 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
                 )
             }
             _uiState.update { st -> st.copy(installingId = null) }
-            if (!result.success && result.conflicts.isNotEmpty()) {
-                val schemeIds = result.conflicts.flatMap { c: FileConflictInfo -> c.claimedBy }.distinct()
-                _uiState.update {
-                    it.copy(
-                        conflictPackageId = item.packageId,
-                        conflictingSchemeIds = schemeIds,
-                    )
-                }
-                return@launch
-            }
             if (result.success) {
                 showToast("已安装「${item.displayName}」，点「部署」生效")
             } else {
@@ -153,6 +165,7 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun deleteDownloaded(item: LocalPackageItem) {
+        if (item.packageId == "builtin") { showToast("内置方案不可删除"); return }
         viewModelScope.launch {
             val ok = withContext(Dispatchers.IO) {
                 val dir = SchemaManager.getMarketDir(context, item.packageId)

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
@@ -181,6 +181,15 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
             val result = withContext(Dispatchers.IO) {
                 SchemaManifestManager.uninstallWithManifest(context, item.packageId)
             }
+            // 若卸载后没有已安装的方案了，全量清理 rime/ 残留
+            val remaining = withContext(Dispatchers.IO) {
+                SchemaManifestManager.getInstalledPackages(context)
+            }
+            if (remaining.isEmpty()) {
+                withContext(Dispatchers.IO) {
+                    SchemaManager.cleanRimeDir(context)
+                }
+            }
             showToast(result.message)
             loadLocalPackages()
         }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaMarketViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.kingzcheung.xime.BuildConfig
-import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.settings.MarketSchemeItem
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.settings.XimeIndexSource
@@ -23,15 +22,10 @@ data class SchemaMarketUiState(
     val downloadingId: String? = null,
     /** 下载进度 0f~1f */
     val downloadProgress: Float = 0f,
-    /** 正在解压/安装的方案 id */
-    val extractingId: String? = null,
     /** 已下载到 market 目录的方案 id（压缩包文件存在） */
     val downloadedIds: Set<String> = emptySet(),
-    /** 已解压安装到 rime 目录的方案 id */
-    val installedIds: Set<String> = emptySet(),
     /** sha256 校验状态：null=未提供sha256, true=校验通过, false=校验不通过 */
     val sha256Status: Map<String, Boolean?> = emptyMap(),
-    val isDeploying: Boolean = false,
     val errorMessage: String? = null,
     val toastMessage: String? = null,
     val searchQuery: String = "",
@@ -180,106 +174,6 @@ class SchemaMarketViewModel(application: Application) : AndroidViewModel(applica
                 else -> "已下载「${item.scheme.name}」"
             }
             showToast(toast)
-        }
-    }
-
-    /** 从 market 目录解压/复制已下载的方案到 rime 目录。 */
-    fun installFromMarket(item: MarketSchemeItem) {
-        if (_uiState.value.extractingId != null) {
-            showToast("正在安装其他方案，请稍候")
-            return
-        }
-        if (!item.compatible) {
-            showToast("需 App ≥ ${item.minAppVersion}")
-            return
-        }
-        viewModelScope.launch {
-            _uiState.update { it.copy(extractingId = item.scheme.id) }
-            val selVer = _uiState.value.selectedVersions
-            val urlById = _uiState.value.schemes.associate { si ->
-                val v = selVer[si.scheme.id]?.let { ver ->
-                    si.scheme.versions.firstOrNull { it.version == ver }
-                } ?: si.scheme.resolvedVersion()
-                si.scheme.id to v?.downloadUrls?.firstOrNull()?.url
-            }
-            val result = withContext(Dispatchers.IO) {
-                XimeIndexSource.installFromMarket(
-                    context, item.scheme,
-                    resolveDepUrl = { id: String -> urlById[id]?.takeIf { it.isNotBlank() } },
-                )
-            }
-            // 安装失败时确保目录清理干净，然后刷新状态让按钮恢复为"下载"
-            if (!result.success) {
-                withContext(Dispatchers.IO) {
-                    val dir = SchemaManager.getMarketDir(context, item.scheme.id)
-                    if (dir.exists()) dir.deleteRecursively()
-                }
-            }
-            val stillDownloaded = withContext(Dispatchers.IO) {
-                SchemaManager.isSchemeDownloaded(context, item.scheme.id)
-            }
-            _uiState.update { st ->
-                st.copy(
-                    extractingId = null,
-                    downloadedIds = if (stillDownloaded) st.downloadedIds else st.downloadedIds - item.scheme.id,
-                    sha256Status = if (stillDownloaded) st.sha256Status else st.sha256Status - item.scheme.id,
-                    installedIds = if (result.success) st.installedIds + item.scheme.id else st.installedIds,
-                )
-            }
-            val msg = when {
-                !result.success && !stillDownloaded ->
-                    "文件不完整，已自动删除，请重新下载"
-                !result.success -> result.failureReason ?: "安装失败"
-                result.unresolvedDeps.isNotEmpty() ->
-                    "已安装，部分依赖未获取：${result.unresolvedDeps.joinToString("、").take(60)}"
-                else -> "已安装「${item.scheme.name}」，点「部署」生效"
-            }
-            showToast(msg)
-        }
-    }
-
-    /** 删除已下载到 market 目录的方案压缩包（不删除已解压到 rime 的文件）。 */
-    fun deleteDownloadedScheme(schemeId: String) {
-        viewModelScope.launch {
-            val ok = withContext(Dispatchers.IO) {
-                SchemaManager.deleteSchemeArchive(context, schemeId)
-            }
-            if (ok) {
-                _uiState.update {
-                    it.copy(
-                        downloadedIds = it.downloadedIds - schemeId,
-                        sha256Status = it.sha256Status - schemeId,
-                    )
-                }
-                showToast("已删除压缩包")
-            } else {
-                showToast("删除失败")
-            }
-        }
-    }
-
-    /** 部署(全局编译已启用方案)。rime 部署是全局的,装好后点一次即可让方案生效。 */
-    fun deploy() {
-        if (_uiState.value.isDeploying) {
-            showToast("正在部署中，请稍候")
-            return
-        }
-        viewModelScope.launch {
-            _uiState.update { it.copy(isDeploying = true) }
-            val success = withContext(Dispatchers.IO) {
-                val engine = RimeEngine.getInstance()
-                engine.startMaintenance(false)
-                var waited = 0L
-                while (engine.isMaintaining() && waited < 120_000L) {
-                    Thread.sleep(100)
-                    waited += 100
-                }
-                val done = !engine.isMaintaining()
-                if (done) engine.updateLastBuildTime()
-                done
-            }
-            _uiState.update { it.copy(isDeploying = false) }
-            showToast(if (success) "部署完成" else "部署失败")
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -14,8 +14,11 @@ import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import com.kingzcheung.xime.settings.SchemaMeta
 import com.kingzcheung.xime.settings.SettingsPreferences
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -37,6 +40,9 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
 
     private val _uiState = MutableStateFlow(SchemaUiState())
     val uiState: StateFlow<SchemaUiState> = _uiState.asStateFlow()
+
+    private val _importCompleted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val importCompleted: SharedFlow<Unit> = _importCompleted.asSharedFlow()
 
     init {
         refresh()
@@ -101,6 +107,7 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
         viewModelScope.launch {
             val success = SchemaManager.importSchemaFile(context, uri)
             refresh()
+            _importCompleted.tryEmit(Unit)
             if (success) {
                 showToast("导入成功")
             } else {
@@ -148,6 +155,7 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
             }
             _uiState.update { it.copy(isDownloading = false) }
             refresh()
+            _importCompleted.tryEmit(Unit)
             showToast(if (success) "导入成功" else "下载或解压失败，请检查链接")
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -66,6 +66,10 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
     fun toggleSchema(schema: SchemaMeta) {
         val enabled = _uiState.value.enabledSchemas.toMutableList()
         if (schema.schemaId in enabled) {
+            if (enabled.size <= 1) {
+                showToast("至少启用一个方案")
+                return
+            }
             enabled.remove(schema.schemaId)
         } else {
             enabled.add(schema.schemaId)

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -4,11 +4,11 @@ import android.app.Application
 import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import android.util.Log
 import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.settings.PersonalDictManager
+import com.kingzcheung.xime.settings.SchemaManifestManager
 import com.kingzcheung.xime.settings.SchemaManager
 import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import com.kingzcheung.xime.settings.SchemaMeta
@@ -27,12 +27,13 @@ data class SchemaUiState(
     val currentSchema: String = "wubi86",
     val isDeploying: Boolean = false,
     val isDownloading: Boolean = false,
-    val toastMessage: String? = null
+    val toastMessage: String? = null,
+    val marketPackages: List<SchemaManifestManager.MarketPackageInfo> = emptyList(),
+    val showUninstallDialog: Boolean = false,
 )
 
 class SchemaSettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val context = application.applicationContext
-    private val TAG = "SchemaSettingsViewModel"
 
     private val _uiState = MutableStateFlow(SchemaUiState())
     val uiState: StateFlow<SchemaUiState> = _uiState.asStateFlow()
@@ -104,6 +105,37 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
         }
     }
 
+    fun loadMarketPackages() {
+        viewModelScope.launch {
+            val packages = withContext(Dispatchers.IO) {
+                SchemaManifestManager.getInstalledPackages(context)
+            }
+            _uiState.update { it.copy(marketPackages = packages) }
+        }
+    }
+
+    fun showUninstallDialog() {
+        loadMarketPackages()
+        _uiState.update { it.copy(showUninstallDialog = true) }
+    }
+
+    fun dismissUninstallDialog() {
+        _uiState.update { it.copy(showUninstallDialog = false) }
+    }
+
+    fun uninstallPackage(packageId: String) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                SchemaManager.deleteSchemaFiles(context, packageId)
+                SchemaManager.deleteSchemeArchive(context, packageId)
+            }
+            _uiState.update { it.copy(showUninstallDialog = false) }
+            refresh()
+            loadMarketPackages()
+            showToast("已卸载")
+        }
+    }
+
     fun importFromUrl(url: String) {
         viewModelScope.launch {
             _uiState.update { it.copy(isDownloading = true) }
@@ -113,32 +145,6 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
             _uiState.update { it.copy(isDownloading = false) }
             refresh()
             showToast(if (success) "导入成功" else "下载或解压失败，请检查链接")
-        }
-    }
-
-    fun deleteSchema(schema: SchemaMeta) {
-        viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                SchemaManager.deleteSchemaFiles(context, schema.schemaId)
-            }
-            if (_uiState.value.currentSchema == schema.schemaId) {
-                // 自动切换到另一个可用方案：优先选已启用的，其次选第一个
-                val remaining = _uiState.value.allSchemas
-                    .filter { it.schemaId != schema.schemaId }
-                    .let { list ->
-                        list.firstOrNull { it.schemaId in _uiState.value.enabledSchemas }
-                            ?: list.firstOrNull()
-                    }
-                if (remaining != null) {
-                    selectSchema(remaining)
-                } else {
-                    // 没有任何其他方案了，重置当前方案防止残留无效 ID
-                    SettingsPreferences.setCurrentSchema(context, "")
-                    _uiState.update { it.copy(currentSchema = "") }
-                }
-            }
-            refresh()
-            showToast("${schema.name} 已删除")
         }
     }
 

--- a/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
@@ -4,10 +4,23 @@ import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.io.File
+
+private fun createCustomPhraseFile(rimeDir: File, schemaId: String) {
+    val dictName = PersonalDictManager.getCustomPhraseDictName(rimeDir, schemaId)
+    File(rimeDir, "$dictName.txt").writeText("""# Rime table
+# coding: utf-8
+#@/db_name	custom_phrase
+#@/db_type	tabledb
+#
+hello	hw
+123	abc
+""")
+}
 
 private fun mockContext(): Context {
     val tmpDir = File.createTempFile("mock_context", "").apply { delete(); mkdirs() }
@@ -386,7 +399,7 @@ c	d
     fun `saveCustomPhrases writes to custom_phrase dot txt`() {
         val context = mockContext()
         val entries = listOf(DictEntry("kingzcheung@gmail.com", "yxdz", 99))
-        PersonalDictManager.saveCustomPhrases(context, entries)
+        PersonalDictManager.saveCustomPhrases(context, null, entries)
         val file = PersonalDictManager.getCustomPhraseFile(context)
         assertTrue(file.exists())
         val loaded = PersonalDictManager.parseStableDbEntries(file.readText(Charsets.UTF_8))
@@ -396,7 +409,7 @@ c	d
     @Test
     fun `applyCustomPhraseTranslator adds translator to custom yaml`() {
         val rimeDir = createTempDir()
-        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86")
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86", "custom_phrase")
         val customFile = File(rimeDir, "wubi86.custom.yaml")
         assertTrue(customFile.exists())
         val text = customFile.readText(Charsets.UTF_8)
@@ -407,10 +420,85 @@ c	d
     @Test
     fun `applyCustomPhraseTranslator is idempotent`() {
         val rimeDir = createTempDir()
-        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86")
-        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86")
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86", "custom_phrase")
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86", "custom_phrase")
         val text = File(rimeDir, "wubi86.custom.yaml").readText(Charsets.UTF_8)
         assertEquals(1, text.split("table_translator@custom_phrase").size - 1)
+    }
+
+    @Test
+    fun `applyCustomPhraseTranslator with custom dictName uses that dictName in config`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86", "custom_phrase_double")
+        val text = File(rimeDir, "wubi86.custom.yaml").readText(Charsets.UTF_8)
+        assertTrue(text.contains("user_dict: custom_phrase_double"))
+    }
+
+    @Test
+    fun `applyCustomPhraseTranslator with custom dictName is idempotent`() {
+        val rimeDir = createTempDir()
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86", "custom_phrase_double")
+        PersonalDictManager.applyCustomPhraseTranslator(rimeDir, "wubi86", "custom_phrase_double")
+        val text = File(rimeDir, "wubi86.custom.yaml").readText(Charsets.UTF_8)
+        assertEquals(1, text.split("table_translator@custom_phrase").size - 1)
+    }
+
+    @Test
+    fun `getCustomPhraseDictName reads user_dict from custom yaml`() {
+        val rimeDir = createTempDir()
+        File(rimeDir, "wubi86.custom.yaml").writeText("""patch:
+  "custom_phrase":
+    user_dict: custom_phrase_double
+""")
+        val rimeDirFinal = rimeDir
+        val result = PersonalDictManager.run { getCustomPhraseDictName(rimeDirFinal, "wubi86") }
+        assertEquals("custom_phrase_double", result)
+    }
+
+    @Test
+    fun `getCustomPhraseDictName returns default when no custom yaml`() {
+        val rimeDir = createTempDir()
+        val rimeDirFinal = rimeDir
+        val result = PersonalDictManager.run { getCustomPhraseDictName(rimeDirFinal, "wubi86") }
+        assertEquals("custom_phrase", result)
+    }
+
+    @Test
+    fun `getCustomPhraseDictName returns default when no custom_phrase section`() {
+        val rimeDir = createTempDir()
+        File(rimeDir, "wubi86.custom.yaml").writeText("""patch:
+  "translator/packs": ["user_simp_pinyin"]
+""")
+        val rimeDirFinal = rimeDir
+        val result = PersonalDictManager.run { getCustomPhraseDictName(rimeDirFinal, "wubi86") }
+        assertEquals("custom_phrase", result)
+    }
+
+    @Test
+    fun `saveCustomPhrases with schemaId writes to the correct custom dict file`() {
+        val context = mockContext()
+        val rimeDir = File(context.filesDir, "rime")
+        rimeDir.mkdirs()
+        File(rimeDir, "wubi86.custom.yaml").writeText("""patch:
+  "custom_phrase":
+    user_dict: custom_phrase_double
+""")
+        val entries = listOf(DictEntry("test", "ce", 1))
+        PersonalDictManager.saveCustomPhrases(context, "wubi86", entries)
+        val file = File(rimeDir, "custom_phrase_double.txt")
+        assertTrue(file.exists())
+        val loaded = PersonalDictManager.parseStableDbEntries(file.readText(Charsets.UTF_8))
+        assertTrue(loaded.any { it.word == "test" })
+    }
+
+    @Test
+    fun `saveCustomPhrases without schemaId writes to default custom_phrase dot txt`() {
+        val context = mockContext()
+        val entries = listOf(DictEntry("hello", "hw"))
+        PersonalDictManager.saveCustomPhrases(context, null, entries)
+        val file = PersonalDictManager.getCustomPhraseFile(context)
+        assertEquals("custom_phrase.txt", file.name)
+        assertTrue(file.exists())
     }
 
     // ── 方案补丁 ──
@@ -449,7 +537,8 @@ speller:
   algebra:
     - erase/^xx$/
 """.trimIndent())
-        PersonalDictManager.ensureSchemaPack(context, "pinyin_simp")
+        createCustomPhraseFile(rimeDir, "pinyin_simp")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "pinyin_simp") }
         val customFile = java.io.File(rimeDir, "pinyin_simp.custom.yaml")
         assertTrue("custom.yaml should be created for schema with algebra", customFile.exists())
         val text = customFile.readText(Charsets.UTF_8)
@@ -467,7 +556,7 @@ speller:
   alphabet: abcdefghijklmnopqrstuvwxyz
   max_code_length: 4
 """.trimIndent())
-        PersonalDictManager.ensureSchemaPack(context, "wubi86")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "wubi86") }
         assertTrue("merged dict should be created", java.io.File(rimeDir, "wubi86_merged.dict.yaml").exists())
         val customFile = java.io.File(rimeDir, "wubi86.custom.yaml")
         assertTrue("custom.yaml should be created", customFile.exists())
@@ -485,7 +574,8 @@ translator:
   dictionary: wubi86_pinyin
   reverse_lookup_translator: true
 """.trimIndent())
-        PersonalDictManager.ensureSchemaPack(context, "wubi86_pinyin")
+        createCustomPhraseFile(rimeDir, "wubi86_pinyin")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "wubi86_pinyin") }
         val customFile = java.io.File(rimeDir, "wubi86_pinyin.custom.yaml")
         assertTrue("custom.yaml should be created (custom_phrase only)", customFile.exists())
         val text = customFile.readText(Charsets.UTF_8)
@@ -501,7 +591,7 @@ translator:
         val rimeDir = java.io.File(context.filesDir, "rime")
         rimeDir.mkdirs()
         // no schema file created
-        PersonalDictManager.ensureSchemaPack(context, "nonexistent")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "nonexistent") }
         val customFile = java.io.File(rimeDir, "nonexistent.custom.yaml")
         assertFalse("no custom.yaml should be created for missing schema", customFile.exists())
     }
@@ -517,8 +607,9 @@ speller:
   algebra:
     - erase/^xx$/
 """.trimIndent())
-        PersonalDictManager.ensureSchemaPack(context, "pinyin_simp")
-        PersonalDictManager.ensureSchemaPack(context, "pinyin_simp")
+        createCustomPhraseFile(rimeDir, "pinyin_simp")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "pinyin_simp") }
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "pinyin_simp") }
         val text = java.io.File(rimeDir, "pinyin_simp.custom.yaml").readText(Charsets.UTF_8)
         // packs line should appear only once
         assertEquals(1, text.split("user_simp_pinyin").size - 1)
@@ -610,7 +701,7 @@ patch:
         // applyCustomPhraseTranslator creates <schemaId>.custom.yaml
         val file = File(dir, "wubi86.custom.yaml")
         file.writeText("# just a comment\n", Charsets.UTF_8)
-        PersonalDictManager.applyCustomPhraseTranslator(dir, "wubi86")
+        PersonalDictManager.applyCustomPhraseTranslator(dir, "wubi86", "custom_phrase")
         val text = file.readText(Charsets.UTF_8)
         assertTrue("patch: should be created", text.contains("patch:"))
         assertTrue("content should be added under patch", text.contains("table_translator@custom_phrase"))
@@ -690,7 +781,7 @@ patch:
     - lua_filter@custom_filter
   menu/page_size: 8
 """, Charsets.UTF_8)
-        PersonalDictManager.applyCustomPhraseTranslator(dir, "pinyin_simp")
+        PersonalDictManager.applyCustomPhraseTranslator(dir, "pinyin_simp", "custom_phrase")
         val text = file.readText(Charsets.UTF_8)
         assertTrue("Lua filter preserved", text.contains("lua_filter@custom_filter"))
         assertTrue("page_size preserved", text.contains("menu/page_size: 8"))
@@ -715,7 +806,8 @@ speller:
     - lua_filter@my_filter
   menu/page_size: 8
 """, Charsets.UTF_8)
-        PersonalDictManager.ensureSchemaPack(context, "flypy")
+        createCustomPhraseFile(rimeDir, "flypy")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "flypy") }
         val text = java.io.File(rimeDir, "flypy.custom.yaml").readText(Charsets.UTF_8)
         // Lua 配置保留
         assertTrue(text.contains("lua_filter@my_filter"))
@@ -736,8 +828,8 @@ speller:
   existing_key: value
 """, Charsets.UTF_8)
         PersonalDictManager.applyPackConfig(dir, "pinyin_simp")
-        PersonalDictManager.applyCustomPhraseTranslator(dir, "pinyin_simp")
-        PersonalDictManager.applyCustomPhraseTranslator(dir, "pinyin_simp")
+        PersonalDictManager.applyCustomPhraseTranslator(dir, "pinyin_simp", "custom_phrase")
+        PersonalDictManager.applyCustomPhraseTranslator(dir, "pinyin_simp", "custom_phrase")
         PersonalDictManager.applyPackConfig(dir, "pinyin_simp")
         val text = file.readText(Charsets.UTF_8)
         assertTrue("existing key preserved", text.contains("existing_key: value"))
@@ -764,7 +856,8 @@ speller:
     - lua_filter@custom_filter
   menu/page_size: 8
 """, Charsets.UTF_8)
-        PersonalDictManager.ensureSchemaPack(context, "wubi86")
+        createCustomPhraseFile(rimeDir, "wubi86")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "wubi86") }
         val text = java.io.File(rimeDir, "wubi86.custom.yaml").readText(Charsets.UTF_8)
         assertTrue("Lua filter preserved", text.contains("lua_filter@custom_filter"))
         assertTrue("page_size preserved", text.contains("menu/page_size: 8"))
@@ -789,7 +882,8 @@ translator:
     - lua_filter@custom_filter
   menu/page_size: 8
 """, Charsets.UTF_8)
-        PersonalDictManager.ensureSchemaPack(context, "wubi86_pinyin")
+        createCustomPhraseFile(rimeDir, "wubi86_pinyin")
+        runBlocking { PersonalDictManager.ensureSchemaPack(context, "wubi86_pinyin") }
         val text = java.io.File(rimeDir, "wubi86_pinyin.custom.yaml").readText(Charsets.UTF_8)
         assertTrue("Lua filter preserved", text.contains("lua_filter@custom_filter"))
         assertTrue("page_size preserved", text.contains("menu/page_size: 8"))

--- a/app/src/test/java/com/kingzcheung/xime/settings/SchemaManagerImportTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/SchemaManagerImportTest.kt
@@ -35,8 +35,16 @@ class SchemaManagerImportTest {
         assertFalse(SchemaManager.isProtectedImportName("cangjie5.schema.yaml"))
         assertFalse(SchemaManager.isProtectedImportName("cangjie5.dict.yaml"))
         assertFalse(SchemaManager.isProtectedImportName("essay.txt"))
-        assertFalse(SchemaManager.isProtectedImportName("default.custom.yaml"))
         assertFalse(SchemaManager.isProtectedImportName("wubi86.custom.yaml"))
+    }
+
+    @Test
+    fun `protects xime yaml and metadata from import`() {
+        assertTrue(SchemaManager.isProtectedImportName("xime.yaml"))
+        assertFalse(SchemaManager.isProtectedImportName("default.custom.yaml"))
+        assertFalse(SchemaManager.isProtectedImportName("xime.custom.yaml"))
+        assertTrue(SchemaManager.isProtectedImportName(".registry.json"))
+        assertTrue(SchemaManager.isProtectedImportName(".manifests/my_scheme.json"))
     }
 
     // ── findSchemaBaseDir：剥 GitHub 归档壳目录(修 essay.txt 落进 rime-essay-master/ 子目录) ──

--- a/app/src/test/java/com/kingzcheung/xime/settings/SchemaManagerImportTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/SchemaManagerImportTest.kt
@@ -44,7 +44,13 @@ class SchemaManagerImportTest {
         assertFalse(SchemaManager.isProtectedImportName("default.custom.yaml"))
         assertFalse(SchemaManager.isProtectedImportName("xime.custom.yaml"))
         assertTrue(SchemaManager.isProtectedImportName(".registry.json"))
-        assertTrue(SchemaManager.isProtectedImportName(".manifests/my_scheme.json"))
+        assertFalse(SchemaManager.isProtectedImportName(".manifests/my_scheme.json"))
+    }
+
+    @Test
+    fun `protects custom_phrase dot txt from import`() {
+        assertTrue(SchemaManager.isProtectedImportName("custom_phrase.txt"))
+        assertTrue(SchemaManager.isProtectedImportName("sub/dir/custom_phrase.txt"))
     }
 
     // ── findSchemaBaseDir：剥 GitHub 归档壳目录(修 essay.txt 落进 rime-essay-master/ 子目录) ──


### PR DESCRIPTION
- 引入 SchemaManifestManager 来管理方案安装清单
- 迁移旧版 market 目录结构（rime/market/ → market/）
- 实现基于清单的精确卸载功能，避免文件冲突
- 在导入和安装时自动创建方案清单文件

refactor(schema): 更新方案管理逻辑

- 修改 getMarketDir 路径为与 rime/ 同级
- 改进文件冲突检测机制，阻止真正冲突的安装
- 增强导入保护机制，保护 xime.yaml 等系统文件
- 将 deleteSchemaFiles 方法改为 suspend 函数

feat(ui): 添加批量卸载方案对话框

- 在方案设置页面添加卸载选项菜单
- 实现多选方案批量卸载功能
- 显示方案详细信息包括文件数量和版本