### PR TITLE
docs(config): 添加 Xime 输入法双语配置示例

### DIFF
--- a/docs/config_examples/xime.ms.double.yaml
+++ b/docs/config_examples/xime.ms.double.yaml
@@ -1,0 +1,212 @@
+metadata:
+  app_name: Xime
+  app_version: ">=2.5.0"
+  platform: android
+  config_version: 1
+  generator: "Xime Config Generator" # 暂时无用
+  modified_time: "2026-07-05"
+
+xime_index:
+  # 方案/插件/模型市场索引端点（ximeiorg/xime-index）。
+  # 可替换为自建代理/镜像，下载器按顺序依次尝试，直到成功为止。
+  # 末尾需要 /。
+  base_urls:
+    - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    - "https://index.ximei.me/"
+    - "https://raw.githubusercontent.com/ximeiorg/xime-index/refs/heads/main/"
+
+style:
+  color_scheme: lavender_purple
+
+color_schemes:
+  lavender_purple:
+    name: "薰衣草紫"
+    primary_color: 0x8F73E2
+  
+  ocean_blue:
+    name: "海洋蔚蓝"
+    primary_color: 0x1A73E8
+  
+  forest_green:
+    name: "森林翠绿"
+    primary_color: 0x2E7D32
+  
+  sunset_orange:
+    name: "落日橙光"
+    primary_color: 0xE65100
+  
+  coral_red:
+    name: "珊瑚绯红"
+    primary_color: 0xC62828
+  
+  slate_gray:
+    name: "沉稳石墨"
+    primary_color: 0x424242
+  
+  rose_pink:
+    name: "浪漫玫瑰"
+    primary_color: 0xAD1457
+  
+  teal_cyan:
+    name: "青碧如水"
+    primary_color: 0x00796B
+
+# ── 26 键全键盘手势配置 ──
+# 每个按键可定义 4 个手势：
+#   tap:        点按
+#   swipe_up:   上滑
+#   swipe_down: 下滑
+#   long_press: 长按（数组，弹出气泡后左右滑动选择）
+#
+# 每个手势的值格式：
+#   - 字符串 "a" → 上屏该文本，显示也是它
+#   - { label, action, value }
+#     label:  按键上显示的文字
+#     action: commit（上屏）, command（内置命令，value 为命令名）, select_all, copy, cut,
+#             paste, line_start, line_end, undo, none, repeat
+#     command 可用命令：
+#       clear_composition - 清空当前输入编码和候选词
+#     value:  上屏时的输出文本（不指定则用 label）
+#
+# long_press 示例（弹出多个选项供滑动选择）：
+#   long_press: { display: "bubble", values: [ { label: "大写", action: "commit", value: "A" }, { label: "Ä", action: "commit", value: "ä" } ] }
+#   # 也支持字符串简写：
+#   long_press: { display: "bubble", values: ["q", "Q"] }
+keyboard:
+  # ── 键盘颜色配置（可选，不设置则使用内置默认值）──
+  # keyboard_bg_color        - 键盘背景色（亮色）
+  # keyboard_bg_color_dark   - 键盘背景色（暗色）
+  # key_bg_color             - 按键背景色（亮色）
+  # key_bg_color_dark        - 按键背景色（暗色）
+  # special_key_bg_color     - 特殊按键背景色（亮色）
+  # special_key_bg_color_dark- 特殊按键背景色（暗色）
+  # candidate_bar_bg_color   - 候选栏背景色（亮色）
+  # candidate_bar_bg_color_dark- 候选栏背景色（暗色）
+  # key_text_color           - 按键文字颜色（亮色）
+  # key_text_color_dark      - 按键文字颜色（暗色）
+  # candidate_text_color     - 候选文字颜色（亮色）
+  # candidate_text_color_dark- 候选文字颜色（暗色）
+  colors:
+    keyboard_bg_color: 0xE3E4E8
+    keyboard_bg_color_dark: 0x202020
+    key_bg_color: 0xFFFFFF
+    key_bg_color_dark: 0x4A4A4A
+    # special_key_bg_color: 0x9fef86 #不设置时默认取主题色
+    # special_key_bg_color_dark: 0x4A4A4A #不设置时默认取主题色
+    candidate_bar_bg_color: 0xE3E4E8
+    candidate_bar_bg_color_dark: 0x202020
+    key_text_color: 0x202124
+    key_text_color_dark: 0xE8EAED
+    candidate_text_color: 0x202124
+    candidate_text_color_dark: 0xE8EAED
+  
+  # ── 按键配置（可选，不设置则使用默认值）──
+  # corner_radius:      按键圆角半径（dp，默认 8），独立于 shadow.shape_radius
+  key:
+    corner_radius: 8
+
+  # ── 按键阴影（可选，不设置则使用默认值）──
+  # enabled:            是否启用阴影
+  # elevation:          阴影高度（dp，默认 0.5）
+  shadow:
+    enabled: true
+    elevation: 0.5
+  qwerty:
+    # ── 按键布局模式 ──
+    # standard: 默认布局（主文字居中，下滑提示在底部）
+    # compact: 紧凑布局（主文字在左上，下滑提示占满键帽中部）
+    button_layout: standard
+    layout:
+      rows:
+        - [q, w, e, r, t, y, u, i, o, p]
+        - [a, s, d, f, g, h, j, k, l,";"]
+        - [z, x, c, v, b, n, m]
+    keys:
+      # ── 第一行 ──
+      # long_press 顺序：小写 → 大写 → 带变音符号的相似字母
+      # swipe_down 显示对应的五笔字根（action:none 仅显示不上屏）
+      # display: bubble → 气泡显示；key → 显示在按键上（最多显示 2 个字）
+      q: { tap: "q", swipe_up: "1", swipe_down: { label: "金 钅𠂊勺㐅 犭𱼀", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["q", "Q"] } }
+      w: { tap: "w", swipe_up: "2", swipe_down: { label: "人亻八癶", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["w", "W"] } }
+      e: { tap: "e", swipe_up: "3", swipe_down: { label: "月⺼彡乃用爫彡𧘇豕", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["e", "E", "è", "é", "ê", "ë"] } }
+      r: { tap: "r", swipe_up: "4", swipe_down: { label: "白手龵扌斤𰀪𠂆", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["r", "R"] } }
+      t: { tap: "t", swipe_up: "5", swipe_down: { label: "禾竹丿𠂉彳夂攵", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["t", "T"] } }
+      y: { tap: "y", swipe_up: "6", swipe_down: { label: "言讠文方广亠丶乀", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["y", "Y", "ÿ"] } }
+      u: { tap: "u", swipe_up: "7", swipe_down: { label: "立六辛冫丬门疒丷䒑", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["u", "U", "ù", "ú", "û", "ü"] } }
+      i: { tap: "i", swipe_up: "8", swipe_down: { label: "水氵小氺头𭕄⺌", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["i", "I", "ì", "í", "î", "ï"] } }
+      o: { tap: "o", swipe_up: "9", swipe_down: { label: "火灬米", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["o", "O", "ò", "ó", "ô", "õ", "ö", "ø"] } }
+      p: { tap: "p", swipe_up: "0", swipe_down: { label: "之辶冖宀廴礻", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["p", "P"] } }
+
+      # ── 第二行 ──
+      a: { tap: "a", swipe_up: { label: "～", value: "~" }, swipe_down: { label: "工匚戈艹廿龷七弋戈", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["a", "A", "à", "á", "â", "ã", "ä", "å", "æ"] } }
+      s: { tap: "s", swipe_up: { label: "／", value: "/" }, swipe_down: { label: "木丁西", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["s", "S", "ß"] } }
+      d: { tap: "d", swipe_up: { label: "：", value: ":" }, swipe_down: { label: "大犬三古龵镸石厂丆", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["d", "D"] } }
+      f: { tap: "f", swipe_up: { label: "；", value: ";" }, swipe_down: { label: "土士二干十寸雨", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["f", "F"] } }
+      g: { tap: "g", swipe_up: { label: "“", value: "“" }, swipe_down: { label: "王龶五一戋", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["g", "G"] } }
+      h: { tap: "h", swipe_up: { label: "”", value: "”" }, swipe_down: { label: "目丨卜⺊上止龰", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["h", "H"] } }
+      j: { tap: "j", swipe_up: { label: "－", value: "-" }, swipe_down: { label: "日曰早廾刂虫丿Ⅱ", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["j", "J"] } }
+      k: { tap: "k", swipe_up: { label: "（", value: "(" }, swipe_down: { label: "口Ⅲ川", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["k", "K"] } }
+      l: { tap: "l", swipe_up: { label: "）", value: ")" }, swipe_down: { label: "田甲囗四罒车皿力", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["l", "L"] } }
+      ";": { tap: ";", shift: ":" }
+      # ── 第三行 ──
+      z: { tap: "z", swipe_up: { label: "＊", value: "*" }, swipe_down: { label: "", action: "none", display: "key" }, long_press: { display: "bubble", values: [ "z","Z"] } }
+      x: { tap: "x", swipe_up: { label: "＠", value: "@" }, swipe_down: { label: "弓匕纟幺弓𠤎", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["x", "X"] } }
+      c: { tap: "c", swipe_up: { label: "、", value: "、" }, swipe_down: { label: "又巴马厶龴ス", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["c", "C", "ç"] } }
+      v: { tap: "v", swipe_up: { label: "？", value: "?" }, swipe_down: { label: "女刀九臼巛彐", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["v", "V"] } }
+      b: { tap: "b", swipe_up: { label: "！", value: "!" }, swipe_down: { label: "子耳了也阝卩㔾凵", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["b", "B"] } }
+      n: { tap: "n", swipe_up: { label: "％", value: "%" }, swipe_down: { label: "已己巳心忄羽乙𠃜", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["n", "N", "ñ"] } }
+      m: { tap: "m", swipe_up: { label: "＃", value: "#" }, swipe_down: { label: "山由贝冂冎几", action: "none", display: "bubble" }, long_press: { display: "bubble", values: ["m", "M"] } }
+      # ── 第四行: 暂时不受layout控制 ──
+      #  逗号键，label 为中文显示，value 为英文显示+提交值
+      "'": { tap: { label: "，", value: "," }, swipe_up: { label: "。", value: "." } , long_press: { display: "bubble", values: [ ",","."] }}
+      # 中/英切换键，label 为按键显示文字
+      earth: { tap: { label: "@language", action: "toggle_ascii" }, long_press: { display: "bubble", values: [ { label: "选择输入法", action: "command", value: "show_ime_picker" } ] } }
+    
+  # 英文键盘布局
+  qwerty_en:
+    # ── 按键布局模式 ──
+    # standard: 默认布局（主文字居中，下滑提示在底部）
+    # compact: 紧凑布局（主文字在左上，下滑提示占满键帽中部）
+    button_layout: standard
+    layout:
+      rows:
+        - [q, w, e, r, t, y, u, i, o, p]
+        - [a, s, d, f, g, h, j, k, l,";"]
+        - [z, x, c, v, b, n, m]
+    keys:
+      # ── 第一行 ──
+      q: { tap: "q", swipe_up: "1", long_press: { display: "bubble", values: ["q", "Q"] } }
+      w: { tap: "w", swipe_up: "2", long_press: { display: "bubble", values: ["w", "W"] } }
+      e: { tap: "e", swipe_up: "3", long_press: { display: "bubble", values: ["e", "E"] } }
+      r: { tap: "r", swipe_up: "4", long_press: { display: "bubble", values: ["r", "R"] } }
+      t: { tap: "t", swipe_up: "5", long_press: { display: "bubble", values: ["t", "T"] } }
+      y: { tap: "y", swipe_up: "6", long_press: { display: "bubble", values: ["y", "Y"] } }
+      u: { tap: "u", swipe_up: "7", long_press: { display: "bubble", values: ["u", "U"] } }
+      i: { tap: "i", swipe_up: "8", long_press: { display: "bubble", values: ["i", "I"] } }
+      o: { tap: "o", swipe_up: "9", long_press: { display: "bubble", values: ["o", "O"] } }
+      p: { tap: "p", swipe_up: "0", long_press: { display: "bubble", values: ["p", "P"] } }
+      # ── 第二行 ──
+      a: { tap: "a", swipe_up: "~", long_press: { display: "bubble", values: ["a", "A"] } }
+      s: { tap: "s", swipe_up: "/", long_press: { display: "bubble", values: ["s", "S"] } }
+      d: { tap: "d", swipe_up: ":", long_press: { display: "bubble", values: ["d", "D"] } }
+      f: { tap: "f", swipe_up: ";", long_press: { display: "bubble", values: ["f", "F"] } }
+      g: { tap: "g", swipe_up: "\"", long_press: { display: "bubble", values: ["g", "G"] } }
+      h: { tap: "h", swipe_up: "\"", long_press: { display: "bubble", values: ["h", "H"] } }
+      j: { tap: "j", swipe_up: "-", long_press: { display: "bubble", values: ["j", "J"] } }
+      k: { tap: "k", swipe_up: "(", long_press: { display: "bubble", values: ["k", "K"] } }
+      l: { tap: "l", swipe_up: ")", long_press: { display: "bubble", values: ["l", "L"] } }
+      ";": { tap: ";", shift: ":" }
+
+      # ── 第三行 ──
+      z: { tap: "z", swipe_up: "*", long_press: { display: "bubble", values: ["z", "Z"] } }
+      x: { tap: "x", swipe_up: "@", long_press: { display: "bubble", values: ["x", "X"] } }
+      c: { tap: "c", swipe_up: "、", long_press: { display: "bubble", values: ["c", "C"] } }
+      v: { tap: "v", swipe_up: "?", long_press: { display: "bubble", values: ["v", "V"] } }
+      b: { tap: "b", swipe_up: "!", long_press: { display: "bubble", values: ["b", "B"] } }
+      n: { tap: "n", swipe_up: "%", long_press: { display: "bubble", values: ["n", "N"] } }
+      m: { tap: "m", swipe_up: "#", long_press: { display: "bubble", values: ["m", "M"] } }
+      #  逗号键，label 为中文显示，value 为英文显示+提交值
+      "'": { tap: { label: ".", value: "." }, swipe_up: { label: ",", value: "," } }
+      # 中/英切换键，label 为按键显示文字
+      earth: { tap: { label: "@language", action: "toggle_ascii" }, long_press: { display: "bubble", values: [ { label: "选择输入法", action: "command", value: "show_ime_picker" } ] } }


### PR DESCRIPTION
添加 xime.ms.double.yaml 配置文件，包含：
- 应用元数据配置（名称、版本、平台等）
- 方案市场索引端点配置，支持多个 CDN 和镜像源
- 多种配色方案（薰衣草紫、海洋蔚蓝、森林翠绿等 8 种主题）
- 完整的 26 键 QWERTY 键盘布局配置
- 中英文双语键盘支持
- 详细的按键手势配置（点按、上滑、下滑、长按）
- 键盘颜色和样式定制
- 五笔字根显示功能