### PR TITLE
feat(XimeInputMethodService): 改进底部导航栏高度检测机制

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -177,6 +177,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
     private val voiceAmplitudeState = mutableFloatStateOf(0f)
     private val quickSendItemsState = mutableStateOf<List<com.kingzcheung.xime.clipboard.ClipboardItem>>(emptyList())
     private val recentClipboardItemsState = mutableStateOf<List<com.kingzcheung.xime.clipboard.ClipboardItem>>(emptyList())
+    private val bottomInsetPxState = mutableStateOf(0)
     private var hasHardwareKeyboard = false
     private var floatingWinX = 100
     private var floatingWinY = 300
@@ -295,15 +296,23 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 if (decorView != null) {
                     val insets = decorView.rootWindowInsets
                     if (insets != null) {
-                        return (insets.getInsetsIgnoringVisibility(
+                        val px = insets.getInsetsIgnoringVisibility(
                             android.view.WindowInsets.Type.navigationBars()
-                        ).bottom / resources.displayMetrics.density).roundToInt()
+                        ).bottom
+                        val dp = (px / resources.displayMetrics.density).roundToInt()
+                        Log.d(TAG, "NavBar: ignoringVisibility px=$px dp=$dp")
+                        return dp
                     }
                 }
             }
             val resId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-            if (resId > 0) (resources.getDimensionPixelSize(resId) / resources.displayMetrics.density).roundToInt() else 0
-        } catch (e: Exception) { 0 }
+            val dp = if (resId > 0) (resources.getDimensionPixelSize(resId) / resources.displayMetrics.density).roundToInt() else 0
+            Log.d(TAG, "NavBar: resourceFallback resId=$resId dp=$dp")
+            return dp
+        } catch (e: Exception) {
+            Log.w(TAG, "NavBar: error", e)
+            0
+        }
     }
 
     private fun tryGetVisibleNavBarHeightDp(): Int {
@@ -316,12 +325,18 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         val px = insets.getInsets(
                             android.view.WindowInsets.Type.navigationBars()
                         ).bottom
-                        if (px > 0) return (px / resources.displayMetrics.density).roundToInt()
+                        val dp = if (px > 0) (px / resources.displayMetrics.density).roundToInt() else 0
+                        Log.d(TAG, "NavBar: visibleOnly px=$px dp=$dp")
+                        return dp
                     }
                 }
             }
+            Log.d(TAG, "NavBar: visibleOnly 0 (no R or null)")
             0
-        } catch (e: Exception) { 0 }
+        } catch (e: Exception) {
+            Log.w(TAG, "NavBar: visibleOnly error", e)
+            0
+        }
     }
 
     private fun tryGetStatusBarHeightDp(): Int {
@@ -340,6 +355,62 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             }
             val resId = resources.getIdentifier("status_bar_height", "dimen", "android")
             if (resId > 0) (resources.getDimensionPixelSize(resId) / resources.displayMetrics.density).roundToInt() else 0
+        } catch (e: Exception) { 0 }
+    }
+
+    private fun dumpAllInsets() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        try {
+            val decorView = window.window?.decorView ?: return
+            val insets = decorView.rootWindowInsets ?: return
+            val density = resources.displayMetrics.density
+            val types = mapOf(
+                "nav" to android.view.WindowInsets.Type.navigationBars(),
+                "status" to android.view.WindowInsets.Type.statusBars(),
+                "system" to android.view.WindowInsets.Type.systemBars(),
+                "tappable" to android.view.WindowInsets.Type.tappableElement(),
+                "sysGestures" to android.view.WindowInsets.Type.systemGestures(),
+                "mandatoryGest" to android.view.WindowInsets.Type.mandatorySystemGestures(),
+                "caption" to android.view.WindowInsets.Type.captionBar(),
+            )
+            val sb = StringBuilder("AllInsets:")
+            for ((name, type) in types) {
+                val ign = insets.getInsetsIgnoringVisibility(type)
+                val vis = insets.getInsets(type)
+                sb.append(" $name=b(ign=${(ign.bottom/density).roundToInt()},vis=${(vis.bottom/density).roundToInt()})")
+            }
+            sb.append(" decorH=${(decorView.height/density).roundToInt()}")
+            Log.d(TAG, sb.toString())
+        } catch (e: Exception) {
+            Log.w(TAG, "dumpAllInsets error", e)
+        }
+    }
+
+    private fun extractBottomInset(
+        insets: android.view.WindowInsets,
+        threshold: Int
+    ): Int {
+        // navigationBars 为 0 但仍有底部区域：检查 systemBars / tappableElement 等
+        val sys = insets.getInsets(android.view.WindowInsets.Type.systemBars()).bottom
+        if (sys > 0) return sys
+        val nav = insets.getInsets(android.view.WindowInsets.Type.navigationBars()).bottom
+        if (nav > 0) return nav
+        val tappable = insets.getInsets(android.view.WindowInsets.Type.tappableElement()).bottom
+        if (tappable > 0) return tappable
+        val mandatory = insets.getInsets(android.view.WindowInsets.Type.mandatorySystemGestures()).bottom
+        if (mandatory > threshold) return mandatory
+        val gestures = insets.getInsets(android.view.WindowInsets.Type.systemGestures()).bottom
+        if (gestures > threshold) return gestures
+        return 0
+    }
+
+    private fun getActiveBottomInsetPx(): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return 0
+        return try {
+            val decorView = window.window?.decorView ?: return 0
+            val insets = decorView.rootWindowInsets ?: return 0
+            val threshold = (resources.displayMetrics.density * 40).toInt()
+            extractBottomInset(insets, threshold)
         } catch (e: Exception) { 0 }
     }
 
