### PR TITLE
fix(XimeInputMethodService): 优化删除按键处理逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1873,15 +1873,30 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     return
                 }
                 "delete" -> {
-                    QuickSendFormEditTextHolder.editText?.let { et ->
-                        val start = et.selectionStart.coerceAtLeast(0)
-                        val end = et.selectionEnd.coerceAtLeast(start)
-                        if (start == end && start > 0) {
-                            et.text?.delete(start - 1, start)
-                            try { et.setSelection(start - 1) } catch (_: Exception) {}
-                        } else if (end > start) {
-                            et.text?.delete(start, end)
-                            try { et.setSelection(start) } catch (_: Exception) {}
+                    val candState = candidateState.value
+                    val isComposing = candState.isComposing || candState.inputText.isNotEmpty()
+                    if (isComposing) {
+                        // Rime 有组合态 → 转发退格到 Rime 清空候选字母/联想词
+                        rimeEngine.processKey(0xff08, 0)
+                        val result = rimeEngine.getProcessResult(true)
+                        if (result.inputText.isEmpty()) {
+                            rimeEngine.clearComposition()
+                        }
+                        uiEventChannel.trySend {
+                            updateUIWithResult(result)
+                        }
+                    } else {
+                        // 无组合态 → 直接操作 EditText 删除已上屏文字
+                        QuickSendFormEditTextHolder.editText?.let { et ->
+                            val start = et.selectionStart.coerceAtLeast(0)
+                            val end = et.selectionEnd.coerceAtLeast(start)
+                            if (start == end && start > 0) {
+                                et.text?.delete(start - 1, start)
+                                try { et.setSelection(start - 1) } catch (_: Exception) {}
+                            } else if (end > start) {
+                                et.text?.delete(start, end)
+                                try { et.setSelection(start) } catch (_: Exception) {}
+                            }
                         }
                     }
                     return


### PR DESCRIPTION
当处于组合输入状态时，删除按键现在会转发给 Rime 引擎处理，
用于清空候选字母或联想词；当无组合状态时则直接操作 EditText
删除已上屏的文字。同时更新了相关依赖子模块。