### PR TITLE
refactor(input-service): 移除shift符号映射逻辑并简化字符处理

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -2226,7 +2226,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     // 所有按键统一经过 Rime 引擎
                     // 字母键不进入此分支（即使 pendingEnglish 非空），需要继续积累编码
                     if (pendingEnglish.isNotEmpty() && !key.matches(Regex("[a-zA-Z]"))) {
-                        val finalKey = if (isShifted) (shiftedSymbol(key, !state.isAsciiMode) ?: key) else key
+                        val finalKey = key
                         withContext(Dispatchers.Main) {
                             commitText(pendingEnglish + finalKey)
                             candidateState.value = candidateState.value.copy(
@@ -2237,7 +2237,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         Log.d(TAG, "Symbol: committed '$pendingEnglish$finalKey'")
                     } else {
                         val isChinese = !state.isAsciiMode
-                        val char = if (isShifted) (shiftedSymbol(key, isChinese) ?: key.uppercase()) else key
+                        val char = key
                         val keyCode = key.lowercase()[0].code
                         val mask = if (isShifted) KeyEvent.META_SHIFT_ON else 0
                         val isLetter = key.matches(Regex("[a-zA-Z]"))
@@ -2992,58 +2992,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         }
     }
     
-    private fun shiftedSymbol(key: String, chineseMode: Boolean = false): String? {
-        if (chineseMode) {
-            return when (key) {
-                "1" -> "！"
-                "2" -> "@"
-                "3" -> "#"
-                "4" -> "$"
-                "5" -> "%"
-                "6" -> "^"
-                "7" -> "&"
-                "8" -> "*"
-                "9" -> "（"
-                "0" -> "）"
-                "-" -> "——"
-                "=" -> "+"
-                "[" -> "「"
-                "]" -> "」"
-                "\\" -> "、"
-                ";" -> "："
-                "'" -> "\""
-                "," -> "《"
-                "." -> "》"
-                "/" -> "？"
-                "`" -> "～"
-                else -> null
-            }
-        }
-        return when (key) {
-            "`" -> "~"
-            "1" -> "!"
-            "2" -> "@"
-            "3" -> "#"
-            "4" -> "$"
-            "5" -> "%"
-            "6" -> "^"
-            "7" -> "&"
-            "8" -> "*"
-            "9" -> "("
-            "0" -> ")"
-            "-" -> "_"
-            "=" -> "+"
-            "[" -> "{"
-            "]" -> "}"
-            "\\" -> "|"
-            ";" -> ":"
-            "'" -> "\""
-            "," -> "<"
-            "." -> ">"
-            "/" -> "?"
-            else -> null
-        }
-    }
 
     private fun keyCodeToKey(keyCode: Int, isShifted: Boolean): String? {
         return when (keyCode) {

--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -59,7 +59,6 @@ data class LongPressConfig(
 
 data class KeyGestureConfig(
     val tap: GestureDef? = null,
-    val shift: GestureDef? = null,
     val swipeUp: GestureDef? = null,
     val swipeDown: GestureDef? = null,
     val longPress: LongPressConfig? = null,
@@ -133,7 +132,6 @@ private fun parseKeyboardConfig(raw: com.charleskorn.kaml.YamlMap?): KeyboardCon
 
 private fun parseKeyGestureConfig(map: com.charleskorn.kaml.YamlMap): KeyGestureConfig {
     var tap: GestureDef? = null
-    var shift: GestureDef? = null
     var swipeUp: GestureDef? = null
     var swipeDown: GestureDef? = null
     var longPress: LongPressConfig? = null
@@ -141,13 +139,12 @@ private fun parseKeyGestureConfig(map: com.charleskorn.kaml.YamlMap): KeyGesture
         val name = (kNode as? com.charleskorn.kaml.YamlScalar)?.content ?: continue
         when (name) {
             "tap" -> tap = parseGestureNode(vNode)
-            "shift" -> shift = parseGestureNode(vNode)
             "swipe_up" -> swipeUp = parseGestureNode(vNode)
             "swipe_down" -> swipeDown = parseGestureNode(vNode)
             "long_press" -> longPress = parseLongPress(vNode)
         }
     }
-    return KeyGestureConfig(tap, shift, swipeUp, swipeDown, longPress)
+    return KeyGestureConfig(tap, swipeUp, swipeDown, longPress)
 }
 
 /**
@@ -791,19 +788,6 @@ object KeysConfigHelper {
         val config = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
         val value = config[key.lowercase()]?.tap?.value
         return value?.takeIf { it.isNotEmpty() } ?: key
-    }
-
-    /** 获取 shift 状态的提交值，无配置时返回 null。 */
-    fun getKeyShiftCommitValue(key: String, isAsciiMode: Boolean = false): String? {
-        val config = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
-        return config[key.lowercase()]?.shift?.value?.takeIf { it.isNotEmpty() }
-    }
-
-    /** 获取 shift 状态的显示标签，无配置时返回 null。 */
-    fun getKeyShiftLabel(key: String, isAsciiMode: Boolean = false): String? {
-        val config = if (isAsciiMode) _keyGestureConfigEn.value else _keyGestureConfig.value
-        val shift = config[key.lowercase()]?.shift
-        return shift?.label?.takeIf { it.isNotEmpty() } ?: shift?.value?.takeIf { it.isNotEmpty() }
     }
 
     /** 获取某个按键指定手势的显示标签。 */

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -437,7 +437,7 @@ fun KeyboardLayout(
 
                                     val rawCommitValue = KeysConfigHelper.getKeyCommitValue(key, isAsciiMode)
                                     val commitValue = if (visualIsShifted) {
-                                        KeysConfigHelper.getKeyShiftCommitValue(key, isAsciiMode) ?: rawCommitValue.uppercase()
+                                        rawCommitValue.uppercase()
                                     } else {
                                         rawCommitValue
                                     }
@@ -973,7 +973,7 @@ fun KeyboardRowWithConfig(
             // 键帽显示文本
             val rawCommitValue = KeysConfigHelper.getKeyCommitValue(key, isAsciiMode)
             val commitValue = if (isShifted) {
-                KeysConfigHelper.getKeyShiftCommitValue(key, isAsciiMode) ?: rawCommitValue.uppercase()
+                rawCommitValue.uppercase()
             } else {
                 rawCommitValue
             }
@@ -1999,7 +1999,7 @@ fun CompactKeyboardRowWithConfig(
 
             val rawCommitValue = KeysConfigHelper.getKeyCommitValue(key, isAsciiMode)
             val commitValue = if (isShifted) {
-                KeysConfigHelper.getKeyShiftCommitValue(key, isAsciiMode) ?: rawCommitValue.uppercase()
+                rawCommitValue.uppercase()
             } else {
                 rawCommitValue
             }

--- a/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/KeyboardGestureConfigTest.kt
@@ -114,7 +114,6 @@ class KeyboardGestureConfigTest {
     fun `部分手势缺失不报错`() {
         val a = parseKeys("""a: { tap: "a" }""".trimIndent())["a"]!!
         assertEquals("a", a.tap!!.label)
-        assertNull(a.shift)
         assertNull(a.swipeUp)
         assertNull(a.swipeDown)
         assertNull(a.longPress)
@@ -415,33 +414,6 @@ class KeyboardGestureConfigTest {
         }
     }
 
-    @Test
-    fun `shift 字符串简写解析`() {
-        val keys = parseKeys("""
-            a: { tap: "a", shift: "A" }
-        """.trimIndent())
-        val kc = keys["a"]!!
-        assertEquals("A", kc.shift!!.label)
-        assertEquals(GestureAction.COMMIT, kc.shift!!.action)
-        assertEquals("A", kc.shift!!.value)
-    }
-
-    @Test
-    fun `shift 对象格式指定 action`() {
-        val keys = parseKeys("""
-            s: { tap: "s", shift: { label: "S", action: "commit" } }
-        """.trimIndent())
-        val kc = keys["s"]!!
-        assertEquals("S", kc.shift!!.label)
-        assertEquals(GestureAction.COMMIT, kc.shift!!.action)
-    }
-
-    @Test
-    fun `shift 缺失不报错`() {
-        val a = parseKeys("""a: { tap: "a" }""".trimIndent())["a"]!!
-        assertNull(a.shift)
-    }
-
     // ── 辅助 ──
 
     private fun parseKeys(yamlFragment: String): Map<String, KeyGestureConfig> {
@@ -460,7 +432,6 @@ class KeyboardGestureConfigTest {
 
     private fun parseKeyGestureConfig(map: com.charleskorn.kaml.YamlMap): KeyGestureConfig {
         var tap: GestureDef? = null
-        var shift: GestureDef? = null
         var swipeUp: GestureDef? = null
         var swipeDown: GestureDef? = null
         var longPress: LongPressConfig? = null
@@ -468,13 +439,12 @@ class KeyboardGestureConfigTest {
             val name = (kNode as com.charleskorn.kaml.YamlScalar).content
             when (name) {
                 "tap" -> tap = parseGestureNode(vNode)
-                "shift" -> shift = parseGestureNode(vNode)
                 "swipe_up" -> swipeUp = parseGestureNode(vNode)
                 "swipe_down" -> swipeDown = parseGestureNode(vNode)
                 "long_press" -> longPress = parseLongPress(vNode)
             }
         }
-        return KeyGestureConfig(tap = tap, shift = shift, swipeUp = swipeUp, swipeDown = swipeDown, longPress = longPress)
+        return KeyGestureConfig(tap = tap, swipeUp = swipeUp, swipeDown = swipeDown, longPress = longPress)
     }
 
     private fun parseLongPress(node: com.charleskorn.kaml.YamlNode): LongPressConfig? {


### PR DESCRIPTION
移除了XimeInputMethodService中复杂的shift符号映射函数shiftedSymbol， 统一使用原始按键值进行处理，简化了字母键和符号键的处理逻辑。

BREAKING CHANGE: 移除了shift符号配置功能，不再支持自定义shift状态下的符号映射