### PR TITLE
feat: 添加快捷发送功能

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,9 +97,11 @@ jobs:
         run: |
           DATE=$(date +'%Y%m%d')
           COMMIT=$(git rev-parse --short HEAD)
+          BASE_VERSION=$(grep -oP 'versionName.*\?:\s*"\K[\d.]+' app/build.gradle.kts)
+          echo "Base version: $BASE_VERSION"
           ./gradlew assembleRelease \
             -PnightlyVersionCode=$DATE \
-            -PnightlyVersionName="2.5.0-nightly-$DATE-$COMMIT" \
+            -PnightlyVersionName="${BASE_VERSION}-nightly-$DATE-$COMMIT" \
             --no-daemon
 
       - name: Sign Main App APKs

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -309,7 +309,7 @@ android {
         minSdk = 28
         targetSdk = 35
         versionCode = project.findProperty("nightlyVersionCode")?.toString()?.toIntOrNull() ?: 56
-        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.5.1"
+        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.6.0-beta1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -168,9 +168,6 @@ class ClipboardManager private constructor(private val context: Context) {
 
     fun release() {
         stopListening()
-        _clipboardItems.value = emptyList()
-        _quickSendItems.value = emptyList()
-        _recentItems.value = emptyList()
     }
     
     fun addItem(text: String) {
@@ -280,6 +277,20 @@ class ClipboardManager private constructor(private val context: Context) {
     }
 
     
+    fun updateQuickSendItem(id: Long, newText: String): Boolean {
+        if (newText.isBlank()) return false
+        val currentItems = _quickSendItems.value.toMutableList()
+        val index = currentItems.indexOfFirst { it.id == id }
+        if (index < 0) return false
+        currentItems[index] = currentItems[index].copy(
+            text = newText,
+            timestamp = System.currentTimeMillis()
+        )
+        _quickSendItems.value = currentItems
+        saveQuickSendItems()
+        return true
+    }
+
     fun addQuickSendItem(text: String) {
         if (text.isBlank()) return
         

--- a/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
@@ -41,4 +41,8 @@ data class InputUIState(
     val cursorY: Int = 0,
     val cursorVisible: Boolean = false,
     val isGlassEffectEnabled: Boolean = false,
+    val showQuickSendForm: Boolean = false,
+    val quickSendFormFocused: Boolean = false,
+    val quickSendEditingItemId: Long? = null,
+    val quickSendEditingItemText: String = "",
 )

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -14,6 +14,7 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
+import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.compose.foundation.background
@@ -102,6 +103,7 @@ import com.kingzcheung.xime.util.FileLogger
 import com.kingzcheung.xime.util.PreeditMergeHelper
 import com.kingzcheung.xime.keyboard.ActionExecutor
 import com.kingzcheung.xime.keyboard.HANDWRITING_SCHEMA_ID
+import com.kingzcheung.xime.keyboard.OverlayRoute
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -116,6 +118,10 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileInputStream
+
+object QuickSendFormEditTextHolder {
+    var editText: android.widget.EditText? = null
+}
 
 class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateRegistryOwner, ViewModelStoreOwner, ActionExecutor {
 
@@ -723,6 +729,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 val navBarDp = navBarInsetDp.dp
                 val hasNavBar = navBarDp > 0.dp
 
+                val quickSendFormExtra = if (state.showQuickSendForm) 200 else 0
+
                 XimeTheme(darkTheme = isDarkTheme, themeId = state.themeId) {
                     Box(
                         modifier = Modifier
@@ -730,11 +738,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             .height(
                                 if (state.isCompact || state.isFloatingMode) effectiveScreenH.dp
                                 else if (state.showKeyboardResize) ((screenHeightDp * 7) / 10 + 100).dp
-                                else (keyboardHeight + state.keyboardBottomPaddingDp).dp + (if (hasNavBar) navBarDp else 0.dp)
+                                else (keyboardHeight + state.keyboardBottomPaddingDp + quickSendFormExtra).dp + (if (hasNavBar) navBarDp else 0.dp)
                             )
                     ) {
                         // Sync FrameLayout height with Compose content height
-                        val contentHeight = if (state.showKeyboardResize) state.resizePreviewHeightDp else floatingCardContentHeight
+                        val contentHeight = if (state.showKeyboardResize) state.resizePreviewHeightDp else floatingCardContentHeight + quickSendFormExtra
                         val totalDp = if (state.isCompact || state.isFloatingMode) effectiveScreenH
                             else contentHeight + state.keyboardBottomPaddingDp + navBarInsetDp
                         Log.d(TAG, "HeightSync: mode=${if (state.showKeyboardResize) "resize" else "normal"} height=$contentHeight navBarDp=${navBarDp.value} padding=${state.keyboardBottomPaddingDp} hasNavBar=$hasNavBar totalDp=$totalDp")
@@ -742,7 +750,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             keyboardContainer.updateHeight(totalDp)
                             currentEffectiveKeyboardHeight = if (state.isFloatingMode) keyboardHeight + floatingDragBarHeight + 50 + state.keyboardBottomPaddingDp
                                 else if (state.isCompact) HARDWARE_CANDIDATE_BAR_HEIGHT
-                                else effectiveKeyboardHeight
+                                else effectiveKeyboardHeight + quickSendFormExtra
                         }
                         val kbColors = KeysConfigHelper.getKeyboardColors()
                         val longToColor: (Long) -> androidx.compose.ui.graphics.Color = { if (it == 0L)  { androidx.compose.ui.graphics.Color(0xE61E1E1E) } else { androidx.compose.ui.graphics.Color(0xFF000000 or it) } }
@@ -778,7 +786,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                             modifier = Modifier
 
                                 .fillMaxWidth()
-                                .height(if (state.showKeyboardResize) (state.resizePreviewHeightDp + state.keyboardBottomPaddingDp).dp else (floatingCardContentHeight + state.keyboardBottomPaddingDp).dp)
+                                .height(if (state.showKeyboardResize) (state.resizePreviewHeightDp + state.keyboardBottomPaddingDp).dp else (floatingCardContentHeight + state.keyboardBottomPaddingDp + quickSendFormExtra).dp)
                                 .align(if (state.isFloatingMode) androidx.compose.ui.Alignment.BottomCenter else androidx.compose.ui.Alignment.TopStart)
                         ) {
                         CompositionLocalProvider(LocalStretchFactor provides state.stretchFactor) {
@@ -829,6 +837,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 t9ResetSignal = state.t9ResetSignal,
                                 t9RightCandidateSelectedCount = state.t9RightCandidateSelectedCount,
                                 t9SelectedCandidatePinyin = state.t9SelectedCandidatePinyin,
+                                showQuickSendForm = state.showQuickSendForm,
+                                quickSendFormFocused = state.quickSendFormFocused,
+                                quickSendEditingItemId = state.quickSendEditingItemId,
+                                quickSendEditingItemText = state.quickSendEditingItemText,
                             )
                             val view = LocalView.current
                             val callbacks = remember(floatingMinY) {
@@ -1041,6 +1053,46 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                         postRimeJob {
                                             commitFirstCandidateAndClearT9()
                                         }
+                                    },
+                                    onShowQuickSendForm = {
+                                        val current = uiState.value
+                                        uiState.value = current.copy(
+                                            showQuickSendForm = true,
+                                            quickSendFormFocused = true,
+                                            quickSendEditingItemId = null,
+                                            quickSendEditingItemText = "",
+                                            enterKeyText = "确定",
+                                        )
+                                    },
+                                    onQuickSendEditItem = { id, text ->
+                                        uiState.value = uiState.value.copy(
+                                            showQuickSendForm = true,
+                                            quickSendFormFocused = true,
+                                            quickSendEditingItemId = id,
+                                            quickSendEditingItemText = text,
+                                            enterKeyText = "确定",
+                                        )
+                                        QuickSendFormEditTextHolder.editText?.let { et ->
+                                            et.setText(text)
+                                            et.setSelection(text.length)
+                                        }
+                                    },
+                                    onHideQuickSendForm = {
+                                        uiState.value = uiState.value.copy(
+                                            showQuickSendForm = false,
+                                            quickSendFormFocused = false,
+                                            quickSendEditingItemId = null,
+                                            quickSendEditingItemText = "",
+                                            enterKeyText = "发送",
+                                        )
+                                        QuickSendFormEditTextHolder.editText = null
+                                        keyboardViewModel.showOverlay(OverlayRoute.Clipboard(1))
+                                    },
+                                    onQuickSendFormFocusChange = { focused: Boolean ->
+                                        uiState.value = uiState.value.copy(
+                                            quickSendFormFocused = focused,
+                                            enterKeyText = if (focused) "确定" else "发送",
+                                        )
                                     },
                                 )
                             }
@@ -1802,6 +1854,41 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
 
     private fun handleKeyPress(key: String, isShifted: Boolean) {
+        if (uiState.value.quickSendFormFocused) {
+            when (key) {
+                "enter" -> {
+                    val editText = QuickSendFormEditTextHolder.editText
+                    val text = editText?.text?.toString() ?: ""
+                    val s = uiState.value
+                    val editingId = s.quickSendEditingItemId
+                    if (text.isNotBlank()) {
+                        if (editingId != null) {
+                            keyboardViewModel.updateQuickSendItem(editingId, text)
+                        } else {
+                            keyboardViewModel.addQuickSendText(text)
+                        }
+                    }
+                    uiState.value = s.copy(showQuickSendForm = false, quickSendFormFocused = false, quickSendEditingItemId = null, quickSendEditingItemText = "")
+                    QuickSendFormEditTextHolder.editText = null
+                    keyboardViewModel.showOverlay(OverlayRoute.Clipboard(1))
+                    return
+                }
+                "delete" -> {
+                    QuickSendFormEditTextHolder.editText?.let { et ->
+                        val start = et.selectionStart.coerceAtLeast(0)
+                        val end = et.selectionEnd.coerceAtLeast(start)
+                        if (start == end && start > 0) {
+                            et.text?.delete(start - 1, start)
+                            try { et.setSelection(start - 1) } catch (_: Exception) {}
+                        } else if (end > start) {
+                            et.text?.delete(start, end)
+                            try { et.setSelection(start) } catch (_: Exception) {}
+                        }
+                    }
+                    return
+                }
+            }
+        }
         val job = serviceScope.launch(keyProcessingDispatcher, start = CoroutineStart.LAZY) {
             val state = uiState.value
             val candState = candidateState.value
@@ -2834,6 +2921,17 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     }
 
     override fun commitText(text: String) {
+        if (uiState.value.quickSendFormFocused) {
+            mainHandler.post {
+                QuickSendFormEditTextHolder.editText?.let { et ->
+                    val start = et.selectionStart.coerceAtLeast(0)
+                    val textLen = text.length
+                    et.text?.replace(start, et.selectionEnd.coerceAtLeast(start), text)
+                    try { et.setSelection(start + textLen) } catch (_: Exception) {}
+                }
+            }
+            return
+        }
         currentInputConnection?.commitText(text, 1)
 
         if (isChineseMode) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBarOverlayPanel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBarOverlayPanel.kt
@@ -1,0 +1,97 @@
+package com.kingzcheung.xime.ui.keyboard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CandidateBarOverlayPanel(
+    heightDp: Int = 200,
+    backgroundColor: Color,
+    cardBgColor: Color,
+    closeButtonBg: Color,
+    closeButtonColor: Color,
+    onCloseClick: () -> Unit,
+    title: String = "",
+    titleColor: Color = closeButtonColor,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(heightDp.dp)
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 6.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(closeButtonBg)
+                    .clickable(onClick = onCloseClick),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "关闭",
+                    tint = closeButtonColor,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+
+            if (title.isNotEmpty()) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = title,
+                    color = titleColor,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(top = 4.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(cardBgColor.copy(alpha = 0.5f))
+                    .padding(horizontal = 14.dp, vertical = 10.dp)
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -61,4 +61,8 @@ data class KeyboardCallbacks(
      * @return 过滤后的 (候选词列表, 注释列表)
      */
     var onFilterT9Candidates: ((List<String>, List<String>) -> Pair<List<String>, List<String>>)? = null,
+    val onShowQuickSendForm: (() -> Unit)? = null,
+    val onHideQuickSendForm: (() -> Unit)? = null,
+    val onQuickSendEditItem: ((Long, String) -> Unit)? = null,
+    val onQuickSendFormFocusChange: ((Boolean) -> Unit)? = null,
 )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -10,8 +10,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -26,11 +33,14 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kingzcheung.xime.handwriting.HandwritingCandidate
 import com.kingzcheung.xime.keyboard.KeyboardPage
@@ -222,6 +232,31 @@ fun KeyboardView(
                         isCalculatorActive = state.isCalculatorMode,
                     )
                 }
+            }
+
+            if (state.showQuickSendForm) {
+                QuickSendFormArea(
+                    backgroundColor = candidateBarBg,
+                    textColor = keyTextColor,
+                    accentColor = accentColor,
+                    isDarkTheme = state.isDarkTheme,
+                    isFocused = state.quickSendFormFocused,
+                    initialText = state.quickSendEditingItemText,
+                    onClose = { text ->
+                        if (text.isNotBlank()) {
+                            val editingId = state.quickSendEditingItemId
+                            if (editingId != null) {
+                                viewModel.updateQuickSendItem(editingId, text)
+                            } else {
+                                viewModel.addQuickSendText(text)
+                            }
+                        }
+                        callbacks.onHideQuickSendForm?.invoke()
+                    },
+                    onFocusChange = { focused ->
+                        callbacks.onQuickSendFormFocusChange?.invoke(focused)
+                    },
+                )
             }
 
             CandidateBar(
@@ -798,7 +833,15 @@ fun KeyboardView(
                         onBack = { viewModel.closeOverlay() },
                         onClipboardTabChange = { viewModel.pushOverlay(OverlayRoute.Clipboard(it)) },
                         bottomPaddingDp = state.keyboardBottomPaddingDp,
-                        modifier = Modifier.fillMaxWidth().fillMaxHeight()
+                        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                        onQuickSendAddClick = {
+                            viewModel.closeOverlay()
+                            callbacks.onShowQuickSendForm?.invoke()
+                        },
+                        onQuickSendEditItem = { id, text ->
+                            viewModel.closeOverlay()
+                            callbacks.onQuickSendEditItem?.invoke(id, text)
+                        },
                     )
                     is OverlayRoute.ToolbarCustomize -> ToolbarCustomizeView(
                         toolbarButtons = state.toolbarButtons,
@@ -883,5 +926,90 @@ fun KeyboardView(
         }
         }
     }
+    }
+}
+
+private val QUICK_SEND_FORM_HEIGHT = 200
+
+@Composable
+private fun QuickSendFormArea(
+    backgroundColor: Color,
+    textColor: Color,
+    accentColor: Color,
+    isDarkTheme: Boolean,
+    isFocused: Boolean,
+    initialText: String = "",
+    onClose: (text: String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(QUICK_SEND_FORM_HEIGHT.dp)
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 6.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(if (isDarkTheme) Color(0xFF374151) else Color(0xFFF3F4F6))
+                .clickable {
+                    val et = com.kingzcheung.xime.service.QuickSendFormEditTextHolder.editText
+                    onClose(et?.text?.toString() ?: "")
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "关闭表单",
+                tint = accentColor,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(top = 4.dp)
+        ) {
+            androidx.compose.ui.viewinterop.AndroidView(
+                factory = { context ->
+                    android.widget.EditText(context).apply {
+                        setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                        setTextColor(textColor.hashCode())
+                        setHintTextColor((textColor.copy(alpha = 0.4f)).hashCode())
+                        hint = "输入快捷发送内容"
+                        textSize = 16f
+                        isSingleLine = false
+                        gravity = android.view.Gravity.TOP or android.view.Gravity.START
+                        setPadding(12, 8, 12, 8)
+
+                        setImeActionLabel("确定", android.view.inputmethod.EditorInfo.IME_ACTION_DONE)
+                        imeOptions = android.view.inputmethod.EditorInfo.IME_FLAG_NO_ENTER_ACTION or
+                            android.view.inputmethod.EditorInfo.IME_ACTION_DONE
+                        
+                        onFocusChangeListener = android.view.View.OnFocusChangeListener { _, hasFocus ->
+                            onFocusChange(hasFocus)
+                        }
+                        setOnClickListener {
+                            onFocusChange(true)
+                        }
+                        com.kingzcheung.xime.service.QuickSendFormEditTextHolder.editText = this
+                        if (isFocused) {
+                            post { requestFocus() }
+                        }
+                    }
+                },
+                update = { editText ->
+                    if (initialText.isNotEmpty() && !editText.text.toString().equals(initialText)) {
+                        editText.setText(initialText)
+                        editText.setSelection(initialText.length)
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+        }
     }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -242,7 +242,9 @@ fun KeyboardView(
                     isDarkTheme = state.isDarkTheme,
                     isFocused = state.quickSendFormFocused,
                     initialText = state.quickSendEditingItemText,
-                    onClose = { text ->
+                    cardBgColor = keyBgColor,
+                    editingItemId = state.quickSendEditingItemId,
+                    onClose = { text: String ->
                         if (text.isNotBlank()) {
                             val editingId = state.quickSendEditingItemId
                             if (editingId != null) {
@@ -253,7 +255,7 @@ fun KeyboardView(
                         }
                         callbacks.onHideQuickSendForm?.invoke()
                     },
-                    onFocusChange = { focused ->
+                    onFocusChange = { focused: Boolean ->
                         callbacks.onQuickSendFormFocusChange?.invoke(focused)
                     },
                 )
@@ -929,87 +931,4 @@ fun KeyboardView(
     }
 }
 
-private val QUICK_SEND_FORM_HEIGHT = 200
 
-@Composable
-private fun QuickSendFormArea(
-    backgroundColor: Color,
-    textColor: Color,
-    accentColor: Color,
-    isDarkTheme: Boolean,
-    isFocused: Boolean,
-    initialText: String = "",
-    onClose: (text: String) -> Unit,
-    onFocusChange: (Boolean) -> Unit,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(QUICK_SEND_FORM_HEIGHT.dp)
-            .background(backgroundColor)
-            .padding(horizontal = 8.dp, vertical = 6.dp)
-    ) {
-        Box(
-            modifier = Modifier
-                .size(28.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(if (isDarkTheme) Color(0xFF374151) else Color(0xFFF3F4F6))
-                .clickable {
-                    val et = com.kingzcheung.xime.service.QuickSendFormEditTextHolder.editText
-                    onClose(et?.text?.toString() ?: "")
-                },
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = "关闭表单",
-                tint = accentColor,
-                modifier = Modifier.size(18.dp)
-            )
-        }
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .padding(top = 4.dp)
-        ) {
-            androidx.compose.ui.viewinterop.AndroidView(
-                factory = { context ->
-                    android.widget.EditText(context).apply {
-                        setBackgroundColor(android.graphics.Color.TRANSPARENT)
-                        setTextColor(textColor.hashCode())
-                        setHintTextColor((textColor.copy(alpha = 0.4f)).hashCode())
-                        hint = "输入快捷发送内容"
-                        textSize = 16f
-                        isSingleLine = false
-                        gravity = android.view.Gravity.TOP or android.view.Gravity.START
-                        setPadding(12, 8, 12, 8)
-
-                        setImeActionLabel("确定", android.view.inputmethod.EditorInfo.IME_ACTION_DONE)
-                        imeOptions = android.view.inputmethod.EditorInfo.IME_FLAG_NO_ENTER_ACTION or
-                            android.view.inputmethod.EditorInfo.IME_ACTION_DONE
-                        
-                        onFocusChangeListener = android.view.View.OnFocusChangeListener { _, hasFocus ->
-                            onFocusChange(hasFocus)
-                        }
-                        setOnClickListener {
-                            onFocusChange(true)
-                        }
-                        com.kingzcheung.xime.service.QuickSendFormEditTextHolder.editText = this
-                        if (isFocused) {
-                            post { requestFocus() }
-                        }
-                    }
-                },
-                update = { editText ->
-                    if (initialText.isNotEmpty() && !editText.text.toString().equals(initialText)) {
-                        editText.setText(initialText)
-                        editText.setSelection(initialText.length)
-                    }
-                },
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-    }
-}

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/QuickSendFormArea.kt
@@ -1,0 +1,82 @@
+package com.kingzcheung.xime.ui.keyboard
+
+import android.view.Gravity
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.kingzcheung.xime.service.QuickSendFormEditTextHolder
+
+private val QUICK_SEND_FORM_HEIGHT = 200
+
+@Composable
+fun QuickSendFormArea(
+    backgroundColor: Color,
+    textColor: Color,
+    accentColor: Color,
+    isDarkTheme: Boolean,
+    isFocused: Boolean,
+    initialText: String = "",
+    cardBgColor: Color,
+    editingItemId: Long? = null,
+    onClose: (text: String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
+) {
+    val closeButtonBg = if (isDarkTheme) Color(0xFF374151) else Color(0xFFF3F4F6)
+    val title = if (editingItemId != null) "编辑快捷发送" else "添加快捷发送"
+
+    CandidateBarOverlayPanel(
+        heightDp = QUICK_SEND_FORM_HEIGHT,
+        backgroundColor = backgroundColor,
+        cardBgColor = cardBgColor,
+        closeButtonBg = closeButtonBg,
+        closeButtonColor = accentColor,
+        title = title,
+        titleColor = textColor,
+        onCloseClick = {
+            val et = QuickSendFormEditTextHolder.editText
+            onClose(et?.text?.toString() ?: "")
+        },
+    ) {
+        AndroidView(
+            factory = { context ->
+                android.widget.EditText(context).apply {
+                    setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                    setTextColor(textColor.hashCode())
+                    setHintTextColor((textColor.copy(alpha = 0.4f)).hashCode())
+                    hint = "输入快捷发送内容"
+                    textSize = 16f
+                    isSingleLine = false
+                    gravity = Gravity.TOP or Gravity.START
+                    setPadding(12, 8, 12, 8)
+
+                    setImeActionLabel("确定", EditorInfo.IME_ACTION_DONE)
+                    imeOptions = EditorInfo.IME_FLAG_NO_ENTER_ACTION or
+                        EditorInfo.IME_ACTION_DONE
+
+                    onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+                        onFocusChange(hasFocus)
+                    }
+                    setOnClickListener {
+                        onFocusChange(true)
+                    }
+                    QuickSendFormEditTextHolder.editText = this
+                    if (isFocused) {
+                        post { requestFocus() }
+                    }
+                }
+            },
+            update = { editText ->
+                if (initialText.isNotEmpty() && !editText.text.toString().equals(initialText)) {
+                    editText.setText(initialText)
+                    editText.setSelection(initialText.length)
+                }
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/ClipboardView.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.ui.unit.sp
 import com.kingzcheung.xime.clipboard.ClipboardItem
 import com.kingzcheung.xime.viewmodel.KeyboardViewModel
@@ -71,7 +73,9 @@ fun ClipboardView(
     onBack: (() -> Unit)? = null,
     onClipboardTabChange: ((Int) -> Unit)? = null,
     bottomPaddingDp: Int = 0,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onQuickSendAddClick: (() -> Unit)? = null,
+    onQuickSendEditItem: ((Long, String) -> Unit)? = null,
 ) {
     val itemBgColor = MaterialTheme.colorScheme.surfaceContainerLow
     val textColor = MaterialTheme.colorScheme.onSurface
@@ -157,6 +161,26 @@ fun ClipboardView(
                     }
                 }
             }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            if (selectedTab == 1 && onQuickSendAddClick != null) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(if (isDarkTheme) Color(0xFF374151) else Color(0xFFF3F4F6))
+                        .clickable(onClick = onQuickSendAddClick),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = "添加快捷发送",
+                        tint = accentColor,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
         }
 
         val pagerState = rememberPagerState(
@@ -200,7 +224,9 @@ fun ClipboardView(
                     subTextColor = subTextColor,
                     accentColor = accentColor,
                     viewModel = viewModel,
-                    onSelect = onSelectItem
+                    onSelect = onSelectItem,
+                    onQuickSendAddClick = onQuickSendAddClick,
+                    onQuickSendEditItem = onQuickSendEditItem,
                 )
             }
         }

--- a/app/src/main/java/com/kingzcheung/xime/ui/menubar/QuickSendView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/menubar/QuickSendView.kt
@@ -6,14 +6,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -45,7 +50,9 @@ fun QuickSendTabContent(
     subTextColor: Color,
     accentColor: Color,
     viewModel: KeyboardViewModel,
-    onSelect: (String) -> Unit
+    onSelect: (String) -> Unit,
+    onQuickSendAddClick: (() -> Unit)? = null,
+    onQuickSendEditItem: ((Long, String) -> Unit)? = null,
 ) {
     if (items.isEmpty()) {
         Box(
@@ -72,7 +79,8 @@ fun QuickSendTabContent(
                     textColor = textColor,
                     accentColor = accentColor,
                     viewModel = viewModel,
-                    onSelect = { onSelect(item.text) }
+                    onSelect = { onSelect(item.text) },
+                    onQuickSendEditItem = onQuickSendEditItem,
                 )
             }
         }
@@ -86,7 +94,8 @@ fun QuickSendCard(
     textColor: Color,
     accentColor: Color,
     viewModel: KeyboardViewModel,
-    onSelect: () -> Unit
+    onSelect: () -> Unit,
+    onQuickSendEditItem: ((Long, String) -> Unit)? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val cardBg = remember(bgColor) { lerp(bgColor, Color.White, 0.15f) }
@@ -157,10 +166,35 @@ fun QuickSendCard(
                     )
                 }
 
+                if (onQuickSendEditItem != null) {
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(accentColor.copy(alpha = 0.15f))
+                            .clickable { onQuickSendEditItem(item.id, item.text) }
+                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Create,
+                            contentDescription = null,
+                            tint = accentColor,
+                            modifier = Modifier.size(12.dp)
+                        )
+                        Text(
+                            text = "编辑",
+                            color = accentColor,
+                            fontSize = 12.sp
+                        )
+                    }
+                }
+
+                val deleteColor = Color(0xFFE53935)
                 Row(
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))
-                        .background(accentColor.copy(alpha = 0.15f))
+                        .background(deleteColor.copy(alpha = 0.12f))
                         .clickable { viewModel.removeQuickSendItem(item.id) }
                         .padding(horizontal = 10.dp, vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -169,12 +203,12 @@ fun QuickSendCard(
                     Icon(
                         Icons.Filled.Delete,
                         contentDescription = null,
-                        tint = accentColor,
+                        tint = deleteColor,
                         modifier = Modifier.size(12.dp)
                     )
                     Text(
                         text = "删除",
-                        color = accentColor,
+                        color = deleteColor,
                         fontSize = 12.sp
                     )
                 }

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -69,6 +69,10 @@ data class KeyboardUiState(
     val t9ResetSignal: Long = 0L,
     val t9RightCandidateSelectedCount: Long = 0L,
     val t9SelectedCandidatePinyin: String = "",
+    val showQuickSendForm: Boolean = false,
+    val quickSendFormFocused: Boolean = false,
+    val quickSendEditingItemId: Long? = null,
+    val quickSendEditingItemText: String = "",
 )
 
 class KeyboardViewModel(application: Application) : AndroidViewModel(application) {
@@ -488,6 +492,10 @@ class KeyboardViewModel(application: Application) : AndroidViewModel(application
 
     fun addQuickSendText(text: String) {
         clipboardManager.addQuickSendItem(text)
+    }
+
+    fun updateQuickSendItem(id: Long, text: String) {
+        clipboardManager.updateQuickSendItem(id, text)
     }
 
     fun removeQuickSendItem(id: Long) {


### PR DESCRIPTION
- 实现快捷发送表单功能，支持添加、编辑和删除快捷发送项目
- 动态从build.gradle.kts中提取基础版本号用于夜间构建
- 在输入法服务中集成快捷发送表单的显示和交互逻辑
- 更新界面组件以支持快捷发送相关的UI操作
- 添加updateQuickSendItem方法支持修改现有快捷发送项目
- 调整键盘高度计算以适配快捷发送表单位置