### PR TITLE
fix(XimeInputMethodService): 在切换输入法时提交当前输入内容

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -2637,6 +2637,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     
     private fun switchInputMethod() {
         Log.d(TAG, "Toggling ascii mode")
+        rimeEngine.commit()
         rimeEngine.toggleAsciiMode()
         updateUI()
     }


### PR DESCRIPTION
在切换输入法模式之前调用 rimeEngine.commit() 来确保当前输入的内容被正确提交，
避免在切换 ASCII 模式时丢失未提交的输入内容。

更新了 librime 及相关子项目的依赖版本。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
