### PR TITLE
chore(ci): 更新GitHub Actions标签器至v6版本并优化配置格式

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,37 @@
 android:
   - changed-files:
-      - any-glob-to-any-file: app/**/*
+      - any-glob-to-any-file:
+          - app/**/*
+
 plugin:
   - changed-files:
       - any-glob-to-any-file:
           - plugins/**/*
           - plugin-core/**/*
+
 ci:
   - changed-files:
       - any-glob-to-any-file:
           - .github/**/*
           - gradle/**/*
+
 docs:
   - changed-files:
       - any-glob-to-any-file:
           - docs/**/*
           - '**/*.md'
+
 jni:
   - changed-files:
-      - any-glob-to-any-file: app/src/main/jni/**/*
+      - any-glob-to-any-file:
+          - app/src/main/jni/**/*
+
 theme:
   - changed-files:
-      - any-glob-to-any-file: app/src/main/assets/themes/**/*
+      - any-glob-to-any-file:
+          - app/src/main/assets/themes/**/*
+
 schema:
   - changed-files:
-      - any-glob-to-any-file: app/src/main/assets/schemas/**/*
+      - any-glob-to-any-file:
+          - app/src/main/assets/schemas/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
更新了.github/workflows/labeler.yml中的actions/labeler从v5到v6版本， 同时重构了.labeler.yml文件的YAML格式，统一了文件路径匹配规则的写法，
使配置更加规范和一致。此外，更新了JNI子项目的提交状态标记。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
