### PR TITLE
fix: T9 右侧候选词消费序列后候选列表空白 并补充内置拼音方案注释配置

### DIFF
--- a/app/src/main/assets/rime/t9_pinyin.schema.yaml
+++ b/app/src/main/assets/rime/t9_pinyin.schema.yaml
@@ -79,6 +79,7 @@ translator:
   dictionary: pinyin_simp
   prism: t9_pinyin
   spelling_hints: 100
+  always_show_comments: true
   comment_format: []
   preedit_format:
     - xlit/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -2458,77 +2458,82 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             index
         }
 
-        if (rimeEngine.selectCandidate(rimeIndex)) {
-            val committedText = rimeEngine.commit()
-            // T9 模式下 fullyConsumed 是判断 full/partial commit 的唯一权威：
-            // 当控制器明确 partial commit 时，即使 RIME commit() 返回非空文本
-            // （RIME 内部做了 partial commit），也不应走 full commit 路径。
-            val isFullCommit = if (isT9) {
-                fullyConsumed && selectedCandidate != null
-            } else {
-                committedText.isNotEmpty()
+        // T9：跳过 rimeEngine.selectCandidate，消费已由 T9 处理器
+        // （T9RightCommitHandler）独立完成。selectCandidate 会遗留
+        // [confirmed, phony] 残留 composition 状态，导致后续 forceSendToRime
+        // 的 setInput 无法正常重建候选项。
+        val selectSucceeded = isT9 || rimeEngine.selectCandidate(rimeIndex)
+        if (!selectSucceeded) return
+        val committedText = if (isT9) "" else rimeEngine.commit()
+        // T9 模式下 fullyConsumed 是判断 full/partial commit 的唯一权威：
+        // 当控制器明确 partial commit 时，即使 RIME commit() 返回非空文本
+        // （RIME 内部做了 partial commit），也不应走 full commit 路径。
+        val isFullCommit = if (isT9) {
+            fullyConsumed && selectedCandidate != null
+        } else {
+            committedText.isNotEmpty()
+        }
+        if (isFullCommit) {
+            if (SettingsPreferences.isSmartPredictionEnabled(this) && selectedCandidate != null && AssociationManager.isInitialized()) {
+                if (predictionManager.lastCommittedText.isNotEmpty()) {
+                    val lastChar = predictionManager.lastCommittedText.last().toString()
+                    predictionManager.recordInputPair(lastChar, selectedCandidate)
+                    Log.d(TAG, "Learned: '$lastChar' + '$selectedCandidate'")
+                }
             }
-            if (isFullCommit) {
-                if (SettingsPreferences.isSmartPredictionEnabled(this) && selectedCandidate != null && AssociationManager.isInitialized()) {
-                    if (predictionManager.lastCommittedText.isNotEmpty()) {
-                        val lastChar = predictionManager.lastCommittedText.last().toString()
-                        predictionManager.recordInputPair(lastChar, selectedCandidate)
-                        Log.d(TAG, "Learned: '$lastChar' + '$selectedCandidate'")
-                    }
-                }
-                // T9 full commit：优先使用用户明确选中的候选词文本作为上屏文本。
-                // UI 候选词列表经 filterCandidatesBySelectionHistory 过滤/重排序后 index
-                // 可能与 RIME 原始候选词 index 不对应。即使已通过 resolveRimeCandidateIndex
-                // 修正了 selectCandidate 的 index，仍以用户选中的 selectedCandidate 为权威
-                // 上屏文本（双保险），避免 RIME commit() 因任何原因返回错误文本。
-                // 非 T9 模式仍保持 RIME committedText 优先（可能含简繁转换等处理）。
-                val textToMerge = if (isT9 && fullyConsumed && selectedCandidate != null) {
-                    selectedCandidate
-                } else if (committedText.isNotEmpty()) {
-                    committedText
-                } else {
-                    selectedCandidate!!
-                }
-                val fullCommitText = if (isT9) {
-                    PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, textToMerge)
-                } else {
-                    textToMerge
-                }
-                withContext(Dispatchers.Main) {
-                    commitText(fullCommitText)
-                    t9PartialCommitTexts.clear()
-                    candidateState.value = candidateState.value.copy(
-                        inputText = "",
-                        candidates = emptyList(),
-                        candidateComments = emptyList(),
-                        isComposing = false,
-                        hasNextPage = false,
-                        hasPrevPage = false,
-                        isShowingRecentClipboard = false
-                    )
-                    uiState.value = uiState.value.copy(
-                        t9ResetSignal = uiState.value.t9ResetSignal + 1,
-                        t9RightCandidateSelectedCount = 0,
-                        t9SelectedCandidatePinyin = ""
-                    )
-                }
+            // T9 full commit：优先使用用户明确选中的候选词文本作为上屏文本。
+            // UI 候选词列表经 filterCandidatesBySelectionHistory 过滤/重排序后 index
+            // 可能与 RIME 原始候选词 index 不对应。即使已通过 resolveRimeCandidateIndex
+            // 修正了 selectCandidate 的 index，仍以用户选中的 selectedCandidate 为权威
+            // 上屏文本（双保险），避免 RIME commit() 因任何原因返回错误文本。
+            // 非 T9 模式仍保持 RIME committedText 优先（可能含简繁转换等处理）。
+            val textToMerge = if (isT9 && fullyConsumed && selectedCandidate != null) {
+                selectedCandidate
+            } else if (committedText.isNotEmpty()) {
+                committedText
             } else {
-                withContext(Dispatchers.Main) {
-                    if (isT9) {
-                        // partial commit：把本次选中的候选文本追加到累积列表，供后续合并显示
-                        if (selectedCandidate != null) {
-                            t9PartialCommitTexts.add(selectedCandidate)
-                        }
-                        // 保留状态字段，供 UI 层感知右侧选词事件
-                        uiState.value = uiState.value.copy(
-                            t9RightCandidateSelectedCount = uiState.value.t9RightCandidateSelectedCount + 1,
-                            t9SelectedCandidatePinyin = candidatePinyin ?: ""
-                        )
-                        // RIME commit() 已清除 composition，需要控制器重新发送剩余数字到 RIME
-                        keyboardCallbacks?.onT9ForceSendToRime?.invoke()
+                selectedCandidate!!
+            }
+            val fullCommitText = if (isT9) {
+                PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, textToMerge)
+            } else {
+                textToMerge
+            }
+            withContext(Dispatchers.Main) {
+                commitText(fullCommitText)
+                t9PartialCommitTexts.clear()
+                candidateState.value = candidateState.value.copy(
+                    inputText = "",
+                    candidates = emptyList(),
+                    candidateComments = emptyList(),
+                    isComposing = false,
+                    hasNextPage = false,
+                    hasPrevPage = false,
+                    isShowingRecentClipboard = false
+                )
+                uiState.value = uiState.value.copy(
+                    t9ResetSignal = uiState.value.t9ResetSignal + 1,
+                    t9RightCandidateSelectedCount = 0,
+                    t9SelectedCandidatePinyin = ""
+                )
+            }
+        } else {
+            withContext(Dispatchers.Main) {
+                if (isT9) {
+                    // partial commit：把本次选中的候选文本追加到累积列表，供后续合并显示
+                    if (selectedCandidate != null) {
+                        t9PartialCommitTexts.add(selectedCandidate)
                     }
-                    updateUI()
+                    // 保留状态字段，供 UI 层感知右侧选词事件
+                    uiState.value = uiState.value.copy(
+                        t9RightCandidateSelectedCount = uiState.value.t9RightCandidateSelectedCount + 1,
+                        t9SelectedCandidatePinyin = candidatePinyin ?: ""
+                    )
+                    // RIME composition 未被 selectCandidate 修改（已跳过），
+                    // 直接发送剩余数字到 RIME 重建 composition。
+                    keyboardCallbacks?.onT9ForceSendToRime?.invoke()
                 }
+                updateUI()
             }
         }
     }


### PR DESCRIPTION
## 关联 Issue
@kingzcheung ，已经跟进主线代码。为了修复如下问题：
Closes #431  #434 

## 修复内容

### Bug 1：右选 partial commit 后 RIME 无法重建候选
- **根因**：`selectCandidateAsync` 中对 T9 schema 调用 `rimeEngine.selectCandidate(index)`，遗留 `[confirmed, phony]` 残留 composition 态，导致后续 `forceSendToRime` 的 `setInput` 无法正常重建候选项。
- **修复**：T9 路径跳过 `rimeEngine.selectCandidate`，消费已由 `T9RightCommitHandler` 独立完成。

### Bug 2：内置九键方案右选候选词不显示拼音注释
- **根因**：`t9_pinyin.schema.yaml` 的 `translator` 配置缺少 `always_show_comments: true`。
- **修复**：在 translator 段追加 `always_show_comments: true`。
- **原因**：避免在：926 9426 →左选tao→右选：“饕”→左选“tian”后，右侧候选词列表中候选词不显示拼音，导致消费错误问题。参考成熟方案（雾凇拼音）解决方案。

## 影响范围
- 仅影响 T9 schema（`t9_pinyin`），不影响其他 schema
- `selectCandidateAsync` 方法中 T9 路径控制流变更

## 验证清单
- [ ] 本地构建通过：`./gradlew assembleDebug --quiet`
- [ ] 测试通过：`./gradlew test`
- [ ] 场景 18 完整操作流程通过
- [ ] 96 33 96 33 → 右选"我的 wo de"后右侧候选列表正常显示