### PR TITLE
chore(ci): 更新 GitHub labeler 配置以支持新语法

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,17 +1,27 @@
 android:
-  - app/**/*
+  - changed-files:
+      - any-glob-to-any-file: app/**/*
 plugin:
-  - plugins/**/*
-  - plugin-core/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/**/*
+          - plugin-core/**/*
 ci:
-  - .github/**/*
-  - gradle/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**/*
+          - gradle/**/*
 docs:
-  - docs/**/*
-  - '**/*.md'
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**/*
+          - '**/*.md'
 jni:
-  - app/src/main/jni/**/*
+  - changed-files:
+      - any-glob-to-any-file: app/src/main/jni/**/*
 theme:
-  - app/src/main/assets/themes/**/*
+  - changed-files:
+      - any-glob-to-any-file: app/src/main/assets/themes/**/*
 schema:
-  - app/src/main/assets/schemas/**/*
+  - changed-files:
+      - any-glob-to-any-file: app/src/main/assets/schemas/**/*


### PR DESCRIPTION
更新 .github/labeler.yml 文件，将标签规则从简单路径匹配改为
changed-files 语法，提高标签分配的准确性。

BREAKING CHANGE: 配置文件格式已更改，需要更新相关工作流。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
