### PR TITLE
feat: 优化剪贴板管理和文件导入功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
+++ b/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
@@ -60,6 +60,7 @@ class XimeApplication : Application(), ImageLoaderFactory {
             defaultHandler?.uncaughtException(thread, throwable)
         }
 
+        val isDebug = BuildConfig.DEBUG
         Log.d(TAG, "Initializing PluginManager...")
         PluginManager.initialize(this, HOST_PROVIDER_AUTHORITY) {
             Log.d(TAG, "PluginManager onSetup callback executing...")
@@ -68,7 +69,7 @@ class XimeApplication : Application(), ImageLoaderFactory {
             val systemInstalled = PluginManager.scanAndInstallSystemPlugins()
             Log.d(TAG, "Installed $systemInstalled plugins from system")
             
-            if (BuildConfig.DEBUG) {
+            if (isDebug) {
                 val assetInstalled = PluginManager.installPluginsFromAssetsForDebug("plugins")
                 Log.d(TAG, "Installed $assetInstalled plugins from assets")
             }

--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -44,13 +44,24 @@ class ClipboardManager private constructor(private val context: Context) {
     }
     
     private val androidClipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as AndroidClipboardManager
+    
     private val clipboardListener = AndroidClipboardManager.OnPrimaryClipChangedListener {
-        val clipData = androidClipboardManager.primaryClip
-        if (clipData != null && clipData.itemCount > 0) {
-            val text = clipData.getItemAt(0).text?.toString()
-            if (!text.isNullOrEmpty()) {
-                addItem(text)
+        try {
+            val clipData = androidClipboardManager.primaryClip
+            if (clipData != null && clipData.itemCount > 0) {
+                val text = clipData.getItemAt(0).text?.toString()
+                if (!text.isNullOrEmpty()) {
+                    addItem(text)
+                } else {
+                    Log.d(TAG, "Clipboard changed but text is null/empty")
+                }
+            } else {
+                Log.d(TAG, "Clipboard changed but primaryClip is null")
             }
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Cannot read clipboard: missing permission", e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Unexpected error reading clipboard", e)
         }
     }
     
@@ -162,12 +173,8 @@ class ClipboardManager private constructor(private val context: Context) {
         androidClipboardManager.addPrimaryClipChangedListener(clipboardListener)
     }
 
-    fun stopListening() {
-        androidClipboardManager.removePrimaryClipChangedListener(clipboardListener)
-    }
-
     fun release() {
-        stopListening()
+        // Singleton — no cleanup needed.
     }
     
     fun addItem(text: String) {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -620,7 +620,6 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     clipboardItemsState.value = items
                 }
             }
-
             serviceScope.launch {
                 clipboardManager.quickSendItems.collect { items ->
                     quickSendItemsState.value = items

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -709,6 +709,20 @@ object SchemaManager {
         name.endsWith(".tgz", ignoreCase = true)
 
     /**
+     * 某些 Android 内容提供器会将未知 MIME 类型的文件（如 .yaml）自动追加 .txt 后缀，
+     * 导致 xime.custom.yaml 变成 xime.custom.yaml.txt。此处修复已知情况。
+     */
+    fun sanitizeDisplayName(name: String): String {
+        return when {
+            name.endsWith(".yaml.txt", ignoreCase = true) ->
+                name.removeSuffix(".txt")
+            name.endsWith(".dict.yaml.txt", ignoreCase = true) ->
+                name.removeSuffix(".txt")
+            else -> name
+        }
+    }
+
+    /**
      * 统一保存导入的文件：
      * - 压缩包（zip/tar.gz/tgz）→ market/{importId}/，等待用户手动安装
      * - 非压缩包（yaml/txt/bin 等）→ 直接放入 rime/
@@ -720,20 +734,21 @@ object SchemaManager {
         inputStream: java.io.InputStream,
         autoEnable: Boolean = true,
     ): ImportResult = withContext(Dispatchers.IO) {
-        if (isArchive(displayName)) {
+        val name = sanitizeDisplayName(displayName)
+        if (isArchive(name)) {
             // 压缩包：保存到 market/ 等待用户手动安装
             val importId = generateImportId()
             val pkgDir = getMarketDir(context, importId)
             try {
                 pkgDir.mkdirs()
-                val archiveFile = File(pkgDir, displayName)
+                val archiveFile = File(pkgDir, name)
                 inputStream.use { input ->
                     archiveFile.outputStream().use { output -> input.copyTo(output) }
                 }
-                Log.i(TAG, "Imported $displayName -> $importId (not installed yet)")
+                Log.i(TAG, "Imported $name -> $importId (not installed yet)")
                 ImportResult(true)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to import archive $displayName", e)
+                Log.e(TAG, "Failed to import archive $name", e)
                 try { if (pkgDir.exists()) pkgDir.deleteRecursively() } catch (_: Exception) {}
                 ImportResult(false)
             }
@@ -742,23 +757,23 @@ object SchemaManager {
             val rimeDir = getRimeDir(context)
             try {
                 rimeDir.mkdirs()
-                val target = File(rimeDir, displayName)
+                val target = File(rimeDir, name)
                 inputStream.use { input ->
                     target.outputStream().use { output -> input.copyTo(output) }
                 }
                 // 如果是 .schema.yaml 文件，自动启用
-                if (autoEnable && displayName.endsWith(".schema.yaml")) {
-                    val schemaId = displayName.removeSuffix(".schema.yaml")
+                if (autoEnable && name.endsWith(".schema.yaml")) {
+                    val schemaId = name.removeSuffix(".schema.yaml")
                     val enabled = getEnabledSchemas(context).toMutableList()
                     if (schemaId !in enabled) {
                         enabled.add(schemaId)
                         setEnabledSchemas(context, enabled)
                     }
                 }
-                Log.i(TAG, "Imported $displayName -> rime/ (direct)")
+                Log.i(TAG, "Imported $name -> rime/ (direct)")
                 ImportResult(true, installedDirect = true)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to import $displayName directly", e)
+                Log.e(TAG, "Failed to import $name directly", e)
                 ImportResult(false)
             }
         }


### PR DESCRIPTION
- 在XimeApplication中缓存BuildConfig.DEBUG值以提高性能
- 为ClipboardManager添加异常处理机制，捕获SecurityException和其他异常
- 移除不必要的stopListening方法，因为单例模式下无需清理
- 在SchemaManager中添加sanitizeDisplayName函数，修复Android内容提供器 自动追加.txt后缀的问题，特别是针对.yaml和.dict.yaml文件
- 修改文件导入逻辑使用清理后的文件名，提升日志准确性
- 更新子项目librime、librime-lua和librime-lua-deps的状态