### PR TITLE
feat(RimeFileBrowser): 增强文件浏览器功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/RimeFileBrowserScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/RimeFileBrowserScreen.kt
@@ -170,7 +170,15 @@ fun RimeFileBrowserContent(onBack: () -> Unit) {
                 items(entries, key = { currentDir.absolutePath + "/" + it.name }) { entry ->
                     FileEntryRow(
                         entry = entry,
-                        onView = { viewingFile = entry.file },
+                        onView = {
+                            if (entry.isDirectory) {
+                                currentDir = entry.file
+                            } else if (entry.name.endsWith(".bin") || entry.name.endsWith(".gram")) {
+                                Toast.makeText(context, "不支持打开二进制文件", Toast.LENGTH_SHORT).show()
+                            } else {
+                                viewingFile = entry.file
+                            }
+                        },
                         onDelete = {
                             if (entry.isDirectory) {
                                 showDeleteDialog = entry.file


### PR DESCRIPTION
- 实现目录导航功能，点击目录可进入下级目录
- 添加二进制文件(.bin/.gram)打开限制提示
- 优化文件查看逻辑，区分目录和文件处理方式

fix(submodule): 更新librime-octagram依赖版本