### PR TITLE
fix(ui): 恢复非T9方案preeditText的显示

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1671,7 +1671,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             displayComments = display.displayComments
             isComposing = display.isComposing
         } else {
-            displayText = inputText
+            displayText = if (preeditText.isNotEmpty()) preeditText else inputText
             displayCandidates = filteredTexts
             displayComments = filteredComments
             isComposing = inputText.isNotEmpty()
@@ -1747,7 +1747,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             displayComments = display.displayComments
             isComposing = display.isComposing
         } else {
-            displayText = result.inputText
+            displayText = if (result.preeditText.isNotEmpty()) result.preeditText else result.inputText
             displayCandidates = filteredTexts
             displayComments = filteredComments
             isComposing = result.inputText.isNotEmpty()


### PR DESCRIPTION
在 fe6c900 (T9三态状态机重构) 后，updateUI() 和
updateUIWithResult() 的非T9分支将 displayText 设为 inputText (原始编码输入)，丢弃了 preeditText 中包含的 RIME segment.prompt
信息(如万象拼音的「haha〔表情：😄〕」提示)。

恢复 preeditText 优先的显示逻辑：
  displayText = if (preeditText.isNotEmpty()) preeditText else inputText

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #487（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
