### PR TITLE
feat(keyboard): 添加键盘布局配置和shift状态支持

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,8 +308,8 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = project.findProperty("nightlyVersionCode")?.toString()?.toIntOrNull() ?: 56
-        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.6.0-beta1"
+        versionCode = project.findProperty("nightlyVersionCode")?.toString()?.toIntOrNull() ?: 57
+        versionName = project.findProperty("nightlyVersionName")?.toString() ?: "2.5.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -117,6 +117,11 @@ keyboard:
     # standard: 默认布局（主文字居中，下滑提示在底部）
     # compact: 紧凑布局（主文字在左上，下滑提示占满键帽中部）
     button_layout: standard
+    layout:
+      rows:
+        - [q, w, e, r, t, y, u, i, o, p]
+        - [a, s, d, f, g, h, j, k, l,";"]
+        - [z, x, c, v, b, n, m]
     keys:
       # ── 第一行 ──
       # long_press 顺序：小写 → 大写 → 带变音符号的相似字母
@@ -143,7 +148,7 @@ keyboard:
       j: { tap: "j", swipe_up: { label: "－", value: "-" }, swipe_down: { label: "日曰早廾刂虫丿Ⅱ", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["j", "J"] } }
       k: { tap: "k", swipe_up: { label: "（", value: "(" }, swipe_down: { label: "口Ⅲ川", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["k", "K"] } }
       l: { tap: "l", swipe_up: { label: "）", value: ")" }, swipe_down: { label: "田甲囗四罒车皿力", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["l", "L"] } }
-
+      ";": { tap: ";", shift: ":" }
       # ── 第三行 ──
       z: { tap: "z", swipe_up: { label: "＊", value: "*" }, swipe_down: { label: "", action: "none", display: "key" }, long_press: { display: "bubble", values: [ "z","Z"] } }
       x: { tap: "x", swipe_up: { label: "＠", value: "@" }, swipe_down: { label: "弓匕纟幺弓𠤎", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["x", "X"] } }
@@ -152,6 +157,7 @@ keyboard:
       b: { tap: "b", swipe_up: { label: "！", value: "!" }, swipe_down: { label: "子耳了也阝卩㔾凵", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["b", "B"] } }
       n: { tap: "n", swipe_up: { label: "％", value: "%" }, swipe_down: { label: "已己巳心忄羽乙𠃜", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["n", "N", "ñ"] } }
       m: { tap: "m", swipe_up: { label: "＃", value: "#" }, swipe_down: { label: "山由贝冂冎几", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["m", "M"] } }
+      # ── 第四行: 暂时不受layout控制 ──
       #  逗号键，label 为中文显示，value 为英文显示+提交值
       "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } , long_press: { display: "bubble", values: [ ",","."] }}
       # 中/英切换键，label 为按键显示文字
@@ -163,6 +169,11 @@ keyboard:
     # standard: 默认布局（主文字居中，下滑提示在底部）
     # compact: 紧凑布局（主文字在左上，下滑提示占满键帽中部）
     button_layout: standard
+    layout:
+      rows:
+        - [q, w, e, r, t, y, u, i, o, p]
+        - [a, s, d, f, g, h, j, k, l, ";"]
+        - [z, x, c, v, b, n, m]
     keys:
       # ── 第一行 ──
       q: { tap: "q", swipe_up: "1", long_press: { display: "bubble", values: ["q", "Q"] } }
@@ -185,6 +196,7 @@ keyboard:
       j: { tap: "j", swipe_up: "-", long_press: { display: "bubble", values: ["j", "J"] } }
       k: { tap: "k", swipe_up: "(", long_press: { display: "bubble", values: ["k", "K"] } }
       l: { tap: "l", swipe_up: ")", long_press: { display: "bubble", values: ["l", "L"] } }
+      ";": { tap: ";", shift: ":" }
 
       # ── 第三行 ──
       z: { tap: "z", swipe_up: "*", long_press: { display: "bubble", values: ["z", "Z"] } }

--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -120,7 +120,7 @@ keyboard:
     layout:
       rows:
         - [q, w, e, r, t, y, u, i, o, p]
-        - [a, s, d, f, g, h, j, k, l,";"]
+        - [a, s, d, f, g, h, j, k, l]
         - [z, x, c, v, b, n, m]
     keys:
       # ── 第一行 ──
@@ -148,7 +148,6 @@ keyboard:
       j: { tap: "j", swipe_up: { label: "－", value: "-" }, swipe_down: { label: "日曰早廾刂虫丿Ⅱ", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["j", "J"] } }
       k: { tap: "k", swipe_up: { label: "（", value: "(" }, swipe_down: { label: "口Ⅲ川", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["k", "K"] } }
       l: { tap: "l", swipe_up: { label: "）", value: ")" }, swipe_down: { label: "田甲囗四罒车皿力", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["l", "L"] } }
-      ";": { tap: ";", shift: ":" }
       # ── 第三行 ──
       z: { tap: "z", swipe_up: { label: "＊", value: "*" }, swipe_down: { label: "", action: "none", display: "key" }, long_press: { display: "bubble", values: [ "z","Z"] } }
       x: { tap: "x", swipe_up: { label: "＠", value: "@" }, swipe_down: { label: "弓匕纟幺弓𠤎", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["x", "X"] } }
@@ -172,7 +171,7 @@ keyboard:
     layout:
       rows:
         - [q, w, e, r, t, y, u, i, o, p]
-        - [a, s, d, f, g, h, j, k, l, ";"]
+        - [a, s, d, f, g, h, j, k, l]
         - [z, x, c, v, b, n, m]
     keys:
       # ── 第一行 ──
