### PR TITLE
fix(rime): 修复 T9 九键右选候选词消费输入序列错误（多场景）

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
@@ -561,10 +561,18 @@ class T9RightCommitHandler {
             ctx.stateMachine.selectionHistory.joinToString("") { it.pinyin } == selectedPinyin &&
             candidateTextLength > 0 &&
             candidateTextLength >= ctx.stateMachine.selectionHistory.size
+        // 场景19（"er 儿"边界条件）：候选词各音节简拼首字母数字码逐位对齐整个 buffer
+        // 数字码时，全拼选中项被多音节简拼拆分消费（如 he(43) 被 ha(4)+er(3) 消费），
+        // 应判定 full commit。isAllSelectedConsumed 要求音节数==选择数会在此失效。
+        val isJianpinAlignedFullCommit = hasSyllableBoundaries &&
+            candidateTextLength > 0 &&
+            candidateTextLength >= commentSyllables.size &&
+            isFullCommitByJianpinAlignment(selectedPinyin, commentSyllables)
         val isFullCommit = (hasSyllableBoundaries && candidateTextLength > 0 &&
             candidateTextLength >= commentSyllables.size &&
             (selectedPinyin.dropLast(prevSelectedOption.pinyin.length).isEmpty() ||
-                isAllSelectedConsumed(selectedPinyin, commentSyllables, ctx.stateMachine.selectionHistory))) ||
+                isAllSelectedConsumed(selectedPinyin, commentSyllables, ctx.stateMachine.selectionHistory) ||
+                isJianpinAlignedFullCommit)) ||
             isFullCommitWithoutBoundaries
         if (isFullCommit) {
             clearAndEnterIdle(ctx)

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
@@ -470,8 +470,39 @@ class T9RightCommitHandler {
         if (effectiveLetterCount > 0) {
             if (effectiveLetterCount < selectedPinyin.length) {
                 if (prevSelectedOption != null) {
-                    // SELECTION 态：保留未消费部分为字母形式（与 scenario 16 设计一致）
                     val consumedPinyin = selectedPinyin.take(effectiveLetterCount)
+                    // 场景18：候选词 pinyin 是 prevSelectedOption.pinyin 的真前缀
+                    // （如 candidatePinyin="ti", prevSelectedOption.pinyin="tian"）。
+                    // removeConsumedSelections 只能移除完整匹配的选择条目，无法处理
+                    // "消费选中项部分 pinyin" 的情况——此时 consumedPinyin 比选中项更短，
+                    // 不匹配任何完整选择，removeConsumedSelections 什么都不会移除，
+                    // 导致 buffer 保持原状、与 RIME 已消费的状态不一致。
+                    // 正确语义：相当于用户从选中项切换到更短的拼音选择（同一层切换），
+                    // 消费 consumedPinyin 对应数字，剩余转纯数字 buffer。
+                    // 与下方 INPUT 态分支逻辑一致；buffer 从字母变为数字时必须清空
+                    // selectionHistory（与 tryShengmuFallback / apostrophe 声母匹配分支
+                    // 的 clearSelectionHistory() + enterInput() 模式一致）。
+                    if (consumedPinyin.length < prevSelectedOption.pinyin.length &&
+                        prevSelectedOption.pinyin.startsWith(consumedPinyin)) {
+                        val remainingDigits = T9PinyinMap.pinyinToDigitCode(
+                            selectedPinyin.drop(effectiveLetterCount))
+                        if (remainingDigits != null) {
+                            ctx.inputBuffer = T9Buffer(
+                                digitSequence = remainingDigits,
+                                selections = emptyList(),
+                                consumedCount = 0,
+                                totalDigitsEntered = remainingDigits.length,
+                            )
+                            ctx.leftColumnLocked = false
+                            ctx.stateMachine.clearSelectionHistory()
+                            ctx.stateMachine.enterInput()
+                            ctx.syncState()
+                            ctx.updateCandidates(true)
+                            ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+                            return false
+                        }
+                    }
+                    // SELECTION 态：保留未消费部分为字母形式（与 scenario 16 设计一致）
                     ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedPinyin)
                     ctx.leftColumnLocked = false
                     return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
@@ -382,7 +382,17 @@ class T9RightCommitHandler {
             buf.withRemainingDigits(remainingDigits, buf)
         }
         ctx.leftColumnLocked = false
-        if (ctx.inputBuffer.isEmpty) ctx.stateMachine.enterIdle() else ctx.stateMachine.enterInput()
+        if (ctx.inputBuffer.isEmpty) {
+            ctx.stateMachine.enterIdle()
+        } else {
+            // withRemainingDigits 创建 selections=emptyList()，已消费全部选择。
+            // 必须同步清理 selectionHistory，否则残留条目会导致后续左选→右选时
+            // isFullCommitWithoutBoundaries 误判（场景17 根因：
+            // joinToString 拼接残留+新条目 ≠ selectedPinyin）。
+            // 与上方 isShengmuMatch/isFullPinyinMatch 分支 line 350-351 一致。
+            ctx.stateMachine.clearSelectionHistory()
+            ctx.stateMachine.enterInput()
+        }
         ctx.syncState()
         ctx.updateCandidates(true)
         ctx.setRimeInput(ctx.inputBuffer.toBufferString())

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
@@ -52,6 +52,48 @@ fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): 
 }
 
 /**
+ * 判断候选词各音节"简拼首字母数字码"是否逐位对齐整个 buffer 的数字码。
+ *
+ * 用于场景19 等"全拼选中项被候选词多音节简拼消费"的边界条件：
+ * 候选词的每个音节仅以其首字母对应的数字码消费 1 位，所有音节首字母数字码
+ * 拼接后等于 buffer 的数字码 → 候选词完整覆盖 buffer，应触发 full commit。
+ *
+ * 典型场景（"er 儿"边界条件）：
+ *   buffer selectedPinyin="khe" → 数字码 "543"（k=5, h=4, e=3）
+ *   候选"卡哈尔"(comment="ka ha er")：ka→k(5)、ha→h(4)、er→e(3)
+ *   三音节简拼首字母数字码 = "543" == buffer 数字码 → full commit
+ *
+ * 此时全拼选中项 `he`(digits 43) 被候选词的 `ha`+`er` 两个简拼音节拆分消费，
+ * 既有 [isAllSelectedConsumed] 因 `commentSyllables.size != selectionHistory.size`
+ * 失败，[handleConsumedAllNonSelected] 的精确/简拼缩写匹配也因 `er`→"37" 既不
+ * 等于 `he`→"43"（精确）也不满足 `he.digitLength==1`（简拼缩写）而失败。
+ *
+ * 判定条件（同时满足）：
+ *   1. 候选音节数 == buffer 数字码位数（每个音节恰消费 1 位）
+ *   2. 每个音节首字母数字码 == buffer 对应位数字
+ *
+ * 这与设计方案 §6.6 "全量提交精确匹配规则" 不冲突：全拼选中项本身仍要求精确匹配，
+ * 本函数仅判定"候选词整体简拼对齐 buffer 数字码"这一多音节简拼消费情形，
+ * 单音节候选（hasSyllableBoundaries=false）不进入此路径。
+ *
+ * @param selectedPinyin 当前 buffer 的 selectedPinyin（selections 拼接）
+ * @param commentSyllables 候选词拼音注释的音节列表
+ * @return true 表示候选词简拼首字母数字码逐位对齐 buffer 数字码
+ */
+fun isFullCommitByJianpinAlignment(
+    selectedPinyin: String,
+    commentSyllables: List<String>,
+): Boolean {
+    if (commentSyllables.isEmpty()) return false
+    val bufferDigits = T9PinyinMap.pinyinToDigitCode(selectedPinyin) ?: return false
+    if (commentSyllables.size != bufferDigits.length) return false
+    return commentSyllables.indices.all { i ->
+        val sylCode = T9PinyinMap.pinyinToDigitCode(commentSyllables[i])
+        sylCode != null && sylCode.take(1) == bufferDigits[i].toString()
+    }
+}
+
+/**
  * 判断 selectionHistory 是否完全覆盖 inputBuffer，且候选词的 comment 音节与选择历史逐位对齐。
  *
  * 当 buffer 完全由 selectionHistory 的拼音拼接构成，且候选词的 comment 音节数字码
@@ -104,4 +146,37 @@ fun shouldFullCommitInSelection(
     val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
         ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
     return commentSyllables.any { T9PinyinMap.areDigitCodesMatching(it, selectedPinyin) }
+}
+
+/**
+ * 解析 RIME 原始候选词列表中与用户选中候选词对应的 index。
+ *
+ * 场景19 后续修复（上屏错词问题）：
+ * T9 模式下，UI 候选词列表经过 [filterCandidatesBySelectionHistory] 过滤/重排序
+ * （FULL 匹配在前、PREFIX 在后、NONE 排除），其 index 可能与 RIME 原始候选词
+ * index 不对应。服务层 [com.kingzcheung.xime.service.XimeInputMethodService.selectCandidateAsync]
+ * 若直接用 UI index 调用 `rimeEngine.selectCandidate(index)`，RIME 会选错词 →
+ * `commit()` 返回错误文本 → full commit 上屏错词。
+ *
+ * 例：selectionHistory=[k, he] 时：
+ *   - RIME 原始列表：[考核, 恐吓, 可恨, 课后, 跨行, 卡哈尔, 开盒儿, 看会儿, 看, 可]
+ *   - 过滤后列表：[考核, 恐吓, 开盒儿, 课后, 跨行, 卡哈尔, 看会儿, 看, 可]
+ *     （可恨被 NONE 排除、开盒儿从 index=6 前移到 index=2）
+ *   - 用户右选"开盒儿"(UI index=2) → selectCandidate(2) → RIME 选"可恨"(已排除) → 上屏错词
+ *
+ * 本函数通过候选词文本在 RIME 原始列表中查找真实 index，确保 RIME 选对词。
+ *
+ * @param uiIndex UI 显示的候选词 index（过滤/重排序后）
+ * @param selectedCandidate 用户选中的候选词文本
+ * @param rawCandidates RIME 原始候选词列表（来自 `RimeEngine.getCandidates()`）
+ * @return RIME 原始候选词的 index；文本不在原始列表中时回退 [uiIndex]
+ */
+fun resolveRimeCandidateIndex(
+    uiIndex: Int,
+    selectedCandidate: String?,
+    rawCandidates: List<String>,
+): Int {
+    if (selectedCandidate == null) return uiIndex
+    val rawIdx = rawCandidates.indexOf(selectedCandidate)
+    return if (rawIdx >= 0) rawIdx else uiIndex
 }

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -85,6 +85,7 @@ import com.kingzcheung.xime.rime.RimeEngine
 import com.kingzcheung.xime.rime.T9InputController
 import com.kingzcheung.xime.rime.convertT9PreeditToPinyin
 import com.kingzcheung.xime.rime.buildT9DisplayState
+import com.kingzcheung.xime.rime.resolveRimeCandidateIndex
 
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
@@ -2307,7 +2308,17 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             false
         }
 
-        if (rimeEngine.selectCandidate(index)) {
+        // T9 模式：UI 候选词列表经过 filterCandidatesBySelectionHistory 过滤/重排序
+        // （FULL 在前、PREFIX 在后、NONE 排除），其 index 可能与 RIME 原始候选词
+        // index 不对应。通过候选词文本查找 RIME 原始候选词的真实 index，确保
+        // selectCandidate 选对词（场景19 后续修复：上屏错词问题）。
+        val rimeIndex = if (isT9 && selectedCandidate != null) {
+            resolveRimeCandidateIndex(index, selectedCandidate, rimeEngine.getCandidates().toList())
+        } else {
+            index
+        }
+
+        if (rimeEngine.selectCandidate(rimeIndex)) {
             val committedText = rimeEngine.commit()
             // T9 模式下 fullyConsumed 是判断 full/partial commit 的唯一权威：
             // 当控制器明确 partial commit 时，即使 RIME commit() 返回非空文本
@@ -2325,9 +2336,19 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         Log.d(TAG, "Learned: '$lastChar' + '$selectedCandidate'")
                     }
                 }
-                // T9 模式：将 partial commit 累积文本与 RIME committedText 合并后上屏，
-                // 避免之前 partial commit 的文本丢失
-                val textToMerge = if (committedText.isNotEmpty()) committedText else selectedCandidate!!
+                // T9 full commit：优先使用用户明确选中的候选词文本作为上屏文本。
+                // UI 候选词列表经 filterCandidatesBySelectionHistory 过滤/重排序后 index
+                // 可能与 RIME 原始候选词 index 不对应。即使已通过 resolveRimeCandidateIndex
+                // 修正了 selectCandidate 的 index，仍以用户选中的 selectedCandidate 为权威
+                // 上屏文本（双保险），避免 RIME commit() 因任何原因返回错误文本。
+                // 非 T9 模式仍保持 RIME committedText 优先（可能含简繁转换等处理）。
+                val textToMerge = if (isT9 && fullyConsumed && selectedCandidate != null) {
+                    selectedCandidate
+                } else if (committedText.isNotEmpty()) {
+                    committedText
+                } else {
+                    selectedCandidate!!
+                }
                 val fullCommitText = if (isT9) {
                     PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, textToMerge)
                 } else {

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
@@ -1414,6 +1414,162 @@ class T9RightCommitHandlerTest {
         assertPinyins(ctrl, "an", "ao", "bo", "a", "b", "c")
     }
 
+    // ── 场景19：简拼对齐的全拼选中项被候选词多音节简拼消费，应 full commit ──
+    //
+    // 操作流程（来自 .trae/docs/T9测试/异常输入流程.md 场景19，行121-138）：
+    // 1. 输入 5143（5 + 分词键 + 43）→ j'ge（j 由分词键确认，43 由 RIME 推断为 ge）
+    // 2. 左选 k → k'43（替换 j 为 k）
+    // 3. 左选 he → khe（SELECTION(he)，he 高亮）
+    // 4. 右选"卡哈尔"(comment="ka ha er", textLength=3) → 候选 3 音节 ka/ha/er 的
+    //    简拼首字母数字码 = 5/4/3 = "543" = buffer 数字码
+    //
+    // 期望：full commit，buffer 清空，进入 IDLE
+    // 根因（修复前）：isAllSelectedConsumed 要求 commentSyllables.size == selectionHistory.size
+    //   （3 != 2 失败），且候选最后音节 "er" 既不精确匹配选中项 "he"（"37"!="43"），
+    //   也不满足简拼缩写匹配（he.digitLength=2，非简拼）→ 误判 partial commit，
+    //   仅消费非选中部分 "k"，保留 "he"，预编辑文本残留 "卡哈尔he"。
+    //   "er 儿" 是边界条件：he(digits 43) 被 ka/ha/er 三音节简拼(5/4/3)完整消费。
+
+    @Test
+    fun `scenario 19 - jianpin-aligned candidate ka ha er full commits consuming entire buffer`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143（5 + 分词键 + 43）
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k → 替换分词键确认的 j
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 左选 he → SELECTION(he)，buffer="khe"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
+        assertEquals("khe", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("he", 2), ctrl.selectedOption)
+
+        // 步骤4: 右选"卡哈尔"(comment="ka ha er", textLength=3)
+        // ka→k(5) ha→h(4) er→e(3)，三音节简拼首字母数字码 "543" == buffer 数字码
+        val result = ctrl.onRightCandidateSelected("ka ha er", 3)
+        assertTrue("Should be full commit — ka/ha/er 简拼对齐 543 消费全部输入", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertTrue(ctrl.selectionHistory.isEmpty())
+    }
+
+    @Test
+    fun `scenario 19 - isFullCommitByJianpinAlignment pure function detects digit-by-digit alignment`() {
+        // 纯函数：候选词各音节简拼首字母数字码逐位等于 buffer 数字码
+        assertTrue(isFullCommitByJianpinAlignment("khe", listOf("ka", "ha", "er")))
+        // er 单独也能对齐 e(3)
+        assertTrue(isFullCommitByJianpinAlignment("e", listOf("er")))
+        // 简拼缩写候选（ke→k, bei→b, er→e）对齐 "kbe"→"523"
+        assertTrue(isFullCommitByJianpinAlignment("kbe", listOf("ke", "bei", "er")))
+        // 音节数 ≠ 数字位数 → 不触发（交由既有路径）
+        assertFalse(isFullCommitByJianpinAlignment("khe", listOf("kao", "he")))
+        assertFalse(isFullCommitByJianpinAlignment("khe", listOf("ke", "hen")))
+        assertFalse(isFullCommitByJianpinAlignment("khe", listOf("kan")))
+        // 某音节首字母数字码不匹配
+        assertFalse(isFullCommitByJianpinAlignment("khe", listOf("ka", "ha", "san")))
+        // 空入参
+        assertFalse(isFullCommitByJianpinAlignment("khe", emptyList()))
+        assertFalse(isFullCommitByJianpinAlignment("", listOf("ka")))
+    }
+
+    // ── 场景19 后续：候选词 index 错位修复（上屏错词问题）──
+    //
+    // 问题：filterCandidatesBySelectionHistory 将候选词分为 FULL/PREFIX 两组重排序，
+    // 导致 UI 列表 index 与 RIME 原始候选词 index 不对应。
+    // selectCandidateAsync 用 UI index 调用 rimeEngine.selectCandidate(index)，
+    // RIME 选错词 → commit() 返回错误文本 → full commit 上屏错词。
+    // 例：selectionHistory=[k, he] 时，RIME 原始列表 [考核, 恐吓, 可恨, 课后, 跨行,
+    // 卡哈尔, 开盒儿, 看会儿, 看, 可]，过滤后 [考核, 恐吓, 开盒儿, 课后, 跨行,
+    // 卡哈尔, 看会儿, 看, 可]（可恨被排除、开盒儿从 index=6 前移到 index=2）。
+    // 用户右选"开盒儿"(UI index=2) → selectCandidate(2) → RIME 选"可恨"(已被排除) →
+    // 甚至可能选到"恐吓" → 上屏"恐吓"而非"开盒儿"。
+    //
+    // 修复：resolveRimeCandidateIndex 通过候选词文本查找 RIME 原始候选词 index。
+
+    @Test
+    fun `resolveRimeCandidateIndex returns raw index when candidate text found in raw list`() {
+        // RIME 原始候选词列表
+        val rawCandidates = listOf("考核", "恐吓", "可恨", "课后", "跨行", "卡哈尔", "开盒儿", "看会儿", "看", "可")
+        // 用户选"开盒儿"（UI index=2，因过滤重排序），但 RIME 原始 index=6
+        val result = resolveRimeCandidateIndex(
+            uiIndex = 2,
+            selectedCandidate = "开盒儿",
+            rawCandidates = rawCandidates,
+        )
+        assertEquals("应返回 RIME 原始 index=6", 6, result)
+    }
+
+    @Test
+    fun `resolveRimeCandidateIndex returns first match when duplicate candidate texts exist`() {
+        val rawCandidates = listOf("看", "可", "看", "可")
+        // 重复文本"看"在 index=0 和 index=2，应返回第一个（index=0）
+        val result = resolveRimeCandidateIndex(
+            uiIndex = 1,
+            selectedCandidate = "看",
+            rawCandidates = rawCandidates,
+        )
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun `resolveRimeCandidateIndex falls back to uiIndex when candidate text not in raw list`() {
+        // 候选词文本不在 RIME 原始列表中（如 UI 层补充的候选词），回退 uiIndex
+        val rawCandidates = listOf("考核", "恐吓", "可恨")
+        val result = resolveRimeCandidateIndex(
+            uiIndex = 5,
+            selectedCandidate = "自定义词",
+            rawCandidates = rawCandidates,
+        )
+        assertEquals("找不到时回退 uiIndex", 5, result)
+    }
+
+    @Test
+    fun `resolveRimeCandidateIndex falls back to uiIndex when selectedCandidate is null`() {
+        val rawCandidates = listOf("考核", "恐吓")
+        val result = resolveRimeCandidateIndex(
+            uiIndex = 1,
+            selectedCandidate = null,
+            rawCandidates = rawCandidates,
+        )
+        assertEquals("selectedCandidate 为 null 时回退 uiIndex", 1, result)
+    }
+
+    @Test
+    fun `resolveRimeCandidateIndex falls back to uiIndex when rawCandidates is empty`() {
+        val result = resolveRimeCandidateIndex(
+            uiIndex = 3,
+            selectedCandidate = "开盒儿",
+            rawCandidates = emptyList(),
+        )
+        assertEquals("rawCandidates 为空时回退 uiIndex", 3, result)
+    }
+
+    @Test
+    fun `resolveRimeCandidateIndex scenario 19 - ka ha er full commit selects correct raw index`() {
+        // 场景19 完整模拟：selectionHistory=[k, he]
+        // RIME 原始列表（基于 preedit "k'he"）：
+        //   [考核(kao he), 恐吓(kong he), 可恨(ke hen), 课后(ke hou), 跨行(kua hang),
+        //    卡哈尔(ka ha er), 开盒儿(kai he er), 看会儿(kan hu er), 看(kan), 可(ke)]
+        // filterCandidatesBySelectionHistory 后（FULL 在前，PREFIX 在后，NONE 排除）：
+        //   FULL: 考核, 恐吓, 开盒儿（kai→k, he→he, er 无对应选择但所有 selection 已匹配）
+        //   PREFIX: 课后, 跨行, 卡哈尔, 看会儿, 看, 可
+        //   NONE(排除): 可恨
+        //   过滤后: [考核, 恐吓, 开盒儿, 课后, 跨行, 卡哈尔, 看会儿, 看, 可]
+        val rawCandidates = listOf("考核", "恐吓", "可恨", "课后", "跨行", "卡哈尔", "开盒儿", "看会儿", "看", "可")
+        // 用户右选"卡哈尔"（过滤后 UI index=5），RIME 原始 index=5 → 一致（巧合）
+        assertEquals(5, resolveRimeCandidateIndex(5, "卡哈尔", rawCandidates))
+        // 用户右选"开盒儿"（过滤后 UI index=2），RIME 原始 index=6 → 修复错位
+        assertEquals(6, resolveRimeCandidateIndex(2, "开盒儿", rawCandidates))
+        // 用户右选"看会儿"（过滤后 UI index=6），RIME 原始 index=7 → 修复错位
+        assertEquals(7, resolveRimeCandidateIndex(6, "看会儿", rawCandidates))
+    }
+
     // ── 辅助方法 ──
 
     private fun createController(): T9InputController {

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
@@ -1336,6 +1336,84 @@ class T9RightCommitHandlerTest {
         assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
     }
 
+    // ── 场景18：右选候选词 pinyin 是选中项 pinyin 的真前缀，应切换选择并消费 ──
+    //
+    // 操作流程（来自 .trae/docs/T9测试/异常输入流程.md 场景18，行99-110）：
+    // 1. 输入 826 8426；预编辑 "tan tiao"
+    // 2. 左选 tao → "tao'8426"
+    // 3. 右选"饕"(tao) → partial commit → "8426"
+    // 4. 左选 tian → "tian"（SELECTION 态，tian 高亮）
+    // 5. 右选"惕"(comment="ti") → 候选词 pinyin "ti" 是选中项 "tian" 的真前缀
+    //
+    // 期望：相当于用户从 tian 切换到 ti，消费 ti(数字84)，剩余 26(an) 转纯数字 buffer
+    // 根因（修复前）：SELECTION 态分支调用 removeConsumedSelections("ti")，但 "ti" 不是
+    //   selections=[tian] 中任何选择的完整 pinyin，无法移除 → buffer 保持 [tian] 不变，
+    //   与 RIME 已消费"ti"的状态不一致 → 左侧候选区不刷新，tian 仍显示选中态
+
+    @Test
+    fun `scenario 18 - right candidate pinyin shorter than selected option switches selection and leaves remaining digits`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 826 + 分词键 + 8426
+        for (d in listOf("8", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onDigitPressed("1")
+        for (d in listOf("8", "4", "2", "6")) ctrl.onDigitPressed(d)
+        assertEquals("tan'8426", ctrl.bufferString)
+
+        // 步骤2: 左选 tao
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tao", 3))
+        assertEquals("tao'8426", ctrl.bufferString)
+
+        // 步骤3: 右选"饕"(tao) → partial commit，selectionHistory 被清空
+        ctrl.onRightCandidateSelected("tao", 1)
+        assertEquals("8426", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertTrue(ctrl.selectionHistory.isEmpty())
+
+        // 步骤4: 左选 tian → SELECTION(tian, "8426")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tian", 4))
+        assertEquals("tian", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("tian", 4), ctrl.selectedOption)
+
+        // 步骤5: 右选"惕"(comment="ti", textLength=1)
+        // 候选词 pinyin "ti" 是 prevSelectedOption.pinyin "tian" 的真前缀
+        // 期望：切换选择 tian→ti，消费 ti(数字84)，剩余 26(an) 转纯数字 buffer
+        val result = ctrl.onRightCandidateSelected("ti", 1)
+        assertFalse("Step 5: Should be partial commit — 'an' digits remain", result)
+        assertEquals("26", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        assertNull("Step 5: selectedOption must be null after switching to digit buffer", ctrl.selectedOption)
+        assertTrue(
+            "Step 5: selectionHistory must be cleared after switching to digit buffer",
+            ctrl.selectionHistory.isEmpty()
+        )
+    }
+
+    @Test
+    fun `scenario 18 - after switching to digit buffer left candidates refresh to an options`() {
+        val ctrl = createController()
+
+        // 前置步骤同上
+        for (d in listOf("8", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onDigitPressed("1")
+        for (d in listOf("8", "4", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tao", 3))
+        ctrl.onRightCandidateSelected("tao", 1)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tian", 4))
+        assertEquals("tian", ctrl.bufferString)
+
+        // 步骤5: 右选"惕"(ti)
+        ctrl.onRightCandidateSelected("ti", 1)
+        assertEquals("26", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 步骤6: 左侧候选区应刷新为数字 26 对应的拼音候选（an/ao/bo...）
+        // 修复前：左侧候选区仍为旧的 [tian, tiao, ti, t, u, v]，tian 仍显示选中态
+        // 与场景18描述的预期左侧候选区【an，ao，bo，a,b,c】一致
+        assertPinyins(ctrl, "an", "ao", "bo", "a", "b", "c")
+    }
+
     // ── 辅助方法 ──
 
     private fun createController(): T9InputController {

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
@@ -1238,6 +1238,104 @@ class T9RightCommitHandlerTest {
         assertNull(ctrl.selectedOption)
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // 场景17：全拼输入，左选拼音→右选候选词(partial)→左选拼音→右选候选词
+    //       第二次右选应 full commit 但因 selectionHistory 残留误判为 partial
+    //
+    // 操作流程（来自 .trae/docs/T9测试/异常输入流程.md 场景17，行81-94）：
+    //   1. 输入 826 + 分词键(1) + 8426 → buffer="tan'8426"
+    //      （T9PinyinMap 中 826=tao/tan, 8426=tian/tiao）
+    //   2. 左选 tao → 替换 tan → buffer="tao'8426"
+    //   3. 右选"饕"(comment="tao", textLength=1) → partial commit, buffer="8426"
+    //   4. 左选 tian → buffer="tian", SELECTION(tian, "8426")
+    //   5. 右选"天"(comment="tian", textLength=1) → 应 full commit, buffer="", IDLE
+    //
+    // 修复前根因：
+    //   步骤3 的 apostrophe else 分支调用 withRemainingDigits 创建 selections=emptyList()
+    //   但 enterInput() 不清理 selectionHistory，残留 [tao]；
+    //   步骤4 左选 tian 后 selectionHistory=[tao,tian]；
+    //   步骤5 isFullCommitWithoutBoundaries 检查 joinToString="taotian"≠"tian" → 判定失败
+    //   → 误为 partial commit，预编辑文本变成"饕天tian"而非上屏"饕天"。
+    //
+    // 修复后：
+    //   步骤3 清理 selectionHistory，步骤5 正确判定为 full commit。
+    //
+    // 注意：多音节候选词如"提案"(comment="ti an")走 hasSyllableBoundaries 路径，
+    //       不依赖 selectionHistory，因此不受此 bug 影响（与场景描述一致）。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 17 - partial commit then left select then right select should full commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 826 + 分词键(1) + 8426 → buffer="tan'8426"
+        for (d in listOf("8", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onDigitPressed("1") // 分词键：自动确认首音节 tan（firstSyllableOptions("826") 首项）
+        for (d in listOf("8", "4", "2", "6")) ctrl.onDigitPressed(d)
+        assertEquals("tan'8426", ctrl.bufferString)
+
+        // 步骤2: 左选 tao → 替换 tan → buffer="tao'8426"
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tao", 3))
+        assertEquals("tao'8426", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("tao", 3), ctrl.selectedOption)
+
+        // 步骤3: 右选"饕"(comment="tao", textLength=1) → partial commit
+        //   候选词"饕"的拼音"tao"恰好匹配已选拼音"tao"，消费选中项，保留未分配数字"8426"
+        val result1 = ctrl.onRightCandidateSelected("tao", 1)
+        assertFalse("Step 3: Should be partial commit — unassigned digits 8426 remain", result1)
+        assertEquals("8426", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+        // 关键不变式：partial commit 消费了全部 selections 后，selectionHistory 必须同步清理
+        assertTrue(
+            "Step 3: selectionHistory must be cleared after partial commit consumed all selections",
+            ctrl.selectionHistory.isEmpty()
+        )
+
+        // 步骤4: 左选 tian → buffer="tian", SELECTION(tian, "8426")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tian", 4))
+        assertEquals("tian", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("tian", 4), ctrl.selectedOption)
+        assertEquals("8426", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 右选"天"(comment="tian", textLength=1) → 应 full commit
+        //   修复前：selectionHistory=[tao,tian] → joinToString="taotian"≠"tian" → 误判 partial
+        //   修复后：selectionHistory=[tian] → joinToString="tian"=="tian" → 正确判定 full commit
+        val result2 = ctrl.onRightCandidateSelected("tian", 1)
+        assertTrue("Step 5: Should be full commit — '天' consumes all remaining input", result2)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `scenario 17 - multi-syllable candidate ti an also full commits after fix`() {
+        // 场景17 步骤6变体：步骤4后右选"提案"(comment="ti an", textLength=2)
+        // 多音节候选词走 hasSyllableBoundaries 路径，不受 selectionHistory 残留影响，
+        // 但修复后此路径同样应正确 full commit。
+        val ctrl = createController()
+
+        for (d in listOf("8", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onDigitPressed("1")
+        for (d in listOf("8", "4", "2", "6")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tao", 3))
+        assertEquals("tao'8426", ctrl.bufferString)
+
+        // 步骤3: 右选"饕" → partial commit
+        ctrl.onRightCandidateSelected("tao", 1)
+        assertEquals("8426", ctrl.bufferString)
+
+        // 步骤4: 左选 tian
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("tian", 4))
+        assertEquals("tian", ctrl.bufferString)
+
+        // 步骤5变体: 右选"提案"(comment="ti an", textLength=2) → full commit
+        val result = ctrl.onRightCandidateSelected("ti an", 2)
+        assertTrue("Should be full commit — '提案' consumes all remaining input", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
     // ── 辅助方法 ──
 
     private fun createController(): T9InputController {


### PR DESCRIPTION
## 关联 Issue

Closes #395 #336

## 变更说明
 场景：17解决：#395

修复 T9 九键右选候选词在三类边界条件下错误消费输入序列的问题，配置文件为 `t9.schema.yaml`（雾凇拼音九键）。

### 场景17：partial commit 后 selectionHistory 残留导致 full commit 误判 

**复现**：输入 `826+8426` → 左选 tao → 右选"饕"(partial) → 左选 tian → 右选"天"
**现象**：应 full commit 清空，实际误判 partial，预编辑残留"饕天tian"，且会累计。除非遇到“ti an提按词语”
**根因**：`handleApostropheRightCommit` else 分支 `withRemainingDigits` 创建空 selections 但未清理 `selectionHistory`，残留 `[tao]` 导致后续 `isFullCommitWithoutBoundaries` 校验失败
**修复**：else 分支 partial commit 路径补充 `clearSelectionHistory()`

### 场景18：候选词拼音为选中项真前缀时左侧候选区不刷新

**复现**：输入 `826+8426` → 左选 tao → 右选"饕" → 左选 tian → 右选"惕"(comment=ti)，对应左侧候选区中：ti拼音。
**现象**：ti 是 tian 的真前缀，也是左侧候选区中一种可能性，应切换选择消费 ti(84)、剩余 26 转纯数字，实际左侧候选区不刷新、tian 仍选中
**根因**：SELECTION 态分支调用 `removeConsumedSelections("ti")`，但 ti 不是 selections=[tian] 的完整 pinyin，无法移除 → buffer 与 RIME 状态不一致
**修复**：SELECTION 态分支添加真前缀检测，消费对应数字、剩余转纯数字 buffer、清空 selectionHistory、进入 INPUT 态

### 场景19：候选词简拼对齐全拼选中项误判 partial + index 错位上屏错词

**复现**：输入 `51(分词)43` → 左选 k → 左选 he → 右选"卡哈尔"(ka ha er)（雾凇拼音词库词语）；上屏：“卡哈尔he”，修复后又发现右选"开盒儿"会错误上屏为"恐吓"等词语。
**现象**：候选词三音节（卡哈尔ka ha er）简拼首字母 k/h/e=543 恰等于 buffer 数字码，应 full commit 但误判 partial；首轮修复后 index 错位导致上屏错词
**根因**（两轮）：
1. `isAllSelectedConsumed` 要求音节数=选择数(3不等于2)失败，且 er→"37" 既不精确匹配 he→"43" 也不满足简拼缩写 → 误判 partial
2. `filterCandidatesBySelectionHistory` 重排序候选词致 UI index不等于RIME index，`selectCandidateAsync` 用 UI index 调 RIME 选错词
**修复**（双层）：
1. 新增 `isFullCommitByJianpinAlignment`：候选词各音节简拼首字母数字码逐位对齐 buffer 时触发 full commit
2. 新增 `resolveRimeCandidateIndex`：通过文本查找 RIME 原始 index；full commit 路径优先用 `selectedCandidate` 上屏

## 提交结构

3 个 GPG 签名 commit，每个场景独立可 revert：

| Commit | 场景 | 修改文件 |
|--------|------|---------|
| `9d6dcf1` | 场景17 | T9RightCommitHandler.kt、T9RightCommitHandlerTest.kt |
| `d310a96` | 场景18 | T9RightCommitHandler.kt、T9RightCommitHandlerTest.kt |
| `d02b7d4` | 场景19 | T9RightCommitHandler.kt、T9RightCommitUtils.kt、XimeInputMethodService.kt、T9RightCommitHandlerTest.kt |

## 测试

- 新增 12 个单元测试（场景17: 2 + 场景18: 2 + 场景19: 8）
- 全部单元测试通过（545/545）
- `./gradlew assembleDebug --quiet` 构建成功
- 所有 commit 均经 GPG 签名验证

## 检查清单

- [x] 关联的 Issue 已创建
- [x] 改动符合最小修改原则（仅修复三个场景，不重构无关代码）
- [x] 所有 commit 均已 GPG 签名
- [x] 本地构建通过：`./gradlew assembleDebug --quiet`
- [x] 测试通过：`./gradlew test`