### PR TITLE
feat(SchemaManager): 统一文件导入逻辑并改进压缩包处理

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -309,7 +309,7 @@ android {
         minSdk = 28
         targetSdk = 35
         versionCode = project.findProperty("nightlyVersionCode")?.toString()?.toIntOrNull() ?: 56
-        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.5.0"
+        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/java/com/kingzcheung/xime/MainActivity.kt
+++ b/app/src/main/java/com/kingzcheung/xime/MainActivity.kt
@@ -212,13 +212,14 @@ class MainActivity : ComponentActivity() {
     
     private fun importSchema(uri: android.net.Uri) {
         prewarmScope.launch {
-            val success = SchemaManager.importSchemaFile(this@MainActivity, uri)
+            val result = SchemaManager.importSchemaFile(this@MainActivity, uri)
             launch(Dispatchers.Main) {
-                Toast.makeText(
-                    this@MainActivity,
-                    if (success) "方案导入成功，请到「输入方案」页面部署" else "方案导入失败",
-                    Toast.LENGTH_LONG
-                ).show()
+                val msg = when {
+                    !result.success -> "方案导入失败"
+                    result.installedDirect -> "方案导入成功，已放入 rime 目录"
+                    else -> "方案导入成功，请到「输入方案」页面部署"
+                }
+                Toast.makeText(this@MainActivity, msg, Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -143,7 +143,7 @@ object SchemaManager {
                             if (entry.isDirectory || isAppleDouble(originalName)) return@forEach
                             val name = originalName.removePrefix(baseDir)
                             if (isProtectedImportName(name)) return@forEach
-                            val hash = streamSha256(zip.getInputStream(entry))
+                            val hash = zip.getInputStream(entry).use { streamSha256(it) }
                             result[name] = hash
                         }
                     }
@@ -453,10 +453,10 @@ object SchemaManager {
 
     fun streamSha256(input: InputStream): String {
         val digest = MessageDigest.getInstance("SHA-256")
-        DigestInputStream(input, digest).use { dis ->
-            val buffer = ByteArray(8192)
-            while (dis.read(buffer) != -1) { }
-        }
+        val dis = DigestInputStream(input, digest)
+        val buffer = ByteArray(8192)
+        while (dis.read(buffer) != -1) { }
+        // 不关闭 dis——调用方负责管理流的生命周期
         return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
     }
 
@@ -683,9 +683,10 @@ object SchemaManager {
         } else {
             // 降级到传统逻辑（无清单的旧方案）
             val rimeDir = getRimeDir(context)
+            // 先读 dictName 再删 schema.yaml，否则 getReferencedDictName 永远返回 null
+            val dictName = getReferencedDictName(context, schemaId) ?: schemaId
             val schemaFile = File(rimeDir, "$schemaId.schema.yaml")
             if (schemaFile.exists()) schemaFile.delete()
-            val dictName = getReferencedDictName(context, schemaId) ?: schemaId
             val dictFile = File(rimeDir, "$dictName.dict.yaml")
             if (dictFile.exists()) dictFile.delete()
             Log.i(TAG, "Legacy uninstall for $schemaId (dict=$dictName)")
@@ -699,35 +700,82 @@ object SchemaManager {
         return true
     }
 
-    suspend fun importSchemaFile(context: Context, uri: Uri): Boolean {
-        return withContext(Dispatchers.IO) {
+    data class ImportResult(val success: Boolean, val installedDirect: Boolean = false)
+
+    /** 判断文件名是否为压缩包。 */
+    fun isArchive(name: String): Boolean =
+        name.endsWith(".zip", ignoreCase = true) ||
+        name.endsWith(".tar.gz", ignoreCase = true) ||
+        name.endsWith(".tgz", ignoreCase = true)
+
+    /**
+     * 统一保存导入的文件：
+     * - 压缩包（zip/tar.gz/tgz）→ market/{importId}/，等待用户手动安装
+     * - 非压缩包（yaml/txt/bin 等）→ 直接放入 rime/
+     * 所有导入路径（文件选择器、无线导入、URL 下载等）最终都汇聚于此。
+     */
+    suspend fun saveImportedFile(
+        context: Context,
+        displayName: String,
+        inputStream: java.io.InputStream,
+        autoEnable: Boolean = true,
+    ): ImportResult = withContext(Dispatchers.IO) {
+        if (isArchive(displayName)) {
+            // 压缩包：保存到 market/ 等待用户手动安装
             val importId = generateImportId()
             val pkgDir = getMarketDir(context, importId)
             try {
-                val displayName = getFileName(context, uri) ?: run {
-                    pkgDir.deleteRecursively(); return@withContext false
-                }
                 pkgDir.mkdirs()
                 val archiveFile = File(pkgDir, displayName)
-
-                val inputStream = when (uri.scheme) {
-                    "file" -> java.io.FileInputStream(uri.path!!)
-                    else -> context.contentResolver.openInputStream(uri)
-                }
-                inputStream?.use { input ->
+                inputStream.use { input ->
                     archiveFile.outputStream().use { output -> input.copyTo(output) }
-                } ?: run {
-                    pkgDir.deleteRecursively()
-                    return@withContext false
                 }
-
                 Log.i(TAG, "Imported $displayName -> $importId (not installed yet)")
-                true
+                ImportResult(true)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to import schema file", e)
+                Log.e(TAG, "Failed to import archive $displayName", e)
                 try { if (pkgDir.exists()) pkgDir.deleteRecursively() } catch (_: Exception) {}
-                false
+                ImportResult(false)
             }
+        } else {
+            // 非压缩包：直接放入 rime/ 目录，不经过 market
+            val rimeDir = getRimeDir(context)
+            try {
+                rimeDir.mkdirs()
+                val target = File(rimeDir, displayName)
+                inputStream.use { input ->
+                    target.outputStream().use { output -> input.copyTo(output) }
+                }
+                // 如果是 .schema.yaml 文件，自动启用
+                if (autoEnable && displayName.endsWith(".schema.yaml")) {
+                    val schemaId = displayName.removeSuffix(".schema.yaml")
+                    val enabled = getEnabledSchemas(context).toMutableList()
+                    if (schemaId !in enabled) {
+                        enabled.add(schemaId)
+                        setEnabledSchemas(context, enabled)
+                    }
+                }
+                Log.i(TAG, "Imported $displayName -> rime/ (direct)")
+                ImportResult(true, installedDirect = true)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to import $displayName directly", e)
+                ImportResult(false)
+            }
+        }
+    }
+
+    suspend fun importSchemaFile(context: Context, uri: Uri): ImportResult {
+        return withContext(Dispatchers.IO) {
+            val displayName = getFileName(context, uri) ?: return@withContext ImportResult(false)
+
+            Log.d(TAG, "importSchemaFile: displayName=$displayName, isArchive=${isArchive(displayName)}")
+
+            val inputStream = when (uri.scheme) {
+                "file" -> java.io.FileInputStream(uri.path!!)
+                else -> context.contentResolver.openInputStream(uri)
+            } ?: return@withContext ImportResult(false)
+
+            saveImportedFile(context, displayName, inputStream)
         }
     }
 
@@ -954,9 +1002,8 @@ object SchemaManager {
      *                       为空/空白时保持原有行为（不校验）。
      */
     /**
-     * 从 URL 下载压缩包到 market 目录（保留压缩包），然后解压到 rime 目录。
-     * @param archiveName 压缩包在 market 目录中保存的文件名，如 "my_scheme.zip"。
-     *                    为空时从 URL 末段自动推断。
+     * 从 URL 下载文件（不限格式），通过 [saveImportedFile] 统一存入 rime/ 或 market/。
+     * @param archiveName 文件名，为空时从 URL 末段自动推断。
      */
     suspend fun importFromUrl(
         context: Context,
@@ -966,65 +1013,55 @@ object SchemaManager {
         onProgress: (Long, Long) -> Unit = { _, _ -> },
     ): Boolean = withContext(Dispatchers.IO) {
         try {
-            val isZip = url.endsWith(".zip", ignoreCase = true)
-            val isTarGz = url.endsWith(".tar.gz", ignoreCase = true) || url.endsWith(".tgz", ignoreCase = true)
-            if (!isZip && !isTarGz) {
-                Log.e(TAG, "Unsupported format: $url")
-                return@withContext false
-            }
+            val fileName = archiveName ?: url.substringAfterLast("/").takeIf { it.isNotBlank() }
+                ?: "download"
+            val tmpFile = File.createTempFile("import_", ".tmp", context.cacheDir)
 
-            val ext = when {
-                isZip -> ".zip"
-                url.endsWith(".tgz", ignoreCase = true) -> ".tgz"
-                else -> ".tar.gz"
-            }
-            val importId = generateImportId()
-            val pkgDir = getMarketDir(context, importId)
-            pkgDir.mkdirs()
-            val archiveFile = File(pkgDir, archiveName ?: (url.substringAfterLast("/").takeIf { it.isNotBlank() } ?: "download$ext"))
-
-            val client = OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(120, TimeUnit.SECONDS)
-                .followRedirects(true)
-                .build()
-            client.newCall(Request.Builder().url(url).build()).execute().use { response ->
-                if (!response.isSuccessful) {
-                    Log.e(TAG, "Download failed: ${response.code} $url")
-                    pkgDir.deleteRecursively()
-                    return@withContext false
-                }
-                val body = response.body ?: return@withContext false
-
-                val totalBytes = body.contentLength()
-                var downloadedBytes = 0L
-                val md = MessageDigest.getInstance("SHA-256")
-                body.byteStream().use { input ->
-                    FileOutputStream(archiveFile).use { output ->
-                        val buf = ByteArray(8192)
-                        var n = input.read(buf)
-                        while (n >= 0) {
-                            output.write(buf, 0, n)
-                            md.update(buf, 0, n)
-                            downloadedBytes += n
-                            if (totalBytes > 0) {
-                                onProgress(downloadedBytes, totalBytes)
-                            }
-                            n = input.read(buf)
-                        }
-                    }
-                }
-                if (!expectedSha256.isNullOrBlank()) {
-                    val actual = md.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
-                    if (!actual.equals(expectedSha256.trim(), ignoreCase = true)) {
-                        Log.e(TAG, "sha256 mismatch for $url: expected=${expectedSha256.trim()} actual=$actual")
-                        pkgDir.deleteRecursively()
+            try {
+                val client = OkHttpClient.Builder()
+                    .connectTimeout(30, TimeUnit.SECONDS)
+                    .readTimeout(120, TimeUnit.SECONDS)
+                    .followRedirects(true)
+                    .build()
+                val sha256Ok = client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Log.e(TAG, "Download failed: ${response.code} $url")
                         return@withContext false
                     }
+                    val body = response.body ?: return@withContext false
+                    val totalBytes = body.contentLength()
+                    var downloadedBytes = 0L
+                    val md = MessageDigest.getInstance("SHA-256")
+                    body.byteStream().use { input ->
+                        FileOutputStream(tmpFile).use { output ->
+                            val buf = ByteArray(8192)
+                            var n = input.read(buf)
+                            while (n >= 0) {
+                                output.write(buf, 0, n)
+                                md.update(buf, 0, n)
+                                downloadedBytes += n
+                                if (totalBytes > 0) onProgress(downloadedBytes, totalBytes)
+                                n = input.read(buf)
+                            }
+                        }
+                    }
+                    if (!expectedSha256.isNullOrBlank()) {
+                        val actual = md.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+                        if (!actual.equals(expectedSha256.trim(), ignoreCase = true)) {
+                            Log.e(TAG, "sha256 mismatch for $url")
+                            return@withContext false
+                        }
+                    }
+                    true
                 }
+                if (!sha256Ok) return@withContext false
 
-                Log.i(TAG, "Downloaded $url -> $importId (not installed yet)")
-                true
+                // 通过统一函数保存
+                val result = saveImportedFile(context, fileName, tmpFile.inputStream())
+                Log.i(TAG, "Imported from url $url -> ${if (result.installedDirect) "rime/" else "market/"} ($fileName)")
+                result.success
+            } finally {
+                tmpFile.delete()
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to import from URL: $url", e)

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -388,7 +388,7 @@ object SchemaManifestManager {
 
     private const val KEY_MIGRATION_VERSION = "manifest_migration_version"
     private const val MIGRATION_VERSION_CURRENT = 3
-    private const val BUILTIN_PACKAGE_ID = "builtin"
+    internal const val BUILTIN_PACKAGE_ID = "builtin"
 
     /**
      * 为旧版已安装方案创建/合并遗留清单。
@@ -464,6 +464,9 @@ object SchemaManifestManager {
                 // 确保 market/builtin/ 存在（迁移前没有此目录的旧版本会在此补齐）
                 ensureBuiltinBackup(context)
 
+                // 每次启动将 untracked 文件追加到 builtin 清单（APP 更新后新文件不会被旧清单追踪）
+                refreshBuiltinManifest(context)
+
                 if (prevVersion >= MIGRATION_VERSION_CURRENT) return@withContext
 
                 val rimeDir = SchemaManager.getRimeDir(context)
@@ -486,12 +489,13 @@ object SchemaManifestManager {
                     }
                 }
 
-                // 扫描 rime/ 下所有文件，归入 builtin 包（排除系统文件与 build/）
+                // 扫描 rime/ 下所有文件，归入 builtin 包（排除系统文件与用户数据）
                 val allFilesInRime = mutableSetOf<String>()
                 rimeDir.walkTopDown().forEach { f ->
                     if (!f.isFile) return@forEach
                     val relPath = f.toRelativeString(rimeDir).replace('\\', '/')
                     if (isProtectedSystemFile(relPath)) return@forEach
+                    if (isUserDataFile(relPath)) return@forEach
                     allFilesInRime.add(relPath)
                 }
                 if (allFilesInRime.isNotEmpty()) {
@@ -552,6 +556,93 @@ object SchemaManifestManager {
     }
 
     // ── Market Package Listing ──
+
+    /** 判断文件是否为用户数据或系统配置（不应被清单追踪，卸载时不应被删除）。 */
+    private fun isUserDataFile(relPath: String): Boolean {
+        if (relPath.startsWith("build/")) return true
+        if (relPath.contains(".userdb/")) return true
+        if (relPath.endsWith(".custom.yaml")) return true
+        if (relPath == "installation.yaml") return true
+        if (relPath == "custom_phrase.txt") return true
+        if (relPath == "xime.custom.yaml") return true
+        return false
+    }
+
+    /**
+     * 扫描 rime/ 下未被任何包（registry）追踪的文件，追加到 builtin 清单和注册表中。
+     *
+     * APP 更新后新版 assets 可能新增了文件，但 builtin 清单仅在首次迁移时创建一次，
+     * 新增文件不会被追踪，导致卸载 builtin 包时删不干净。每次安装前调用此函数，
+     * 可确保所有内置文件都在清单中。
+     *
+     * 用户数据文件（.userdb/、*.custom.yaml、installation.yaml、custom_phrase.txt）
+     * 不会被追踪，确保卸载时不被误删。
+     */
+    suspend fun refreshBuiltinManifest(context: Context) = withContext(Dispatchers.IO) {
+        val rimeDir = SchemaManager.getRimeDir(context)
+        if (!rimeDir.exists()) return@withContext
+
+        val registry = loadRegistry(context)
+        val allFiles = registry.optJSONObject("files") ?: JSONObject()
+
+        // 找出 rime/ 中未被任何包追踪且非用户数据的文件
+        val untracked = mutableMapOf<String, File>()
+        rimeDir.walkTopDown().forEach { f ->
+            if (!f.isFile) return@forEach
+            val relPath = f.toRelativeString(rimeDir).replace('\\', '/')
+            if (isProtectedSystemFile(relPath)) return@forEach
+            if (isUserDataFile(relPath)) return@forEach
+            if (allFiles.has(relPath)) return@forEach
+            untracked[relPath] = f
+        }
+        if (untracked.isEmpty()) return@withContext
+
+        val existingManifest = loadManifest(context, BUILTIN_PACKAGE_ID)
+        val fileEntries = existingManifest?.optJSONObject("files") ?: JSONObject()
+
+        for ((relPath, file) in untracked) {
+            val sha256 = SchemaManager.fileSha256(file) ?: continue
+            fileEntries.put(relPath, JSONObject().apply {
+                put("sha256", sha256)
+                put("size", file.length())
+            })
+            allFiles.put(relPath, JSONObject().apply {
+                put("sha256", sha256)
+                put("size", file.length())
+                put("claimedBy", JSONArray(listOf(BUILTIN_PACKAGE_ID)))
+            })
+        }
+
+        // 更新或创建 builtin 清单
+        if (existingManifest != null) {
+            existingManifest.put("files", fileEntries)
+            saveManifest(context, BUILTIN_PACKAGE_ID, existingManifest)
+        } else {
+            val manifest = JSONObject().apply {
+                put("schemeId", BUILTIN_PACKAGE_ID)
+                put("displayName", "系统内置方案")
+                put("version", "")
+                put("installedAt",
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).format(Date()))
+                put("fromMarket", false)
+                put("legacy", true)
+                put("files", fileEntries)
+            }
+            saveManifest(context, BUILTIN_PACKAGE_ID, manifest)
+        }
+
+        registry.put("files", allFiles)
+        saveRegistry(context, registry)
+
+        // 同步备份到 market/builtin/
+        val builtinDir = SchemaManager.getMarketDir(context, BUILTIN_PACKAGE_ID)
+        builtinDir.mkdirs()
+        for ((relPath, file) in untracked) {
+            file.copyTo(File(builtinDir, relPath), overwrite = true)
+        }
+
+        Log.i(TAG, "refreshBuiltinManifest: added ${untracked.size} untracked files")
+    }
 
     /** 从注册表查询指定 schemaId 所属的包 ID。 */
     suspend fun getPackageIdForSchema(context: Context, schemaId: String): String? = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/kingzcheung/xime/settings/WirelessImportHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/WirelessImportHelper.kt
@@ -137,29 +137,18 @@ class WirelessImportHelper(private val context: Context) {
                     name.endsWith(".tar.gz", ignoreCase = true) ||
                     name.endsWith(".tgz", ignoreCase = true) ||
                     name.endsWith(".yaml") || name.endsWith(".schema.yaml") || name.endsWith(".dict.yaml") -> {
-                        // 保存到 market/{importId}/，不直接解压到 rime/
-                        val importId = SchemaManager.generateImportId()
-                        val pkgDir = if (name.endsWith(".yaml") || name.endsWith(".schema.yaml") || name.endsWith(".dict.yaml"))
-                            SchemaManager.getMarketDir(context, importId)
-                        else
-                            SchemaManager.getMarketDir(context, importId)
-                        pkgDir.mkdirs()
-                        val targetFile = File(pkgDir, name)
-
+                        // 先读到内存再调用统一 saveImportedFile（因 raf 需 seek 回内容起始）
                         raf.seek(contentStart)
-                        targetFile.outputStream().use { out ->
-                            val buf = ByteArray(8192)
-                            var remaining = contentLen
-                            while (remaining > 0) {
-                                val toRead = minOf(buf.size.toLong(), remaining).toInt()
-                                raf.readFully(buf, 0, toRead)
-                                out.write(buf, 0, toRead)
-                                remaining -= toRead
-                            }
-                        }
-
-                        saved = true
-                        _uploadResults.trySend(UploadResult(fileName = name, success = true))
+                        val buf = ByteArray(contentLen.toInt())
+                        raf.readFully(buf)
+                        val result = SchemaManager.saveImportedFile(
+                            context, name, buf.inputStream(), autoEnable = false
+                        )
+                        saved = result.success
+                        _uploadResults.trySend(
+                            if (result.success) UploadResult(fileName = name, success = true)
+                            else UploadResult(fileName = name, success = false, error = "保存失败")
+                        )
                     }
                     else -> {
                         _uploadResults.trySend(UploadResult(fileName = name, success = false, error = "不支持的文件类型"))
@@ -296,14 +285,14 @@ button:disabled{background:#c7c7cc;cursor:default}
 <body>
 <div class=card>
 <h1>导入输入方案</h1>
-<p>将 .schema.yaml / .dict.yaml 拖拽到下方，或点击选择</p>
+<p>将方案压缩包或者 xime.custom.yaml 拖拽到下方，或点击选择</p>
 <div class=drop-zone id=dz onclick="document.getElementById('fi').click()">
 <div class=drop-zone-icon>&#128196;</div>
 <div class=drop-zone-text>拖拽文件到此处</div>
-<div class=drop-zone-hint>支持 .schema.yaml / .dict.yaml / .zip / .tar.gz</div>
+<div class=drop-zone-hint>支持 xime.custom.yaml / .zip / .tar.gz</div>
 <div style='color:#8e8e93;font-size:12px;margin-top:12px;padding:10px;background:#f5f5f7;border-radius:8px;line-height:1.5'>💡 多文件或复杂目录结构，请打包为 .zip 或 .tar.gz 上传</div>
 </div>
-<input type=file id=fi accept='.yaml,.zip,.tar.gz,.tgz' multiple style='display:none'>
+<input type=file id=fi accept='.yaml,.zip,.tar.gz,.tgz,.gram' multiple style='display:none'>
 <div id=fl></div>
 <button id=ub disabled onclick=up()>上传</button>
 <div id=sm></div>

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
@@ -138,6 +138,8 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
             _uiState.update { it.copy(conflictPackageId = null, installingId = pkgId) }
             for (sid in _uiState.value.conflictingSchemeIds) {
                 withContext(Dispatchers.IO) {
+                    // 先刷新 builtin 清单：APP 更新后可能新增了未被清单追踪的文件
+                    SchemaManifestManager.refreshBuiltinManifest(context)
                     SchemaManifestManager.uninstallWithManifest(context, sid)
                 }
             }
@@ -178,8 +180,9 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
 
     fun uninstall(item: LocalPackageItem) {
         viewModelScope.launch {
-            val result = withContext(Dispatchers.IO) {
-                SchemaManifestManager.uninstallWithManifest(context, item.packageId)
+            withContext(Dispatchers.IO) {
+                SchemaManager.deleteSchemaFiles(context, item.packageId)
+                SchemaManager.deleteSchemeArchive(context, item.packageId)
             }
             // 若卸载后没有已安装的方案了，全量清理 rime/ 残留
             val remaining = withContext(Dispatchers.IO) {
@@ -190,7 +193,7 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
                     SchemaManager.cleanRimeDir(context)
                 }
             }
-            showToast(result.message)
+            showToast("已卸载")
             loadLocalPackages()
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaSettingsViewModel.kt
@@ -105,11 +105,15 @@ class SchemaSettingsViewModel(application: Application) : AndroidViewModel(appli
 
     fun importSchemaFile(uri: Uri) {
         viewModelScope.launch {
-            val success = SchemaManager.importSchemaFile(context, uri)
+            val result = SchemaManager.importSchemaFile(context, uri)
             refresh()
             _importCompleted.tryEmit(Unit)
-            if (success) {
-                showToast("导入成功")
+            if (result.success) {
+                if (result.installedDirect) {
+                    showToast("导入成功，已放入 rime 目录")
+                } else {
+                    showToast("导入成功，请到「本地方案」安装")
+                }
             } else {
                 showToast("导入失败")
             }


### PR DESCRIPTION
- 实现统一的 saveImportedFile 函数，根据文件扩展名决定保存位置：
  - 压缩包（zip/tar.gz/tgz）→ market/{importId}/ 等待手动安装
  - 非压缩包（yaml/txt/bin 等）→ 直接放入 rime/ 目录
- 修改 importSchemaFile 返回 ImportResult 数据类，包含导入结果和是否直装状态
- 更新 MainActivity 和 SchemaSettingsViewModel 中的导入反馈提示
- 改进 URL 下载功能，支持任意格式文件而非仅限压缩包
- 优化 streamSha256 函数的资源管理

refactor(SchemaManifestManager): 完善内置清单管理和用户数据保护

- 将 BUILTIN_PACKAGE_ID 设为 internal 访问级别
- 添加 refreshBuiltinManifest 函数，在应用启动时扫描未追踪的内置文件
- 实现 isUserDataFile 函数识别用户数据文件，避免在卸载时被误删
- 排除 build/、.userdb/、*.custom.yaml、installation.yaml 等用户数据文件

fix(WirelessImportHelper): 修复无线导入功能和UI显示

- 修正无线导入使用统一的 saveImportedFile 函数
- 更新前端界面文字描述，明确支持的文件类型
- 添加 .gram 文件类型支持

chore(version): 更新版本号至 2.5.1