### PR TITLE
feat(clipboard): 增强剪贴板管理功能并添加重试机制

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/clipboard/ClipboardManager.kt
@@ -2,6 +2,8 @@ package com.kingzcheung.xime.clipboard
 
 import android.content.ClipData
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,17 +48,31 @@ class ClipboardManager private constructor(private val context: Context) {
     private val androidClipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as AndroidClipboardManager
     
     private val clipboardListener = AndroidClipboardManager.OnPrimaryClipChangedListener {
+        readClipboard()
+    }
+
+    private fun readClipboard(retries: Int = 3) {
         try {
             val clipData = androidClipboardManager.primaryClip
             if (clipData != null && clipData.itemCount > 0) {
-                val text = clipData.getItemAt(0).text?.toString()
-                if (!text.isNullOrEmpty()) {
-                    addItem(text)
-                } else {
-                    Log.d(TAG, "Clipboard changed but text is null/empty")
+                val item = clipData.getItemAt(0)
+                val text = when {
+                    item.text != null -> item.text.toString()
+                    item.uri != null -> item.uri.toString()
+                    item.intent != null -> item.intent.toUri(0)
+                    else -> null
                 }
+                if (!text.isNullOrEmpty()) {
+                    if (retries < 3) Log.d(TAG, "Clipboard read succeeded after retry #${3 - retries}")
+                    addItem(text)
+                    return
+                }
+            }
+            if (retries > 0) {
+                Log.d(TAG, "Clipboard not ready, retrying in 100ms ($retries left)")
+                Handler(Looper.getMainLooper()).postDelayed({ readClipboard(retries - 1) }, 100L)
             } else {
-                Log.d(TAG, "Clipboard changed but primaryClip is null")
+                Log.w(TAG, "Failed to read clipboard after all retries")
             }
         } catch (e: SecurityException) {
             Log.w(TAG, "Cannot read clipboard: missing permission", e)


### PR DESCRIPTION
- 添加Handler和Looper导入以支持延迟重试
- 实现readClipboard函数，支持文本、URI和intent类型的内容读取
- 添加重试逻辑，在剪贴板未准备好时自动重试最多3次，间隔100毫秒
- 改进错误处理，对不同情况提供相应的日志记录
- 优化剪贴板内容检测逻辑，支持多种数据类型的识

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
