### PR TITLE
fix(t9): 修复九键右选后上屏丢失累积文本的问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -2520,6 +2520,10 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     t9SelectedCandidatePinyin = ""
                 )
             }
+            // T9 full commit 后清除 RIME composition，防止残留状态导致
+            // 后续按键（如左侧候选区标点符号）重新拉取旧 preedit 和候选词。
+            // 放在 keyProcessingDispatcher 上执行，避免阻塞 Main 线程。
+            rimeEngine.clearComposition()
         } else {
             withContext(Dispatchers.Main) {
                 if (isT9) {

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -100,7 +100,6 @@ import kotlin.math.roundToInt
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.ui.theme.XimeTheme
 import com.kingzcheung.xime.util.FileLogger
-import com.kingzcheung.xime.util.PreeditMergeHelper
 import com.kingzcheung.xime.keyboard.ActionExecutor
 import com.kingzcheung.xime.keyboard.HANDWRITING_SCHEMA_ID
 import com.kingzcheung.xime.keyboard.OverlayRoute
@@ -2495,7 +2494,11 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 selectedCandidate!!
             }
             val fullCommitText = if (isT9) {
-                PreeditMergeHelper.mergePartialCommitText(t9PartialCommitTexts, textToMerge)
+                if (t9PartialCommitTexts.isNotEmpty()) {
+                    t9PartialCommitTexts.joinToString("") + textToMerge
+                } else {
+                    textToMerge
+                }
             } else {
                 textToMerge
             }


### PR DESCRIPTION
@kingzcheung 
### 概述
已经跟进主线变动
修复九键模式下右选部分候选词后上屏时丢失累积文本的 Bug。

**根因**：`selectCandidateAsync` 的 full commit 路径使用了 `PreeditMergeHelper.mergePartialCommitText()`，该函数的去重逻辑（`displayText.startsWith(partialText)`）在 partial text 与 committedText 相同时，丢弃了之前累积的文本。

**修复**：full commit 路径改用 `t9PartialCommitTexts.joinToString("") + textToMerge` 直接拼接，跳过去重逻辑。preedit 显示路径不受影响。

### 关联 Issue

Closes #471 #449 #434 

### 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

### 自测清单

- [ ] 代码编译通过（`./gradlew assembleDebug --quiet`）
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

### 备注

此修复仅影响 full commit 上屏路径，preedit 显示路径（`T9DisplayHelper.kt`）仍使用 `PreeditMergeHelper.mergePartialCommitText` 保留去重逻辑，确保显示正确。单文件改动，最小修改原则。