@@ -670,6 +741,20 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             }
         )
         
+        bottomInsetPxState.value = getActiveBottomInsetPx()
+        val threshold = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            (resources.displayMetrics.density * 40).toInt()
+        } else 0
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            keyboardContainer.setOnApplyWindowInsetsListener { v, insets ->
+                val px = extractBottomInset(insets, threshold)
+                if (px != bottomInsetPxState.value) {
+                    bottomInsetPxState.value = px
+                }
+                v.onApplyWindowInsets(insets)
+            }
+        }
+        
         val composeView = ComposeView(this).apply {
             isFocusable = true
             isFocusableInTouchMode = true
@@ -688,8 +773,8 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 // 用物理屏幕高度减去状态栏，保证不同 Android 版本一致
                 val effectiveScreenH = if (state.isFloatingMode) physicalScreenDp - statusBarHeightDp else screenHeightDp
                 val windowVisibleHeightDp = effectiveScreenH
-                // 检测 config.screenHeightDp 是否已排除导航栏（非全屏 + 3按钮导航）
                 val navBarAlreadyExcluded = (physicalScreenDp - screenHeightDp) >= (navBarHeightDp + statusBarHeightDp - 3)
+                Log.d(TAG, "ScreenInfo: physicalH=$physicalScreenDp configH=$screenHeightDp statusBar=$statusBarHeightDp navBar=$navBarHeightDp visibleNavBar=$visibleNavBarHeightDp navBarExcluded=$navBarAlreadyExcluded")
                 val floatingMinY = if (navBarAlreadyExcluded) 0 else visibleNavBarHeightDp
 
                 val screenWidthDp = resources.configuration.screenWidthDp
@@ -721,11 +806,17 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 Log.d(TAG, "ComposeHeight: showResize=${state.showKeyboardResize} orientHeight=$orientationHeight displayHeight=$displayHeight keyboardHeight=$keyboardHeight floatScale=$floatScale effectiveHeight=$effectiveKeyboardHeight isFloatingMode=${state.isFloatingMode} isLandscape=$isLandscape")
                 
                 val density = LocalDensity.current
-                val navBarInsetPx = WindowInsets.navigationBars.getBottom(density)
-                val navBarInsetDp = if (navBarInsetPx > 0) {
-                    with(density) { navBarInsetPx.toDp().value.toInt() }
+                // 优先使用 Compose 的 navigationBars 检测（标准设备正常返回值）
+                val composeNavPx = WindowInsets.navigationBars.getBottom(density)
+                // 如果 Compose 返回 0（如 iQOO 不把底部工具栏归为 nav），fallback 到 View 层多类型检测
+                val activeBottomPx = if (composeNavPx > 0) composeNavPx else bottomInsetPxState.value
+                val rawDp = if (activeBottomPx > 0) {
+                    with(density) { activeBottomPx.toDp().value.toInt() }
                 } else 0
-                val navBarDp = navBarInsetDp.dp
+                // 保证底部最小留白（替换原来键盘内部 10dp 的作用）
+                val minBottomDp = 26
+                val activeBottomDp = if (rawDp > 0 && rawDp < minBottomDp) minBottomDp else rawDp
+                val navBarDp = activeBottomDp.dp
                 val hasNavBar = navBarDp > 0.dp
 
                 val quickSendFormExtra = if (state.showQuickSendForm) 200 else 0
@@ -743,7 +834,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         // Sync FrameLayout height with Compose content height
                         val contentHeight = if (state.showKeyboardResize) state.resizePreviewHeightDp else floatingCardContentHeight + quickSendFormExtra
                         val totalDp = if (state.isCompact || state.isFloatingMode) effectiveScreenH
-                            else contentHeight + state.keyboardBottomPaddingDp + navBarInsetDp
+                            else contentHeight + state.keyboardBottomPaddingDp + activeBottomDp
                         Log.d(TAG, "HeightSync: mode=${if (state.showKeyboardResize) "resize" else "normal"} height=$contentHeight navBarDp=${navBarDp.value} padding=${state.keyboardBottomPaddingDp} hasNavBar=$hasNavBar totalDp=$totalDp")
                         SideEffect {
                             keyboardContainer.updateHeight(totalDp)
@@ -2931,7 +3022,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 if (decor != null) {
                     val navBarBg = decor.findViewById<View>(android.R.id.navigationBarBackground)
                     val navBarH = navBarBg?.height ?: 0
-                    val h = (decor.height - navBarH).coerceAtLeast(0)
+                    val decorH = decor.height
+                    val h = (decorH - navBarH).coerceAtLeast(0)
+                    Log.d(TAG, "onComputeInsets: compactMode decorH=$decorH navBarBgH=$navBarH top=$h")
                     outInsets.contentTopInsets = h
                     outInsets.visibleTopInsets = h
                     outInsets.touchableInsets = Insets.TOUCHABLE_INSETS_VISIBLE
@@ -2970,6 +3063,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             }
         } else {
             super.onComputeInsets(outInsets)
+            val decor = window.window?.decorView
+            val decorH = decor?.height ?: -1
+            Log.d(TAG, "onComputeInsets: normalMode contentTop=${outInsets.contentTopInsets} visibleTop=${outInsets.visibleTopInsets} decorH=$decorH")
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CommonSymbolKeyboardLayout.kt
@@ -104,7 +104,7 @@ fun CommonSymbolKeyboardLayout(
                 drawContent()
                 bubbleData?.let { drawSwipeBubble(it) }
             }
-            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 10.dp),
+            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 0.dp),
     ) {
         if (isLandscape) {
             CommonSymbolLandscapeContent(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardLayout.kt
@@ -250,7 +250,7 @@ fun KeyboardLayout(
                 drawContent()
                 bubbleData?.let { drawSwipeBubble(it) }
             }
-            .padding(bottom = if (uiState.isFloatingMode || isLandscape) {0.dp} else {10.dp})
+            .padding(bottom = if (uiState.isFloatingMode || isLandscape) {0.dp} else {0.dp})
     ) {
             if (isLandscape) {
             LandscapeKeyboardContent(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/NumberKeyboardLayout.kt
@@ -101,7 +101,7 @@ fun NumberKeyboardLayout(
                 drawContent()
                 bubbleData?.let { drawSwipeBubble(it) }
             }
-            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 10.dp)) {
+            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 0.dp)) {
         if (isLandscape) {
             Row(
                 modifier = Modifier

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/StrokeKeyboardLayout.kt
@@ -167,7 +167,7 @@ private fun StrokeKeyboardSwipeOverlay(
                 drawContent()
                 bubbleData?.let { drawSwipeBubble(it) }
             }
-            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 10.dp),
+            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 0.dp),
     ) {
         if (isLandscape) {
             Row(

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -215,7 +215,7 @@ private fun T9KeyboardSwipeOverlay(
                 drawContent()
                 bubbleData?.let { drawSwipeBubble(it) }
             }
-            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 10.dp)) {
+            .padding(bottom = if (isFloatingMode || isLandscape) 0.dp else 0.dp)) {
         if (isLandscape) {
             Row(
                 modifier = Modifier


### PR DESCRIPTION
- 添加了更精确的导航栏高度检测方法，支持 Android R 及以上版本的多种窗口 插入类型检测
- 新增了 `bottomInsetPxState` 状态用于实时跟踪底部插入高度
- 实现了 `extractBottomInset` 和 `getActiveBottomInsetPx` 方法，能够处理 不同设备厂商对导航栏的不同实现方式
- 增加了详细的日志输出用于调试屏幕高度相关计算
- 修改了键盘布局中的底部内边距逻辑，移除了固定的 10dp 底部间距， 改由动态检测的导航栏高度决定
- 添加了 `dumpAllInsets` 调试方法用于分析各类型的窗口插入情况

fix(keyboards): 移除键盘布局中的固定底部内边距

- 将所有键盘布局（CommonSymbol、Number、Stroke、T9）中的固定 10dp 底部内边距设置移除
- 改为依赖新的动态底部插入检测机制来处理导航栏高度

chore(submodule): 更新 librime-octagram 子模块

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
