### PR TITLE
feat(service): 切换输入法时处理待提交文本和候选词

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1,4 +1,4 @@
-package com.kingzcheung.xime.service
+﻿package com.kingzcheung.xime.service
 
 import android.content.Intent
 import android.inputmethodservice.InputMethodService
@@ -2635,9 +2635,29 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         }
     }
     
-    private fun switchInputMethod() {
+    private suspend fun switchInputMethod() {
         Log.d(TAG, "Toggling ascii mode")
-        rimeEngine.commit()
+        val candState = candidateState.value
+        val pendingEnglish = candState.pendingEnglishText
+        if (pendingEnglish.isNotEmpty()) {
+            withContext(Dispatchers.Main) {
+                commitText(pendingEnglish)
+                candidateState.value = candidateState.value.copy(
+                    pendingEnglishText = "",
+                    associationCandidates = emptyList()
+                )
+            }
+        } else if (candState.isComposing) {
+            if (candState.candidates.isNotEmpty()) {
+                selectCandidateAsync(0)
+            } else {
+                val input = candState.inputText
+                if (input.isNotEmpty()) {
+                    commitText(input)
+                    rimeEngine.clearComposition()
+                }
+            }
+        }
         rimeEngine.toggleAsciiMode()
         updateUI()
     }


### PR DESCRIPTION
切换输入法功能现在会先处理当前待提交的英文文本或候选词，
确保在切换到ASCII模式前完成文本提交，避免输入状态丢失。

- 在切换前检查并提交待提交的英文文本
- 处理候选词状态，选择第一个候选词或清空组合状态
- 使用suspend函数配合协程处理异步操作

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
