### PR TITLE
fix: 修复键盘切换状态相关问题（计算器候选词阻塞、键盘布局持久化、ASCII 模式同步）

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1310,6 +1310,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             val availableSchemas = rimeEngine.getAvailableSchemas()
             Log.d(TAG, "onStartInput: saved=$savedSchema, current=$currentSchema, available=${availableSchemas.joinToString()}")
             
+            // switchSchema 会重置 ASCII 模式为 schema 默认值，先保存以便后续恢复
+            val asciiModeBeforeSchemaSwitch = rimeEngine.isAsciiMode()
+            
             val actualSchema: String
             when {
                 savedSchema == HANDWRITING_SCHEMA_ID -> {
@@ -1366,6 +1369,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 else -> actualSchema = savedSchema
             }
             updateSchemaName()
+            
+            // switchSchema 可能会重置 ASCII 模式，恢复之以保持引擎与 UI 状态同步
+            if (rimeEngine.isAsciiMode() != asciiModeBeforeSchemaSwitch) {
+                rimeEngine.toggleAsciiMode()
+            }
         }
 
         uiState.value = uiState.value.copy(
@@ -2538,8 +2546,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private fun selectCandidate(index: Int) {
         composeViewRef?.let { feedbackManager.performKeyPressEffect(view = it) }
 
-        // 计算器模式
-        if (calculatorEngine.isActive()) {
+        // 计算器模式（仅在数字/常用符号键盘下生效，防止状态残留导致其他键盘候选词点击异常）
+        val layoutState = keyboardViewModel.keyboardState.value
+        val isCalculatorKeyboard = layoutState is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.Number
+                || layoutState is com.kingzcheung.xime.ui.keyboard.KeyboardLayoutState.CommonSymbol
+        if (calculatorEngine.isActive() && isCalculatorKeyboard) {
             val result = calculatorEngine.getResult()
             val expression = calculatorEngine.getExpression()
             val formulaResult = calculatorEngine.getFormulaResult()

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -140,9 +140,6 @@ fun KeyboardView(
         if (keyboardState is KeyboardLayoutState.Number) {
             if (savedNumberAsciiMode == null) {
                 savedNumberAsciiMode = state.isAsciiMode
-                if (!state.isAsciiMode && page is KeyboardPage.Main) {
-                    callbacks.onKeyPress("ime_switch", false)
-                }
             }
         } else {
             savedNumberAsciiMode = null
@@ -459,6 +456,7 @@ fun KeyboardView(
                         val numberOnKeyPress: (String) -> Unit = { key ->
                             when (key) {
                                 "abc" -> {
+                                    callbacks.onKeyPress("abc", false)
                                     val saved = savedNumberAsciiMode
                                     savedNumberAsciiMode = null
                                     if (saved != null && saved != state.isAsciiMode) {


### PR DESCRIPTION
## 问题描述
@kingzcheung 

只解决：#428 其中：4,5,6三个问题。剩余：1，2, 3 需要根据后续讨论内容进行调整，作为特性分支去统一设计。已经同步最新主线代码。

### Issue 4：九键数字键盘计算器返回异常
在数字键盘中触发计算器（如 `1+2`）后点击"返回"箭头回到九键拼音键盘，计算器候选词 `3, 1+2=3` 残留显示在工具栏，导致后续输入数字键（如 `5`）时非首位候选词无法点击。

### Issue 5：九键拼音 → 数字键盘 → 手势关闭 → 重新打开显示英文键盘
在九键拼音键盘中点击"123"进入数字键盘，使用全面屏手势关闭输入窗口后重新呼出，键盘显示为英文键盘而非九键拼音键盘。

### Issue 6：英文键盘 → 地球图标 → 需要点击两次才能切换回九键拼音
`onStartInput` 中 `switchSchema` 重置了 Rime 引擎的 ASCII 模式，但 `uiState.isAsciiMode` 保持旧值，导致首次点击地球图标时引擎状态与 UI 不同步，需要点击两次才生效。

## 修改内容

### Issue 4 — 计算器候选词残留 & 候选词点击异常
- **`KeyboardView.kt`**: `numberOnKeyPress("abc")` 切换布局前调用 `callbacks.onKeyPress("abc", false)`，触发服务层 `calculatorEngine.clear()`，清除计算器残留状态，与 26 键盘标准处理一致
- **`XimeInputMethodService.kt`**: `selectCandidate` 中计算器分支添加 `isCalculatorKeyboard` 防御（仅在数字/常用符号键盘下生效），防止状态残留阻塞其他键盘的候选词点击

### Issue 5 — 键盘布局状态持久化
- **`KeyboardView.kt`**: 删除 `LaunchedEffect(keyboardState)` 中 `if (!state.isAsciiMode && page is KeyboardPage.Main) { callbacks.onKeyPress("ime_switch", false) }` 代码块，避免进入 Number 键盘时误触发 `ime_switch` 永久切换 Rime 引擎的 ASCII 模式

### Issue 6 — switchSchema 重置 ASCII 模式
- **`XimeInputMethodService.kt`**: `onStartInput` 中 `switchSchema` 前保存 `rimeEngine.isAsciiMode()`，`switchSchema` 后若 ASCII 模式被重置则调用 `toggleAsciiMode()` 恢复，保持引擎与 UI 状态同步

## 验证
- `./gradlew assembleDebug --quiet` ✅
- `./gradlew test --quiet` ✅
- 已 rebase 到最新的 `upstream/main`