### PR TITLE
feat(ci): 更新夜间构建脚本以支持动态版本号

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,13 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build Debug APKs
-        run: ./gradlew assembleDebug --no-daemon
+        run: |
+          DATE=$(date +'%Y%m%d')
+          COMMIT=$(git rev-parse --short HEAD)
+          ./gradlew assembleDebug \
+            -PnightlyVersionCode=$DATE \
+            -PnightlyVersionName="2.5.0-nightly-$DATE-$COMMIT" \
+            --no-daemon
 
       - name: Get build info
         id: info

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 55
-        versionName = "2.5.0-beta12"
+        versionCode = project.findProperty("nightlyVersionCode")?.toString()?.toIntOrNull() ?: 55
+        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.5.0-beta12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
- 在GitHub Actions工作流中添加日期和提交哈希作为夜间版本标识
- 修改build.gradle.kts以支持通过项目属性动态设置版本代码和版本名称
- 集成版本信息注入机制，用于区分夜间构建与正式发布