@@ -196,7 +195,7 @@ keyboard:
       j: { tap: "j", swipe_up: "-", long_press: { display: "bubble", values: ["j", "J"] } }
       k: { tap: "k", swipe_up: "(", long_press: { display: "bubble", values: ["k", "K"] } }
       l: { tap: "l", swipe_up: ")", long_press: { display: "bubble", values: ["l", "L"] } }
-      ";": { tap: ";", shift: ":" }
+      # ";": { tap: ";", shift: ":" }
 
       # ── 第三行 ──
       z: { tap: "z", swipe_up: "*", long_press: { display: "bubble", values: ["z", "Z"] } }

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -34,8 +34,7 @@ object RimeConfigHelper {
         copyAssetsToRimeDir(context, rimeDir)
         // F1: assets 会用内置 default.yaml 覆盖，这里把启用方案重新写回 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
-        // 确保个人词库和自定义短语文件存在，并为所有方案打补丁
-        PersonalDictManager.ensureAllPackFilesExist(context)
+        // 为所有启用方案打个人词库补丁
         PersonalDictManager.ensureSchemaPacks(context)
 
         Log.d(TAG, "Checking for missing schema files...")
@@ -71,7 +70,6 @@ object RimeConfigHelper {
         copyAssetsToRimeDir(context, rimeDir)
         // F1: 同步初始化路径也写回 default.yaml 的 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
-        PersonalDictManager.ensureAllPackFilesExist(context)
         runBlocking { PersonalDictManager.ensureSchemaPacks(context) }
         checkAndCleanBuildDir(rimeDir)
         listFilesRecursively(rimeDir, TAG)

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -36,23 +36,13 @@ object RimeConfigHelper {
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
         // 为所有启用方案打个人词库补丁
         PersonalDictManager.ensureSchemaPacks(context)
-
-        Log.d(TAG, "Checking for missing schema files...")
-        try {
-            withTimeout(60_000L) {
-                val downloaded = SchemaConfigHelper.downloadMissingSchemas(context)
-                if (downloaded.isNotEmpty()) {
-                    Log.i(TAG, "Downloaded schemas: $downloaded")
-                }
-            }
-        } catch (e: TimeoutCancellationException) {
-            Log.w(TAG, "Schema download timed out, continuing with existing files")
+        invalidateBuildIfConfigChanged(context)
+        // 配置文件有改动时重新部署，确保 build 目录最新
+        if (!File(rimeDir, "build").exists() || File(rimeDir, "build").list()?.isEmpty() == true) {
+            Log.i(TAG, "Build directory missing or empty, triggering deploy")
+            RimeEngine.getInstance().deploy()
+            storeDeploymentHash(context)
         }
-
-        // 迁移旧版方案到清单系统（创建遗留清单）
-        SchemaManifestManager.migrateLegacySchemas(context)
-        
-        checkAndCleanBuildDir(rimeDir)
         listFilesRecursively(rimeDir, TAG)
         
         return Pair(rimeDir.absolutePath, rimeDir.absolutePath)
@@ -71,7 +61,7 @@ object RimeConfigHelper {
         // F1: 同步初始化路径也写回 default.yaml 的 schema_list
         SchemaManager.applyEnabledSchemasToDefaultYaml(context)
         runBlocking { PersonalDictManager.ensureSchemaPacks(context) }
-        checkAndCleanBuildDir(rimeDir)
+        invalidateBuildIfConfigChanged(context)
         listFilesRecursively(rimeDir, TAG)
         
         return Pair(rimeDir.absolutePath, rimeDir.absolutePath)
@@ -153,37 +143,16 @@ object RimeConfigHelper {
         return digest.digest().joinToString("") { String.format("%02x", it) }
     }
 
-    private fun checkAndCleanBuildDir(rimeDir: File) {
+    private fun invalidateBuildIfConfigChanged(context: Context) {
+        val rimeDir = File(context.filesDir, "rime")
         val buildDir = File(rimeDir, "build")
-        val defaultYaml = File(rimeDir, "default.yaml")
-        
-        if (!defaultYaml.exists() || !buildDir.exists()) {
-            Log.d(TAG, "default.yaml or build directory not found, skipping check")
-            return
-        }
-        
-        try {
-            val content = defaultYaml.readText()
-            val schemaListRegex = Regex("""schema:\s*(\S+)""")
-            val schemas = schemaListRegex.findAll(content).map { it.groupValues[1] }.toList()
-            Log.d(TAG, "Schemas in default.yaml: $schemas")
-            
-            for (schema in schemas) {
-                val schemaFile = File(rimeDir, "$schema.schema.yaml")
-                val prismFile = File(buildDir, "$schema.prism.bin")
-                
-                if (schemaFile.exists()) {
-                    if (prismFile.exists()) {
-                        Log.d(TAG, "Schema $schema already deployed")
-                    } else {
-                        Log.d(TAG, "Schema $schema needs deployment (missing prism.bin)")
-                    }
-                } else {
-                    Log.d(TAG, "Schema $schema schema file not found, skipping")
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to parse default.yaml", e)
+        if (!buildDir.exists()) return
+        val currentHash = computeDeploymentHash(context)
+        val storedHash = SettingsPreferences.getDeploymentHash(context)
+        if (!currentHash.isNullOrEmpty() && currentHash != storedHash) {
+            Log.i(TAG, "Config hash changed, clearing build dir for fresh deploy")
+            buildDir.deleteRecursively()
+            buildDir.mkdirs()
         }
     }
     

--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -59,6 +59,7 @@ data class LongPressConfig(
 
 data class KeyGestureConfig(
     val tap: GestureDef? = null,
+    val shift: GestureDef? = null,
     val swipeUp: GestureDef? = null,
     val swipeDown: GestureDef? = null,
     val longPress: LongPressConfig? = null,
@@ -66,6 +67,14 @@ data class KeyGestureConfig(
 
 data class KeyboardConfig(
     val keys: Map<String, KeyGestureConfig> = emptyMap(),
+)
+
+/**
+ * 键盘行布局配置，从 xime.yaml keyboard.<section>.layout 加载。
+ * rows[i] 为第 i 行的按键 ID 列表。
+ */
+data class KeyboardLayoutConfig(
+    val rows: List<List<String>> = emptyList(),
 )
 
 /**
@@ -124,6 +133,7 @@ private fun parseKeyboardConfig(raw: com.charleskorn.kaml.YamlMap?): KeyboardCon
 
 private fun parseKeyGestureConfig(map: com.charleskorn.kaml.YamlMap): KeyGestureConfig {
     var tap: GestureDef? = null
+    var shift: GestureDef? = null
     var swipeUp: GestureDef? = null
     var swipeDown: GestureDef? = null
     var longPress: LongPressConfig? = null
@@ -131,12 +141,13 @@ private fun parseKeyGestureConfig(map: com.charleskorn.kaml.YamlMap): KeyGesture
         val name = (kNode as? com.charleskorn.kaml.YamlScalar)?.content ?: continue
         when (name) {
             "tap" -> tap = parseGestureNode(vNode)
+            "shift" -> shift = parseGestureNode(vNode)
             "swipe_up" -> swipeUp = parseGestureNode(vNode)
             "swipe_down" -> swipeDown = parseGestureNode(vNode)
             "long_press" -> longPress = parseLongPress(vNode)
         }
     }
-    return KeyGestureConfig(tap, swipeUp, swipeDown, longPress)
+    return KeyGestureConfig(tap, shift, swipeUp, swipeDown, longPress)
 }
 
 /**
@@ -315,6 +326,26 @@ object KeysConfigHelper {
     private var _buttonLayoutEn: ButtonLayout = ButtonLayout.STANDARD
     fun getButtonLayout(isAsciiMode: Boolean): ButtonLayout =
         if (isAsciiMode) _buttonLayoutEn else _buttonLayoutZh
+
+    // 键盘行布局默认值
+    private val DEFAULT_ZH_ROWS: List<List<String>> = listOf(
+        listOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"),
+        listOf("a", "s", "d", "f", "g", "h", "j", "k", "l"),
+        listOf("z", "x", "c", "v", "b", "n", "m"),
+    )
+    private val DEFAULT_EN_ROWS: List<List<String>> = listOf(
+        listOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"),
+        listOf("a", "s", "d", "f", "g", "h", "j", "k", "l"),
+        listOf("z", "x", "c", "v", "b", "n", "m"),
+    )
+
+    // 键盘行布局缓存（中文 / 英文）
+    private var _zhRows: List<List<String>> = DEFAULT_ZH_ROWS
+    private var _enRows: List<List<String>> = DEFAULT_EN_ROWS
+
+    /** 获取键盘行布局，每个子 List 为一行的按键 ID 列表，索引 0=第一行 */
+    fun getKeyRows(isAsciiMode: Boolean): List<List<String>> =
+        if (isAsciiMode) _enRows else _zhRows
     
     /** 配置版本号，每次 loadConfig 时递增，用于 Compose 感知配置变更。 */
     private val _configVersion = MutableStateFlow(0)
@@ -348,6 +379,10 @@ object KeysConfigHelper {
             val parsedLayouts = parseButtonLayoutFromAssets(context)
             _buttonLayoutZh = parsedLayouts.first
             _buttonLayoutEn = parsedLayouts.second
+            // 键盘行布局
+            val parsedRows = parseKeyboardLayoutFromAssets(context)
+            _zhRows = parsedRows.first
+            _enRows = parsedRows.second
             // 校验配置版本兼容性
             val merged = try { loadMergedConfig(context) } catch (_: YamlException) { null }
             val meta = merged?.metadata
@@ -580,6 +615,43 @@ object KeysConfigHelper {
         return result
     }
 
+    /** 从 xime.yaml + xime.custom.yaml 合并解析键盘行布局。 */
+    private fun parseKeyboardLayoutFromAssets(context: Context): Pair<List<List<String>>, List<List<String>>> {
+        val defaultText = readAssetText(context, XIME_CONFIG_FILE) ?: return Pair(DEFAULT_ZH_ROWS, DEFAULT_EN_ROWS)
+
+        val defaultZh = parseKeyboardLayoutYamlText(defaultText, "qwerty")
+        val defaultEn = parseKeyboardLayoutYamlText(defaultText, "qwerty_en")
+
+        val customText = readUserDataText(context, XIME_CUSTOM_CONFIG_FILE)
+            ?: readAssetText(context, XIME_CUSTOM_CONFIG_FILE)
+
+        val customZh = customText?.let { parseKeyboardLayoutYamlText(it, "qwerty") }
+        val customEn = customText?.let { parseKeyboardLayoutYamlText(it, "qwerty_en") }
+
+        return Pair(
+            customZh ?: defaultZh ?: DEFAULT_ZH_ROWS,
+            customEn ?: defaultEn ?: DEFAULT_EN_ROWS,
+        )
+    }
+
+    /** 从 YAML 文本中提取 keyboard.<section>.layout.rows。 */
+    private fun parseKeyboardLayoutYamlText(yamlText: String, section: String): List<List<String>>? {
+        val root = yaml.parseToYamlNode(yamlText) as? YamlMap ?: return null
+        val keyboardNode = root["keyboard"] as? YamlMap ?: return null
+        val sectionNode = keyboardNode[section] as? YamlMap ?: return null
+        val layoutNode = sectionNode["layout"] as? YamlMap ?: return null
+        val rowsNode = layoutNode["rows"] as? YamlList ?: return null
+        val rows = mutableListOf<List<String>>()
+        for (rowNode in rowsNode.items) {
+            val rowList = rowNode as? YamlList ?: continue
+            val row = rowList.items.mapNotNull { (it as? YamlScalar)?.content }
+            if (row.isNotEmpty()) {
+                rows.add(row)
+            }
+        }
+        return rows.takeIf { it.isNotEmpty() }
+    }
+
     /** 从 YAML 文本中提取 keyboard.<section>.button_layout。 */
     private fun parseButtonLayoutYamlText(yamlText: String, section: String): ButtonLayout? {
         val root = yaml.parseToYamlNode(yamlText) as? YamlMap ?: return null
@@ -721,6 +793,19 @@ object KeysConfigHelper {
         return value?.takeIf { it.isNotEmpty() } ?: key
     }
 
+    /** 获取 shift 状态的提交值，无配置时返回 null。 */
+    fun getKeyShiftCommitValue(key: String, isAsciiMode: Boolean = false): String? {
+        val config = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
+        return config[key.lowercase()]?.shift?.value?.takeIf { it.isNotEmpty() }
+    }
+
+    /** 获取 shift 状态的显示标签，无配置时返回 null。 */
+    fun getKeyShiftLabel(key: String, isAsciiMode: Boolean = false): String? {
+        val config = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
+        val shift = config[key.lowercase()]?.shift
+        return shift?.label?.takeIf { it.isNotEmpty() } ?: shift?.value?.takeIf { it.isNotEmpty() }
+    }
+
     /** 获取某个按键指定手势的显示标签。 */
     fun getGestureLabel(key: String, gesture: String, isAsciiMode: Boolean = false): String? {
         val config = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
@@ -799,7 +884,6 @@ object KeysConfigHelper {
         val configMap = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
         return configMap[key.lowercase()]?.swipeUp?.display ?: DisplayMode.BOTH
     }
-
 
     private fun getDefaultSwipeUp(): Map<String, String> = mapOf(
         "q" to "1", "w" to "2", "e" to "3", "r" to "4", "t" to "5",

--- a/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
@@ -17,14 +17,17 @@ use_preset_vocabulary: false
 ...
 """
 
-    private fun packName(schemaId: String) = "user_$schemaId"
+    private fun packName(rimeDir: File, schemaId: String): String {
+        val dictName = schemaDictionaryName(rimeDir, schemaId)
+        return "user_$dictName"
+    }
 
-    private fun packFileName(schemaId: String) = "${packName(schemaId)}.dict.yaml"
+    private fun packHeader(rimeDir: File, schemaId: String) = DEFAULT_HEADER.format(packName(rimeDir, schemaId))
 
-    private fun packHeader(schemaId: String) = DEFAULT_HEADER.format(packName(schemaId))
-
-    fun getPackFile(context: Context, schemaId: String): File =
-        File(SchemaManager.getRimeDir(context), packFileName(schemaId))
+    fun getPackFile(context: Context, schemaId: String): File {
+        val rimeDir = SchemaManager.getRimeDir(context)
+        return File(rimeDir, "${packName(rimeDir, schemaId)}.dict.yaml")
+    }
 
     fun getCustomPhraseFile(context: Context, schemaId: String? = null): File {
         val rimeDir = SchemaManager.getRimeDir(context)
@@ -117,7 +120,7 @@ use_preset_vocabulary: false
                 legacy.renameTo(packFile)
             } else {
                 packFile.parentFile?.mkdirs()
-                packFile.writeText(packHeader(schemaId), Charsets.UTF_8)
+                packFile.writeText(packHeader(rimeDir, schemaId), Charsets.UTF_8)
             }
         }
         if (hasReverseLookupTranslator(schemaFile) && !hasTableTranslator(schemaFile)) {
@@ -200,7 +203,7 @@ use_preset_vocabulary: false
 
     // 方案有固定音节表：translator/packs via .custom.yaml
     internal fun applyPackConfig(rimeDir: java.io.File, schemaId: String) {
-        val pkName = packName(schemaId)
+        val pkName = packName(rimeDir, schemaId)
         val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
         val entry = "  \"translator/packs\": [\"$pkName\"]\n"
         if (customFile.exists()) {
@@ -219,9 +222,18 @@ use_preset_vocabulary: false
         insertUnderPatch(customFile, entry)
     }
 
+    /** 从 schema 文件中读取 translator.dictionary 名称，没有则用 schemaId 兜底。 */
+    private fun schemaDictionaryName(rimeDir: File, schemaId: String): String {
+        val schemaFile = File(rimeDir, "${schemaId}.schema.yaml")
+        if (!schemaFile.exists()) return schemaId
+        val regex = Regex("""translator:.*?dictionary:\s*(\S+)""", setOf(RegexOption.DOT_MATCHES_ALL))
+        return regex.find(schemaFile.readText(Charsets.UTF_8))?.groupValues?.get(1) ?: schemaId
+    }
+
     // 方案无固定音节表：import_tables 合并词典 + translator/dictionary via .custom.yaml
     internal fun applyMergedDictConfig(rimeDir: java.io.File, schemaId: String) {
-        val pkName = packName(schemaId)
+        val dictName = schemaDictionaryName(rimeDir, schemaId)
+        val pkName = packName(rimeDir, schemaId)
         val mergedId = "${schemaId}_merged"
         val dictFile = java.io.File(rimeDir, "${mergedId}.dict.yaml")
         dictFile.writeText("""# Rime dict
@@ -230,7 +242,7 @@ name: $mergedId
 version: "1.0"
 sort: original
 import_tables:
-  - $schemaId
+  - $dictName
   - $pkName
 ...
 """, Charsets.UTF_8)
@@ -298,7 +310,7 @@ import_tables:
 
     /** 从 Context 获取 rime 目录下的个人词库文件。 */
     private fun getPackFile(rimeDir: File, schemaId: String): File =
-        File(rimeDir, packFileName(schemaId))
+        File(rimeDir, "${packName(rimeDir, schemaId)}.dict.yaml")
 
     /** 旧版文件名映射（兼容性），新文件不存在时用于兜底读取。 */
     private fun legacyPackFile(rimeDir: File, schemaId: String): File? {

--- a/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
@@ -17,11 +17,7 @@ use_preset_vocabulary: false
 ...
 """
 
-    private fun packName(schemaId: String): String = when {
-        schemaId == "pinyin_simp" || schemaId == "t9_pinyin" -> "user_simp_pinyin"
-        schemaId == "wubi86" -> "user_simp_wubi"
-        else -> "user_simp_pinyin"
-    }
+    private fun packName(schemaId: String) = "user_$schemaId"
 
     private fun packFileName(schemaId: String) = "${packName(schemaId)}.dict.yaml"
 
@@ -59,16 +55,7 @@ use_preset_vocabulary: false
         return CUSTOM_PHRASE_FILE.removeSuffix(".txt")
     }
 
-    fun ensureAllPackFilesExist(context: Context) {
-        for (sid in listOf("pinyin_simp", "t9_pinyin", "wubi86")) {
-            val file = getPackFile(context, sid)
-            if (!file.exists()) {
-                file.parentFile?.mkdirs()
-                file.writeText(packHeader(sid), Charsets.UTF_8)
-            }
-        }
-    }
-
+    
     fun ensureCustomPhraseFileExists(context: Context, schemaId: String? = null) {
         val file = getCustomPhraseFile(context, schemaId)
         if (!file.exists()) {
@@ -122,8 +109,19 @@ use_preset_vocabulary: false
     private suspend fun ensureSchemaPackInner(rimeDir: java.io.File, context: Context, schemaId: String) {
         val schemaFile = java.io.File(rimeDir, "${schemaId}.schema.yaml")
         if (!schemaFile.exists()) return
-        if (hasReverseLookupTranslator(schemaFile)) {
-            // reverse_lookup 方案不替换词典，只加 custom_phrase
+        // 确保个人词库空白文件存在，供 applyPackConfig / applyMergedDictConfig 引用
+        val packFile = getPackFile(context, schemaId)
+        if (!packFile.exists()) {
+            val legacy = legacyPackFile(rimeDir, schemaId)
+            if (legacy != null) {
+                legacy.renameTo(packFile)
+            } else {
+                packFile.parentFile?.mkdirs()
+                packFile.writeText(packHeader(schemaId), Charsets.UTF_8)
+            }
+        }
+        if (hasReverseLookupTranslator(schemaFile) && !hasTableTranslator(schemaFile)) {
+            // 纯反查方案（如反查拼音），无主翻译器，不需要个人词库
         } else if (hasSpellerAlgebra(schemaFile)) {
             applyPackConfig(rimeDir, schemaId)
         } else {
@@ -149,6 +147,11 @@ use_preset_vocabulary: false
     internal fun hasReverseLookupTranslator(schemaFile: java.io.File): Boolean {
         val text = schemaFile.readText(Charsets.UTF_8)
         return text.contains("reverse_lookup_translator")
+    }
+
+    internal fun hasTableTranslator(schemaFile: java.io.File): Boolean {
+        val text = schemaFile.readText(Charsets.UTF_8)
+        return text.contains("table_translator")
     }
 
     // 为方案添加 custom_phrase 翻译器（独立于主词典音节表）
@@ -199,11 +202,21 @@ use_preset_vocabulary: false
     internal fun applyPackConfig(rimeDir: java.io.File, schemaId: String) {
         val pkName = packName(schemaId)
         val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
+        val entry = "  \"translator/packs\": [\"$pkName\"]\n"
         if (customFile.exists()) {
             val text = customFile.readText(Charsets.UTF_8)
-            if (text.contains(pkName)) return
+            if (text.contains("\"$pkName\"")) return
+            val existing = extractOwnPatchKey(text, "translator/packs")
+            if (existing != null) {
+                // 之前由本代码写入的旧名字 → 替换
+                val cleaned = removePatchKey(text, "translator/packs")
+                customFile.writeText(cleaned, Charsets.UTF_8)
+            } else if (text.contains("translator/packs")) {
+                // 用户手动配置的 translator/packs，不动
+                return
+            }
         }
-        insertUnderPatch(customFile, "  \"translator/packs\": [\"$pkName\"]\n")
+        insertUnderPatch(customFile, entry)
     }
 
     // 方案无固定音节表：import_tables 合并词典 + translator/dictionary via .custom.yaml
@@ -211,8 +224,7 @@ use_preset_vocabulary: false
         val pkName = packName(schemaId)
         val mergedId = "${schemaId}_merged"
         val dictFile = java.io.File(rimeDir, "${mergedId}.dict.yaml")
-        if (!dictFile.exists()) {
-            dictFile.writeText("""# Rime dict
+        dictFile.writeText("""# Rime dict
 ---
 name: $mergedId
 version: "1.0"
@@ -222,29 +234,104 @@ import_tables:
   - $pkName
 ...
 """, Charsets.UTF_8)
-        }
         val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
+        val entry = "  \"translator/dictionary\": $mergedId\n"
         if (customFile.exists()) {
             val text = customFile.readText(Charsets.UTF_8)
             if (text.contains(mergedId)) return
+            val existing = extractOwnPatchKey(text, "translator/dictionary")
+            if (existing != null) {
+                val cleaned = removePatchKey(text, "translator/dictionary")
+                customFile.writeText(cleaned, Charsets.UTF_8)
+            } else if (text.contains("translator/dictionary")) {
+                return
+            }
         }
-        insertUnderPatch(customFile, "  \"translator/dictionary\": $mergedId\n")
+        insertUnderPatch(customFile, entry)
+    }
+
+    /** 提取 patch 块中本代码之前写入的 key 的值（user_* 或旧版 user_simp_*），没有则返回 null。 */
+    private fun extractOwnPatchKey(text: String, key: String): String? {
+        val regex = Regex("""^[ \t]+"?$key"?\s*:\s*(.+)$""", RegexOption.MULTILINE)
+        return regex.find(text)?.let { m ->
+            val value = m.groupValues[1].trim().removeSurrounding("\"").removeSurrounding("[").removeSurrounding("]").trim()
+            value.takeIf { it.startsWith("user_simp_") || it.startsWith("user_") }
+        }
+    }
+    private fun removePatchKey(text: String, key: String): String {
+        val escapedKey = Regex.escape(key)
+        val regex = Regex("""^[ \t]+"?$escapedKey"?\s*:.*$""", RegexOption.MULTILINE)
+        val removed = text.replace(regex, "")
+        return removed.replace(Regex("\n{3,}"), "\n\n")
     }
 
     // ── 个人词库 ──
 
+    /**
+     * 解析方案实际引用的个人词库文件名。
+     * 优先级：custom.yaml 中的 translator/packs → translator/dictionary（一路追溯到 user_*） → 默认 packName。
+     */
+    fun resolvePersonalDictFile(rimeDir: File, schemaId: String): File {
+        val customFile = File(rimeDir, "${schemaId}.custom.yaml")
+        if (customFile.exists()) {
+            val text = customFile.readText(Charsets.UTF_8)
+            // 1) translator/packs 中最前面的 user_* 或显式声明的名字
+            val packs = Regex(""""?translator/packs"?\s*:\s*\[(.+?)]""", RegexOption.DOT_MATCHES_ALL)
+                .find(text)?.groupValues?.get(1)?.split(',')?.firstOrNull { it.trim().removeSurrounding("\"").startsWith("user_") }
+            if (packs != null) return File(rimeDir, "${packs.trim().removeSurrounding("\"")}.dict.yaml")
+            // 2) translator/dictionary → 如果是 *_merged 则去合并文件中找 import_tables
+            val dict = Regex(""""?translator/dictionary"?\s*:\s*"?(\w+)"?""").find(text)?.groupValues?.get(1)
+            if (dict != null) {
+                if (dict.endsWith("_merged")) {
+                    val mergedFile = File(rimeDir, "$dict.dict.yaml")
+                    if (mergedFile.exists()) {
+                        val pk = Regex("""^[ \t]+-\s+(user_\S+)""", RegexOption.MULTILINE).findAll(mergedFile.readText(Charsets.UTF_8))
+                            .map { it.groupValues[1] }.firstOrNull()
+                        if (pk != null) return File(rimeDir, "$pk.dict.yaml")
+                    }
+                }
+                return File(rimeDir, "$dict.dict.yaml")
+            }
+        }
+        return getPackFile(rimeDir, schemaId)
+    }
+
+    /** 从 Context 获取 rime 目录下的个人词库文件。 */
+    private fun getPackFile(rimeDir: File, schemaId: String): File =
+        File(rimeDir, packFileName(schemaId))
+
+    /** 旧版文件名映射（兼容性），新文件不存在时用于兜底读取。 */
+    private fun legacyPackFile(rimeDir: File, schemaId: String): File? {
+        val oldName = when (schemaId) {
+            "pinyin_simp", "t9_pinyin" -> "user_simp_pinyin"
+            "wubi86", "wubi86_pinyin" -> "user_simp_wubi"
+            else -> return null
+        }
+        val file = File(rimeDir, "$oldName.dict.yaml")
+        return file.takeIf { it.exists() }
+    }
+
     fun loadEntries(context: Context, schemaId: String): List<DictEntry> {
-        val file = getPackFile(context, schemaId)
-        if (!file.exists()) return emptyList()
+        val rimeDir = SchemaManager.getRimeDir(context)
+        val file = resolvePersonalDictFile(rimeDir, schemaId)
+        if (!file.exists()) {
+            val legacy = legacyPackFile(rimeDir, schemaId)
+            if (legacy != null) return try {
+                parsePersonalDictEntries(legacy.readText(Charsets.UTF_8))
+            } catch (_: Exception) { emptyList() }
+            return emptyList()
+        }
         return try {
             parsePersonalDictEntries(file.readText(Charsets.UTF_8))
         } catch (_: Exception) { emptyList() }
     }
 
     fun saveEntries(context: Context, schemaId: String, entries: List<DictEntry>) {
-        val file = getPackFile(context, schemaId)
+        val rimeDir = SchemaManager.getRimeDir(context)
+        val file = resolvePersonalDictFile(rimeDir, schemaId)
         file.parentFile?.mkdirs()
-        val defaultH = packHeader(schemaId)
+        val dictName = file.nameWithoutExtension
+        val defaultH = DEFAULT_HEADER.format(dictName)
         val header = if (file.exists()) extractHeader(file, defaultH) else defaultH
         file.writeText(buildDictText(header, entries), Charsets.UTF_8)
     }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -138,6 +138,7 @@ fun KeyboardLayout(
     val isDarkTheme = uiState.isDarkTheme
     val isSttEnabled = uiState.isSttEnabled
     val isVoiceMode = uiState.isVoiceMode
+    val keyRows = KeysConfigHelper.getKeyRows(isAsciiMode)
     val onKeyPressDown = callbacks.onKeyPressDown
     val onKeyRelease = callbacks.onKeyRelease
     val onVoiceModeChange = callbacks.onVoiceModeChange
@@ -288,8 +289,9 @@ fun KeyboardLayout(
                         }
                     } else {
                         Box(modifier = Modifier.weight(1f)) {
+                            val row0 = keyRows.getOrElse(0) { listOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p") }
                             KeyboardRowWithConfig(
-                                keys = listOf("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"),
+                                keys = row0,
                                 onKeyPress = onKeyPress,
                                 config = KeyboardRowConfig(
                                     keyBackgroundColor = keyBackgroundColor,
@@ -333,8 +335,10 @@ fun KeyboardLayout(
                         }
                     } else {
                         Box(modifier = Modifier.weight(1f)) {
+                            val row1 = keyRows.getOrElse(1) { listOf("a", "s", "d", "f", "g", "h", "j", "k", "l") }
+                            val row1Padding = if (row1.size > 9) Modifier else Modifier.padding(horizontal = 16.dp)
                             KeyboardRowWithConfig(
-                                keys = listOf("a", "s", "d", "f", "g", "h", "j", "k", "l"),
+                                keys = row1,
                                 onKeyPress = onKeyPress,
                                 config = KeyboardRowConfig(
                                     keyBackgroundColor = keyBackgroundColor,
@@ -346,7 +350,7 @@ fun KeyboardLayout(
                                 ),
                                 isShifted = visualIsShifted,
                                 isAsciiMode = isAsciiMode,
-                                modifier = Modifier.padding(horizontal = 16.dp),
+                                modifier = row1Padding,
                                 onSwipeStateChange = { state, bounds ->
                                     processSwipeState(
                                         state,
@@ -402,7 +406,7 @@ fun KeyboardLayout(
                                         .fillMaxHeight()
                                         .background(keyboardBackgroundColor),
                                 ) {
-                                val bottomKeys = listOf("z", "x", "c", "v", "b", "n", "m")
+                                val bottomKeys = keyRows.getOrElse(2) { listOf("z", "x", "c", "v", "b", "n", "m") }
                                 bottomKeys.forEach { key ->
                                     val rawSwipeUpLabel = KeysConfigHelper.getSwipeUpLabel(key, isAsciiMode)
                                     val swipeUpText =
@@ -432,7 +436,11 @@ fun KeyboardLayout(
                                     } else null
 
                                     val rawCommitValue = KeysConfigHelper.getKeyCommitValue(key, isAsciiMode)
-                                    val commitValue = if (visualIsShifted) rawCommitValue.uppercase() else rawCommitValue
+                                    val commitValue = if (visualIsShifted) {
+                                        KeysConfigHelper.getKeyShiftCommitValue(key, isAsciiMode) ?: rawCommitValue.uppercase()
+                                    } else {
+                                        rawCommitValue
+                                    }
                                     val displayText = if (isAsciiMode) {
                                         commitValue
                                     } else {
@@ -964,7 +972,11 @@ fun KeyboardRowWithConfig(
 
             // 键帽显示文本
             val rawCommitValue = KeysConfigHelper.getKeyCommitValue(key, isAsciiMode)
-            val commitValue = if (isShifted) rawCommitValue.uppercase() else rawCommitValue
+            val commitValue = if (isShifted) {
+                KeysConfigHelper.getKeyShiftCommitValue(key, isAsciiMode) ?: rawCommitValue.uppercase()
+            } else {
+                rawCommitValue
+            }
             val displayText = if (isAsciiMode) {
                 commitValue
             } else {
@@ -1986,7 +1998,11 @@ fun CompactKeyboardRowWithConfig(
             } else null
 
             val rawCommitValue = KeysConfigHelper.getKeyCommitValue(key, isAsciiMode)
-            val commitValue = if (isShifted) rawCommitValue.uppercase() else rawCommitValue
+            val commitValue = if (isShifted) {
+                KeysConfigHelper.getKeyShiftCommitValue(key, isAsciiMode) ?: rawCommitValue.uppercase()
+            } else {
+                rawCommitValue
+            }
             val compactDisplayText = if (isAsciiMode) commitValue else KeysConfigHelper.getKeyDisplayLabel(key, isAsciiMode)
             val compactOnClick = remember(key, commitValue, onKeyPress) { { onKeyPress(commitValue) } }
             val compactOnPress: (() -> Unit)? = remember(key, onKeyPressDown) { { onKeyPressDown?.invoke(key); Unit } }

--- a/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
@@ -114,6 +114,7 @@ class KeyboardGestureConfigTest {
     fun `部分手势缺失不报错`() {
         val a = parseKeys("""a: { tap: "a" }""".trimIndent())["a"]!!
         assertEquals("a", a.tap!!.label)
+        assertNull(a.shift)
         assertNull(a.swipeUp)
         assertNull(a.swipeDown)
         assertNull(a.longPress)
@@ -414,6 +415,33 @@ class KeyboardGestureConfigTest {
         }
     }
 
+    @Test
+    fun `shift 字符串简写解析`() {
+        val keys = parseKeys("""
+            a: { tap: "a", shift: "A" }
+        """.trimIndent())
+        val kc = keys["a"]!!
+        assertEquals("A", kc.shift!!.label)
+        assertEquals(GestureAction.COMMIT, kc.shift!!.action)
+        assertEquals("A", kc.shift!!.value)
+    }
+
+    @Test
+    fun `shift 对象格式指定 action`() {
+        val keys = parseKeys("""
+            s: { tap: "s", shift: { label: "S", action: "commit" } }
+        """.trimIndent())
+        val kc = keys["s"]!!
+        assertEquals("S", kc.shift!!.label)
+        assertEquals(GestureAction.COMMIT, kc.shift!!.action)
+    }
+
+    @Test
+    fun `shift 缺失不报错`() {
+        val a = parseKeys("""a: { tap: "a" }""".trimIndent())["a"]!!
+        assertNull(a.shift)
+    }
+
     // ── 辅助 ──
 
     private fun parseKeys(yamlFragment: String): Map<String, KeyGestureConfig> {
@@ -432,6 +460,7 @@ class KeyboardGestureConfigTest {
 
     private fun parseKeyGestureConfig(map: com.charleskorn.kaml.YamlMap): KeyGestureConfig {
         var tap: GestureDef? = null
+        var shift: GestureDef? = null
         var swipeUp: GestureDef? = null
         var swipeDown: GestureDef? = null
         var longPress: LongPressConfig? = null
@@ -439,12 +468,13 @@ class KeyboardGestureConfigTest {
             val name = (kNode as com.charleskorn.kaml.YamlScalar).content
             when (name) {
                 "tap" -> tap = parseGestureNode(vNode)
+                "shift" -> shift = parseGestureNode(vNode)
                 "swipe_up" -> swipeUp = parseGestureNode(vNode)
                 "swipe_down" -> swipeDown = parseGestureNode(vNode)
                 "long_press" -> longPress = parseLongPress(vNode)
             }
         }
-        return KeyGestureConfig(tap, swipeUp, swipeDown, longPress)
+        return KeyGestureConfig(tap = tap, shift = shift, swipeUp = swipeUp, swipeDown = swipeDown, longPress = longPress)
     }
 
     private fun parseLongPress(node: com.charleskorn.kaml.YamlNode): LongPressConfig? {

--- a/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
@@ -612,7 +612,7 @@ speller:
         runBlocking { PersonalDictManager.ensureSchemaPack(context, "pinyin_simp") }
         val text = java.io.File(rimeDir, "pinyin_simp.custom.yaml").readText(Charsets.UTF_8)
         // packs line should appear only once
-        assertEquals(1, text.split("user_simp_pinyin").size - 1)
+        assertEquals(1, text.split("user_pinyin_simp").size - 1)
         assertEquals(1, text.split("table_translator@custom_phrase").size - 1)
     }
 
@@ -624,7 +624,7 @@ speller:
         assertTrue(customFile.exists())
         val text = customFile.readText(Charsets.UTF_8)
         assertTrue(text.contains("translator/packs"))
-        assertTrue(text.contains("user_simp_pinyin"))
+        assertTrue(text.contains("user_pinyin_simp"))
     }
 
     @Test
@@ -634,7 +634,7 @@ speller:
         PersonalDictManager.applyPackConfig(rimeDir, "pinyin_simp")
         val customFile = File(rimeDir, "pinyin_simp.custom.yaml")
         val text = customFile.readText(Charsets.UTF_8)
-        assertEquals(1, text.split("user_simp_pinyin").size - 1)
+        assertEquals(1, text.split("user_pinyin_simp").size - 1)
     }
 
     @Test
@@ -646,7 +646,7 @@ speller:
         val dictText = dictFile.readText(Charsets.UTF_8)
         assertTrue(dictText.contains("import_tables:"))
         assertTrue(dictText.contains("- wubi86"))
-        assertTrue(dictText.contains("- user_simp_wubi"))
+        assertTrue(dictText.contains("- user_wubi86"))
         val customFile = File(rimeDir, "wubi86.custom.yaml")
         assertTrue(customFile.exists())
         val customText = customFile.readText(Charsets.UTF_8)
@@ -692,7 +692,7 @@ patch:
         assertTrue("existing lua translator preserved", text.contains("lua_translator@my_script"))
         assertTrue("new pack config added", text.contains("translator/packs"))
         assertTrue("existing menu/page_size preserved", text.contains("menu/page_size: 6"))
-        assertTrue("pack name present", text.contains("user_simp_pinyin"))
+        assertTrue("pack name present", text.contains("user_pinyin_simp"))
     }
 
     @Test
@@ -817,7 +817,7 @@ speller:
         assertTrue(text.contains("table_translator@custom_phrase"))
         // 确保幂等
         assertEquals("custom_phrase appears once", 1, text.split("table_translator@custom_phrase").size - 1)
-        assertEquals("packs appears once", 1, text.split("user_simp_pinyin").size - 1)
+        assertEquals("packs appears once", 1, text.split("user_flypy").size - 1)
     }
 
     @Test


### PR DESCRIPTION
- 在xime.yaml中添加layout配置项，支持自定义键盘行布局
- 新增";"键的配置和第四行注释标记
- 添加KeyGestureConfig的shift属性用于定义shift状态下的行为
- 创建KeyboardLayoutConfig数据类处理键盘行布局配置
- 实现键盘行布局的解析、加载和缓存功能
- 支持通过getKeyRows函数获取当前模式下的键盘行布局
- 实现shift状态下的提交值和显示标签获取功能
- 更新KeyboardLayout组件使用动态键盘行布局
- 支持shift状态下优先使用配置的提交值，未配置时使用大写转换