### PR TITLE
fix(t9): 修复简拼和全拼混合时左选与右选消费输入序列异常与lua脚本优化

### DIFF
--- a/app/src/main/assets/rime/lua/date_hint.lua
+++ b/app/src/main/assets/rime/lua/date_hint.lua
@@ -1,83 +1,61 @@
 -- 九键日期提示
--- 在输入特定触发词时，在候选词列表中插入对应日期候选
+-- 在输入特定触发词时，在候选词列表中插入组合的日期候选
 -- 触发词及对应日期：
---   今天/今日/今 → 当前日期（x月x日）
---   明天/明日/明 → 明天日期（x月x日）
---   昨天/昨日/昨 → 昨天日期（x月x日）
+--   今天/今日 → 当前日期（x月x日）
+--   明天/明日 → 明天日期（x月x日）
+--   昨天/昨日 → 昨天日期（x月x日）
 -- 在 engine/filters 增加 - lua_filter@*date_hint
 
 local trigger_map = {
-    today     = { "今天", "今日", "今" },
-    tomorrow  = { "明天", "明日", "明" },
-    yesterday = { "昨天", "昨日", "昨" },
+    today     = { "今天", "今日" },
+    tomorrow  = { "明天", "明日" },
+    yesterday = { "昨天", "昨日" },
 }
+-- 注意：仅保留双字触发词，去掉"今"/"明"/"昨"单字。
+-- 例：输入6464(ming)→单字"明"不触发；输入646474(ming ri)→"明日"触发。
 
--- 构建查找用的 set
+-- 预构建快速查找用的 set 和偏移表
 local trigger_set = {}
-for _, words in pairs(trigger_map) do
+local offset_map = {}
+for t, words in pairs(trigger_map) do
+    local offset = 0
+    if t == "tomorrow" then
+        offset = 86400
+    elseif t == "yesterday" then
+        offset = -86400
+    end
     for _, w in ipairs(words) do
         trigger_set[w] = true
+        offset_map[w] = offset
     end
-end
-
-local function detect_trigger(candidates)
-    for _, cand in ipairs(candidates) do
-        if trigger_set[cand.text] then
-            return cand
-        end
-    end
-    return nil
 end
 
 local function date_hint(input, env)
-    -- 收集所有候选
-    local candidates = {}
+    local found = false
+
     for cand in input:iter() do
-        table.insert(candidates, cand)
-    end
-
-    if #candidates == 0 then
-        return
-    end
-
-    -- 查找触发词
-    local trigger_cand = detect_trigger(candidates)
-    if not trigger_cand then
-        -- 无触发词，原样输出
-        for _, cand in ipairs(candidates) do
+        if found then
+            -- 已找到触发词：直接 yield，无需缓冲
             yield(cand)
-        end
-        return
-    end
+        elseif trigger_set[cand.text] then
+            -- 找到触发词：先 yield 触发词，再 yield 组合日期候选
+            found = true
+            yield(cand)
 
-    -- 计算偏移天数和日期
-    local text = trigger_cand.text
-    local offset = 0
-    for t, words in pairs(trigger_map) do
-        for _, w in ipairs(words) do
-            if w == text then
-                if t == "tomorrow" then
-                    offset = 86400
-                elseif t == "yesterday" then
-                    offset = -86400
-                end
-                break
-            end
-        end
-    end
-
-    local target_time = os.time() + offset
-    local date_str = os.date("%m月%d日", target_time)
-
-    -- 构建输出：在原触发词后插入日期候选
-    for _, cand in ipairs(candidates) do
-        yield(cand)
-        if cand == trigger_cand then
-            local start = cand.start
-            local end_ = cand._end
-            local date_cand = Candidate("date_hint", start, end_, date_str, "")
+            -- 组合日期候选词复用触发词的 comment（如"jin ri"），
+            -- 使 T9 消费逻辑能通过正常拼音匹配数字序列 → full commit。
+            -- 若触发词无 comment（RIME 未产生 spelling hint），回退空字符串。
+            local date_str = os.date("(%m月%d日)", os.time() + offset_map[cand.text])
+            local combined_text = cand.text .. date_str
+            local date_cand = Candidate("date_hint", cand.start, cand._end, combined_text, cand.comment or "")
             date_cand.quality = cand:get_genuine().quality - 1
             yield(date_cand)
+
+            -- 触发词之后的所有候选词直接从迭代器 yield
+            -- no extra buffer, no second loop
+        else
+            -- 未找到触发词：直接 yield
+            yield(cand)
         end
     end
 end

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -554,6 +554,17 @@ class T9InputController(
         return result
     }
 
+    /**
+     * 右侧候选直接提交上屏：不经过消耗算法，清空缓冲区并进入空闲状态。
+     * 用于 emoji/符号等无拼音注释的候选词，RIME 引擎已匹配输入序列到候选词，
+     * T9 控制器无需做音节级消费计算。
+     */
+    fun onRightCandidateSelectedByDirectCommit(): Boolean {
+        if (inputBuffer.isEmpty) return true
+        resetState(clearCache = true, clearRime = false)
+        return true
+    }
+
     fun clearRimeAndResend() {
         rimeBridge.clearRimeAndResend()
         sendToRime()

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitHandler.kt
@@ -153,13 +153,33 @@ class T9RightCommitHandler {
         prevSelectedOption: T9PinyinMap.SyllableOption?,
         prevSelectionCandidateDigits: String?,
         prevConfirmedPinyin: String = "",
+    ): Boolean = commitState(ctx, ctx.inputBuffer, Triple(prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin))
+
+    /**
+     * 统一状态提交入口。替代分发的状态同步逻辑，消除状态同步不一致。
+     *
+     * 所有 handler 出口统一通过此方法进入最终状态，确保：
+     * - buffer 与 stateMachine 状态一致
+     * - consumedCount 与 selections 同步
+     * - UI 刷新与 RIME 输入同步
+     *
+     * @param ctx 上下文
+     * @param buffer 最终状态的 T9Buffer
+     * @param newState (selectedOption, selectionCandidateDigits, confirmedPinyin)
+     *         为 null 的 selectedOption 表示 INPUT 态，否则为 SELECTION 态
+     * @return buffer 是否为空（full commit → true）
+     */
+    private fun commitState(
+        ctx: Ctx,
+        buffer: T9Buffer,
+        newState: Triple<T9PinyinMap.SyllableOption?, String?, String>,
     ): Boolean {
-        if (prevSelectedOption != null) {
+        ctx.inputBuffer = buffer
+        ctx.leftColumnLocked = false
+        val (opt, digits, confirmed) = newState
+        if (opt != null) {
             ctx.stateMachine.restoreFrom(
-                T9StateMachine.State.SELECTION,
-                prevSelectedOption,
-                prevSelectionCandidateDigits ?: "",
-                prevConfirmedPinyin,
+                T9StateMachine.State.SELECTION, opt, digits ?: "", confirmed,
                 ctx.stateMachine.selectionHistory.toList(),
             )
         } else {
@@ -168,7 +188,7 @@ class T9RightCommitHandler {
         ctx.syncState()
         ctx.updateCandidates(true)
         ctx.setRimeInput(null)
-        return false
+        return buffer.isEmpty
     }
 
     /**
@@ -199,84 +219,6 @@ class T9RightCommitHandler {
         return buf.copy(selections = buf.selections.drop(cutIndex))
     }
 
-    /**
-     * 构造纯数字 T9Buffer（用于 digitSegment 模式的剩余数字）。
-     * 保留原始 digitSequence 和 totalDigitsEntered。
-     */
-    private fun T9Buffer.withRemainingDigits(
-        remainingDigits: String,
-        originalBuf: T9Buffer,
-    ): T9Buffer {
-        if (remainingDigits.isEmpty()) return T9Buffer.EMPTY
-        // 剩余数字是原始 digitSequence 的后缀
-        // consumedCount = digitSequence.length - remainingDigits.length
-        return T9Buffer(
-            digitSequence = originalBuf.digitSequence,
-            selections = emptyList(),
-            consumedCount = originalBuf.digitSequence.length - remainingDigits.length,
-            totalDigitsEntered = originalBuf.totalDigitsEntered,
-        )
-    }
-
-    // ── 三层消费算法实现（T9Buffer 版本） ──
-
-    /**
-     * 计算右侧候选选词时消费的数字段和剩余段（T9Buffer 版本）。
-     *
-     * 三层消费算法：
-     *   层级1：apostrophe 模式（selections 非空 && unassigned 非空）
-     *     从 unassigned 中按字母数消费
-     *   层级2：digitSegment 模式（selections 为空 && unassigned 非空）
-     *     从 candidatePinyin 逐音节匹配 unassigned 前缀
-     *   层级3：letterBuffer 模式（selections 非空 && unassigned 为空）
-     *     通过 pinyinToDigitCode 回退转为数字，再按数字段模式处理
-     */
-    private fun computeRightCommitConsumption(
-        buf: T9Buffer,
-        candidatePinyin: String?,
-    ): Pair<String, String> {
-        val hasSelections = buf.selections.isNotEmpty()
-        val unassigned = buf.unassigned
-
-        // apostrophe 模式
-        if (hasSelections && unassigned.isNotEmpty()) {
-            val candidateLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
-            val consumedAfter = candidateLetterCount - buf.selectedPinyin.length
-            if (consumedAfter > 0) {
-                val remaining = unassigned.drop(consumedAfter)
-                return unassigned.take(consumedAfter) to remaining
-            }
-            return unassigned to unassigned
-        }
-
-        // digitSegment 模式
-        if (!hasSelections && unassigned.isNotEmpty()) {
-            val segment = unassigned
-            val consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin)
-            return segment.take(consumedCount) to segment.drop(consumedCount)
-        }
-
-        // letterBuffer 模式
-        val selectedPinyin = buf.selectedPinyin
-        val effectiveLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
-        if (effectiveLetterCount > 0 && effectiveLetterCount < selectedPinyin.length) {
-            val consumedDig = T9PinyinMap.pinyinToDigitCode(selectedPinyin.take(effectiveLetterCount)) ?: ""
-            val remainingDig = T9PinyinMap.pinyinToDigitCode(selectedPinyin.drop(effectiveLetterCount)) ?: ""
-            return consumedDig to remainingDig
-        }
-        if (effectiveLetterCount >= selectedPinyin.length) return "" to ""
-
-        val digits = T9PinyinMap.pinyinToDigitCode(selectedPinyin)
-        if (digits != null) {
-            val consumedDigitCount = T9PinyinMap.firstSyllableOptions(digits, maxResults = 1)
-                .firstOrNull()?.digitLength ?: 0
-            if (consumedDigitCount in 1..<digits.length) {
-                return digits.take(consumedDigitCount) to digits.drop(consumedDigitCount)
-            }
-        }
-        return "" to ""
-    }
-
     private fun handleApostropheRightCommit(
         ctx: Ctx,
         remainingDigits: String,
@@ -293,86 +235,193 @@ class T9RightCommitHandler {
         ) {
             val selectedPinyin = prevSelectedOption.pinyin
             val nonSelectedPinyin = confirmedPinyin.dropLast(selectedPinyin.length)
-            val candidateLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
-            val consumedFromNonSelected = minOf(candidateLetterCount, nonSelectedPinyin.length)
-            val unconsumedPinyin = nonSelectedPinyin.drop(consumedFromNonSelected)
+            val candidateLetterCount = candidatePinyin.candidateLetterCount()
+            // 单音节候选词在 multi-selection 上下文中的 cap（对应 C++ CapToFirstSelectionDigitLength）：
+            // "jin"(546) 匹配 "54482" 时，字母数=3 → 贪婪消费 nonSelectedPinyin "jg"=2 位，
+            // 实际应只消费第一个非选中 selection "j"(1位)。
+            val consumedFromNonSelected = if (buf.selections.size > 1) {
+                val syllables = candidatePinyin.parseSyllables()
+                if (syllables.size <= 1) {
+                    minOf(buf.selections[0].pinyin.length, nonSelectedPinyin.length)
+                } else {
+                    // 多音节候选词在 apostrophe 模式下，音节数可能少于非选中
+                    // selections 数。字母数模型在此场景会过度消费（每个字母对应
+                    // 一个 selection），应使用音节数对应的 selection 长度之和。
+                    // 例：54482 左选 j→g→g→t，"价格(jia ge)" 2音节 vs 3个非选中
+                    // selection [j,g,g] → 消费前2个 "jg"=2，保留 "g"。
+                    val nonSelectedSelections = buf.selections.dropLast(1)
+                    if (syllables.size < nonSelectedSelections.size) {
+                        nonSelectedSelections.take(syllables.size)
+                            .sumOf { it.pinyin.length }
+                            .coerceAtMost(nonSelectedPinyin.length)
+                    } else {
+                        minOf(candidateLetterCount, nonSelectedPinyin.length)
+                    }
+                }
+            } else {
+                minOf(candidateLetterCount, nonSelectedPinyin.length)
+            }
 
             // apostrophe 模式下，候选词注释的音节数必须足以覆盖所有已确认选择
             // 以及未分配数字（至少一个额外音节）。若音节不足，即使字母数模型显示
             // remainingDigits 为空，也不能触发 full commit，否则会把未分配数字一并提交。
             // 典型场景：kg'3 + "客观(ke guan)" → ke/k, guan/g，剩余 3 未被覆盖。
-            val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
-                ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
-            val requiredSyllables = buf.selections.size + if (buf.unassigned.isNotEmpty()) 1 else 0
-            val canCoverAllBySyllableCount = commentSyllables.size >= requiredSyllables
+            val commentSyllables = candidatePinyin.parseSyllables()
+            val canCoverAll = canCoverAllBySyllableCount(commentSyllables, buf.selections.size, buf.unassigned.isNotEmpty())
 
-            if (canCoverAllBySyllableCount &&
+            if (canCoverAll &&
                 shouldFullCommitInSelection(consumedFromNonSelected, nonSelectedPinyin.length, remainingDigits, candidatePinyin, selectedPinyin)
             ) {
                 clearAndEnterIdle(ctx)
                 return true
+            }
+            // 当 canCoverAllBySyllableCount 为 true 且 remainingDigits 非空时，
+            // 检查候选词多余音节是否能覆盖剩余未分配数字。
+            // 条件：prevSelectedOption 的拼音在 commentSyllables 中（候选词包含选中项），
+            //   且多余音节的数字码以剩余数字开头。
+            // 例：54482 左选 j→g→hu，右选"价格湖北(jia ge hu bei)"，
+            //   "hu" 在 commentSyllables 中，多余音节"bei"(234) 以"2"开头 → full commit。
+            // 反例：k'43 右选"开户(kai hu)"，"k" 不在 commentSyllables 中 → 不触发。
+            if (canCoverAll && consumedFromNonSelected >= nonSelectedPinyin.length &&
+                remainingDigits.isNotEmpty() && commentSyllables.size > buf.selections.size &&
+                commentSyllables.contains(prevSelectedOption.pinyin)
+            ) {
+                val extraSyllables = commentSyllables.drop(buf.selections.size)
+                val extraCode = extraSyllables.joinToString("") { T9PinyinMap.pinyinToDigitCode(it) ?: "" }
+                if (extraCode.isNotEmpty() && extraCode.startsWith(remainingDigits)) {
+                    clearAndEnterIdle(ctx)
+                    return true
+                }
             }
             val consumedNonSelectedPinyin = nonSelectedPinyin.take(consumedFromNonSelected)
             // 移除被消费的前缀选择，保留 unassigned 不变
             ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedNonSelectedPinyin)
             ctx.leftColumnLocked = false
 
-            // 候选词消费选中项：当 nonSelected 已完全消费、候选词最后一个音节
-            // 与当前选中项匹配时，表示该选中项也被候选项消费。
-            // 两种匹配模式：
-            //   声母匹配：选中项为简拼(digitLength==1)，候选词最后音节声母数字码
-            //            与选中项数字码一致（如 g 匹配 guan 的声母 g）
-            //   全拼匹配：选中项为全拼(digitLength>1)，候选词最后音节数字码
-            //            与选中项数字码完全一致（如 shan 匹配 shan）
-            // 例如 kg'3 右选 "客观(ke guan)"：ke 消费 k，guan 的声母 g 消费选中项 g，
-            // 仅保留未分配数字 3 并进入 INPUT 态。
-            // 例如 yunshan'98726 右选 "云山(yun shan)"：yun 消费 yun，shan 消费选中项 shan，
-            // 仅保留未分配数字 98726 并进入 INPUT 态。
-            if (unconsumedPinyin.isEmpty() && commentSyllables.isNotEmpty()) {
-                val lastSyl = commentSyllables.last()
-                val lastSylCode = T9PinyinMap.pinyinToDigitCode(lastSyl)
-                val selCode = T9PinyinMap.pinyinToDigitCode(prevSelectedOption.pinyin)
-                val selDigits = prevSelectionCandidateDigits ?: ""
-
-                val isShengmuMatch = prevSelectedOption.digitLength == 1 &&
-                    lastSylCode != null && selCode != null &&
-                    lastSylCode.startsWith(selCode) &&
-                    selDigits.startsWith(selCode)
-
-                val isFullPinyinMatch = prevSelectedOption.digitLength > 1 &&
-                    lastSylCode != null && selCode != null &&
-                    lastSylCode == selCode
-
-                if (isShengmuMatch || isFullPinyinMatch) {
-                    ctx.inputBuffer = ctx.inputBuffer.copy(
-                        selections = ctx.inputBuffer.selections.dropLast(1),
-                    )
-                    ctx.stateMachine.clearSelectionHistory()
-                    ctx.stateMachine.enterInput()
-                    ctx.syncState()
-                    ctx.updateCandidates(true)
-                    ctx.setRimeInput(ctx.inputBuffer.toBufferString())
-                    return false
-                }
+            // 候选词消费选中项：提取为独立方法 [tryConsumeSelectedBySyllableMatch]
+            if (tryConsumeSelectedBySyllableMatch(
+                    ctx, buf, remainingDigits, commentSyllables,
+                    prevSelectedOption, prevSelectionCandidateDigits,
+                )) {
+                return false
             }
-
             return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
         }
         // 非 SELECTION 或 confirmedPinyin 不以 selectedPinyin 结尾：
         // 候选词消费了部分 unassigned 数字，新 buffer 为剩余数字。
-        // 与主分支一致地校验音节覆盖：即使 remainingDigits 为空，若候选词注释音节数
-        // 不足以覆盖 selections.size + unassigned 数字段，不能触发 full commit，
-        // 否则未分配数字会被一并提交（数据丢失）。
-        val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
-            ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
-        val requiredSyllables = buf.selections.size + if (buf.unassigned.isNotEmpty()) 1 else 0
-        val canCoverAllBySyllableCount = commentSyllables.size >= requiredSyllables
+        return handleNonSelectionApostropheFallback(
+            ctx, buf, remainingDigits, candidatePinyin,
+            prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin,
+        )
+    }
 
-        if (remainingDigits.isEmpty() && !canCoverAllBySyllableCount) {
+    // ── apostrophe 模式子方法 ──
+
+    /**
+     * 候选词消费选中项：当 nonSelected 已完全消费、候选词多余音节与当前选中项匹配时，
+     * 消费选中项并进入 INPUT 态（仅保留剩余数字）。
+     *
+     * 两种匹配模式：
+     *   声母匹配：选中项为简拼(digitLength==1)，候选词音节声母数字码与选中项一致
+     *   全拼匹配：选中项为全拼(digitLength>1)，候选词音节数字码与选中项完全一致
+     *
+     * 例如 kg'3 右选"客观(ke guan)"：ke 消费 k，guan 声母 g 消费选中项 g。
+     * 例如 yunshan'98726 右选"云山(yun shan)"：yun 消费 yun，shan 消费选中项 shan。
+     *
+     * @return true 表示已处理（选中项被消费，调用者应 return false）
+     */
+    private fun tryConsumeSelectedBySyllableMatch(
+        ctx: Ctx,
+        buf: T9Buffer,
+        remainingDigits: String,
+        commentSyllables: List<String>,
+        prevSelectedOption: T9PinyinMap.SyllableOption,
+        prevSelectionCandidateDigits: String?,
+    ): Boolean {
+        // 候选词消费选中项包含"unconsumedPinyin.isEmpty()"前置条件，
+        // 已在调用处保证（nonSelected 已完全消费）。
+        if (commentSyllables.isEmpty()) return false
+        val nonSelectedSelectionCount = buf.selections.size - 1
+        // 仅当候选词有多余音节（音节数 > 非选中 selections 数）时，
+        // 音节才可被视为消费选中项。否则该音节已用于非选中部分。
+        val hasExtraSyllableForSelected = commentSyllables.size > nonSelectedSelectionCount
+        if (!hasExtraSyllableForSelected) return false
+
+        val selCode = T9PinyinMap.pinyinToDigitCode(prevSelectedOption.pinyin)
+        val selDigits = prevSelectionCandidateDigits ?: ""
+        // 所有多余音节（非选中 selections 用完后剩余的）：
+        // 任一音节匹配选中项即消费选中项；否则只消费 unassigned。
+        val extraSyllables = commentSyllables.drop(nonSelectedSelectionCount)
+        val matchedSyllable = extraSyllables.firstOrNull { syl ->
+            val sylCode = T9PinyinMap.pinyinToDigitCode(syl) ?: return@firstOrNull false
+            if (prevSelectedOption.digitLength == 1) {
+                selCode != null && sylCode.startsWith(selCode) && selDigits.startsWith(selCode)
+            } else {
+                selCode != null && sylCode == selCode
+            }
+        }
+
+        if (matchedSyllable != null) {
+            ctx.inputBuffer = if (remainingDigits.isEmpty()) {
+                T9Buffer.EMPTY
+            } else {
+                buf.withRemainingDigits(remainingDigits, buf)
+            }
+            ctx.stateMachine.clearSelectionHistory()
+            ctx.stateMachine.enterInput()
+            ctx.syncState()
+            ctx.updateCandidates(true)
+            ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+            return true
+        }
+
+        // 所有多余音节均不匹配选中项 → 仅消费 unassigned 部分
+        val unassignedConsumedDelta = buf.unassigned.length - remainingDigits.length
+        if (unassignedConsumedDelta > 0) {
+            ctx.inputBuffer = ctx.inputBuffer.copy(
+                consumedCount = buf.consumedCount + unassignedConsumedDelta,
+            )
+        }
+        return false
+    }
+
+    /**
+     * 非 SELECTION 态下的 apostrophe 模式降级处理：
+     * 候选词消费了部分 unassigned 数字，新 buffer 为剩余数字。
+     *
+     * 两种子情形：
+     *   1. remainingDigits 为空但音节覆盖不足：保留选中部分为字母形式，
+     *      避免 full commit 把未分配数字一并提交。
+     *   2. 正常情形：remainingDigits 为剩余数字段，进入 INPUT 态。
+     */
+    private fun handleNonSelectionApostropheFallback(
+        ctx: Ctx,
+        buf: T9Buffer,
+        remainingDigits: String,
+        candidatePinyin: String?,
+        prevSelectedOption: T9PinyinMap.SyllableOption?,
+        prevSelectionCandidateDigits: String?,
+        prevConfirmedPinyin: String,
+    ): Boolean {
+        val commentSyllables = candidatePinyin.parseSyllables()
+        val canCoverAll = canCoverAllBySyllableCount(commentSyllables, buf.selections.size, buf.unassigned.isNotEmpty())
+
+        if (remainingDigits.isEmpty() && !canCoverAll) {
             // 音节覆盖不足但字母数模型显示 remaining 为空：保留选中部分为字母形式，
             // 避免直接 full commit 把未分配数字一并提交。
             ctx.inputBuffer = removeConsumedSelections(ctx, buf, buf.selectedPinyin)
             ctx.leftColumnLocked = false
+            // 如果所有 selection 都被移除（只有一个 selection 且就是选中项），
+            // state 应进入 INPUT 而非 SELECTION，否则后续消费会错误地
+            // 受 SELECTION 态保护限制（lockedDigits）。
+            if (ctx.inputBuffer.selections.isEmpty()) {
+                ctx.stateMachine.clearSelectionHistory()
+                ctx.stateMachine.enterInput()
+                ctx.syncState()
+                ctx.updateCandidates(true)
+                ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+                return false
+            }
             return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
         }
 
@@ -387,9 +436,7 @@ class T9RightCommitHandler {
         } else {
             // withRemainingDigits 创建 selections=emptyList()，已消费全部选择。
             // 必须同步清理 selectionHistory，否则残留条目会导致后续左选→右选时
-            // isFullCommitWithoutBoundaries 误判（场景17 根因：
-            // joinToString 拼接残留+新条目 ≠ selectedPinyin）。
-            // 与上方 isShengmuMatch/isFullPinyinMatch 分支 line 350-351 一致。
+            // isFullCommitWithoutBoundaries 误判（场景17 根因）。
             ctx.stateMachine.clearSelectionHistory()
             ctx.stateMachine.enterInput()
         }
@@ -408,7 +455,7 @@ class T9RightCommitHandler {
     ): Boolean {
         val buf = ctx.inputBuffer
         val segment = buf.unassigned
-        var consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin)
+        var consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin, allowLongestPrefix = true)
         val lockedDigits = if (prevSelectedOption != null) {
             // prevSelectionCandidateDigits 为 null 时（异常状态）视为全部 segment 被锁定，
             // 走 maxConsumable <= 0 分支恢复状态，避免消费本应被锁定的数字
@@ -466,10 +513,62 @@ class T9RightCommitHandler {
     ): Boolean {
         val buf = ctx.inputBuffer
         val selectedPinyin = buf.selectedPinyin
-        val effectiveLetterCount = candidatePinyin?.count { it.isLetter() } ?: 0
+        val effectiveLetterCount = candidatePinyin.candidateLetterCount()
+
+        // 单音节候选词在 multi-selection 上下文中，防止消费跨越 selection 边界
+        if (effectiveLetterCount > 0 && buf.selections.size > 1 && prevSelectedOption != null) {
+            val syllables = candidatePinyin.parseSyllables()
+            if (syllables.size <= 1) {
+                // 无空格的全匹配注释（如 "ligua" == "li"+"gua"）→ 不 cap
+                val candidateClean = candidatePinyin.candidateLettersOnly()
+                val joinedSelections = buf.selections.joinToString("") { it.pinyin }
+                if (candidateClean != joinedSelections) {
+                    val consumedLen = buf.selections[0].pinyin.length
+                    val consumedPinyin = selectedPinyin.take(consumedLen)
+                    // 场景18守卫：候选词拼音是选中项拼音的真前缀时，
+                    // 切换选择并保留剩余数字（如 "ti" 是 "tian" 的前缀）。
+                    val isCandidateShorterPrefix = candidateClean.length < prevSelectedOption.pinyin.length &&
+                        prevSelectedOption.pinyin.startsWith(candidateClean)
+                    if (isCandidateShorterPrefix) {
+                        val remainingDigits = T9PinyinMap.pinyinToDigitCode(
+                            selectedPinyin.drop(consumedLen))
+                        if (remainingDigits != null) {
+                            ctx.inputBuffer = T9Buffer(
+                                digitSequence = remainingDigits,
+                                selections = emptyList(),
+                                consumedCount = 0,
+                                totalDigitsEntered = remainingDigits.length,
+                            )
+                            ctx.leftColumnLocked = false
+                            ctx.stateMachine.clearSelectionHistory()
+                            ctx.stateMachine.enterInput()
+                            ctx.syncState()
+                            ctx.updateCandidates(true)
+                            ctx.setRimeInput(ctx.inputBuffer.toBufferString())
+                            return false
+                        }
+                    }
+                    ctx.inputBuffer = removeConsumedSelections(ctx, buf, consumedPinyin)
+                    ctx.leftColumnLocked = false
+                    return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin)
+                }
+            }
+        }
+
         if (effectiveLetterCount > 0) {
             if (effectiveLetterCount < selectedPinyin.length) {
                 if (prevSelectedOption != null) {
+                    // 多音节候选词 + 音节数 < selections 数 + EndsWith → HSLBC（音节匹配路径）
+                    val commentSyllables = candidatePinyin.parseSyllables()
+                    val syllableCount = commentSyllables.size
+                    val selectionCount = buf.selections.size
+                    if (syllableCount > 1 && syllableCount < selectionCount &&
+                        selectedPinyin.endsWith(prevSelectedOption.pinyin)) {
+                        return handleSelectionLetterBufferCommit(
+                            ctx, candidatePinyin, candidateTextLength, effectiveLetterCount,
+                            prevSelectedOption, prevSelectionCandidateDigits, prevConfirmedPinyin, prevBuf,
+                        )
+                    }
                     val consumedPinyin = selectedPinyin.take(effectiveLetterCount)
                     // 场景18：候选词 pinyin 是 prevSelectedOption.pinyin 的真前缀
                     // （如 candidatePinyin="ti", prevSelectedOption.pinyin="tian"）。
@@ -552,8 +651,7 @@ class T9RightCommitHandler {
         val buf = ctx.inputBuffer
         val selectedPinyin = buf.selectedPinyin
 
-        val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
-            ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+        val commentSyllables = candidatePinyin.parseSyllables()
         val hasSyllableBoundaries = commentSyllables.size > 1
 
         val isFullCommitWithoutBoundaries = !hasSyllableBoundaries &&
@@ -568,10 +666,26 @@ class T9RightCommitHandler {
             candidateTextLength > 0 &&
             candidateTextLength >= commentSyllables.size &&
             isFullCommitByJianpinAlignment(selectedPinyin, commentSyllables)
+        // 简拼转全拼匹配：当 selection 为简拼(digitLength==1)时，候选词音节数字码
+        // 前缀匹配即可；当 selection 为全拼(digitLength>1)时，需要精确匹配。
+        // 例：54482 左选 j→g→hu→b，右选"价格湖北(jia ge hu bei)"，
+        //   jia(542) 前缀匹配 j(5), ge(43) 前缀匹配 g(4),
+        //   hu(48) 精确匹配 hu(48), bei(234) 前缀匹配 b(2) → full commit。
+        val isPrefixMatchAllSelected = hasSyllableBoundaries && candidateTextLength > 0 &&
+            candidateTextLength >= commentSyllables.size &&
+            commentSyllables.size == ctx.stateMachine.selectionHistory.size &&
+            commentSyllables.indices.all { i ->
+                val sylCode = T9PinyinMap.pinyinToDigitCode(commentSyllables[i])
+                val selCode = T9PinyinMap.pinyinToDigitCode(ctx.stateMachine.selectionHistory[i].pinyin)
+                val sel = ctx.stateMachine.selectionHistory[i]
+                sylCode != null && selCode != null &&
+                    if (sel.digitLength == 1) sylCode.startsWith(selCode) else sylCode == selCode
+            }
         val isFullCommit = (hasSyllableBoundaries && candidateTextLength > 0 &&
             candidateTextLength >= commentSyllables.size &&
             (selectedPinyin.dropLast(prevSelectedOption.pinyin.length).isEmpty() ||
                 isAllSelectedConsumed(selectedPinyin, commentSyllables, ctx.stateMachine.selectionHistory) ||
+                isPrefixMatchAllSelected ||
                 isJianpinAlignedFullCommit)) ||
             isFullCommitWithoutBoundaries
         if (isFullCommit) {
@@ -642,42 +756,6 @@ class T9RightCommitHandler {
         return true
     }
 
-    private fun computeSelectionConsumedCount(
-        hasSyllableBoundaries: Boolean,
-        candidateTextLength: Int,
-        commentSyllables: List<String>,
-        effectiveLetterCount: Int,
-        prevSelectedOption: T9PinyinMap.SyllableOption,
-        nonSelectedDigits: String,
-        candidatePinyin: String?,
-    ): Int {
-        if (hasSyllableBoundaries && candidateTextLength > 0 && commentSyllables.size > candidateTextLength) {
-            var consumed = 0
-            for (i in 0 until minOf(candidateTextLength, commentSyllables.size)) {
-                consumed += T9PinyinMap.pinyinToDigitCode(commentSyllables[i])?.length ?: 0
-            }
-            return consumed
-        }
-
-        val candidateNonSelectedLetters = effectiveLetterCount - prevSelectedOption.pinyin.length
-        if (candidateNonSelectedLetters in 1..nonSelectedDigits.length) {
-            if (hasSyllableBoundaries && candidateNonSelectedLetters >= nonSelectedDigits.length) {
-                val nonSelectedSyllables = if (commentSyllables.lastOrNull() == prevSelectedOption.pinyin)
-                    commentSyllables.dropLast(1) else commentSyllables
-                val totalSyllableDigits = nonSelectedSyllables.sumOf {
-                    T9PinyinMap.pinyinToDigitCode(it)?.length ?: 0
-                }
-                return if (totalSyllableDigits > nonSelectedDigits.length) {
-                    computeConsumedDigitsFromPinyin(nonSelectedDigits, candidatePinyin)
-                } else {
-                    candidateNonSelectedLetters
-                }
-            }
-            return candidateNonSelectedLetters
-        }
-        return computeConsumedDigitsFromPinyin(nonSelectedDigits, candidatePinyin)
-    }
-
     private fun handleConsumedAllNonSelected(
         ctx: Ctx,
         hasSyllableBoundaries: Boolean,
@@ -695,7 +773,7 @@ class T9RightCommitHandler {
         val selectedPinyin = buf.selectedPinyin
         if (hasSyllableBoundaries && candidateTextLength >= commentSyllables.size &&
             commentSyllables.size >= ctx.stateMachine.selectionHistory.size) {
-            val candidateClean = candidatePinyin?.filter { it.isLetter() } ?: ""
+            val candidateClean = candidatePinyin.candidateLettersOnly()
             if (candidateClean.isNotEmpty()) {
                 val candidateDigitCode = T9PinyinMap.pinyinToDigitCode(candidateClean)
                 val fullBufferDigitCode = T9PinyinMap.pinyinToDigitCode(selectedPinyin)
@@ -719,6 +797,28 @@ class T9RightCommitHandler {
                     }
                 }
             }
+        }
+
+        // 候选词所有音节已被非选中 selections 覆盖时，跳过 shengmu 回退。
+        // 例："ji ge"(2音节) + [j,g,hua] → "jg" 匹配 j 和 g(2个) = 2音节全匹配
+        //   → 不应额外消费 hua。反例："ke hen"(2音节) + [k,he] → "k" 仅匹配
+        //   1个 < 2音节 → 需要 shengmu 回退消费 he 的声母。
+        val matchedNonSelectedCount = if (hasSyllableBoundaries) {
+            var remaining = nonSelectedPart
+            buf.selections.count { sel ->
+                if (remaining.isEmpty()) false
+                else if (sel.pinyin.length <= remaining.length && remaining.startsWith(sel.pinyin)) {
+                    remaining = remaining.drop(sel.pinyin.length)
+                    true
+                } else false
+            }
+        } else 0
+
+        // 所有音节已被非选中 selections 覆盖 → 保留剩余选择，进入 SELECTION 态
+        if (matchedNonSelectedCount > 0 && matchedNonSelectedCount >= commentSyllables.size) {
+            ctx.inputBuffer = removeConsumedSelections(ctx, buf, nonSelectedPart)
+            ctx.leftColumnLocked = false
+            return restorePrevState(ctx, prevSelectedOption, prevSelectionCandidateDigits)
         }
 
         if (tryShengmuFallback(ctx, hasSyllableBoundaries, commentSyllables, prevSelectedOption,
@@ -753,7 +853,15 @@ class T9RightCommitHandler {
             return false
         }
 
-        val remainingFromSelected = selDigits.drop(initialCode.length)
+        // 候选最后音节可能完整消费选中项前缀（如 "gu"(48) 完全匹配 "gua"(482) 前缀），
+        // 不仅限于首字母。优先使用完整数字码长度，回退到声母长度。
+        val lastSylFullCode = T9PinyinMap.pinyinToDigitCode(lastSyl)
+        val consumedFromSelected = if (lastSylFullCode != null && selDigits.startsWith(lastSylFullCode)) {
+            lastSylFullCode.length
+        } else {
+            initialCode.length
+        }
+        val remainingFromSelected = selDigits.drop(consumedFromSelected)
         // 消费全部非选中部分 + 移除最后一个选择（prevSelectedOption）
         ctx.inputBuffer = removeConsumedSelections(ctx, buf, nonSelectedPart)
         // removeConsumedSelections 只移除非选中部分的选择，需要额外移除 prevSelectedOption

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9RightCommitUtils.kt
@@ -4,6 +4,23 @@ package com.kingzcheung.xime.rime
 // 设计文档 6.2 节：三层消费算法 — 纯函数
 // ─────────────────────────────────────────────────────────
 
+// ── 公共扩展：候选拼音解析 ──
+
+/** 将候选词拼音注释按空格拆分为音节列表（仅含字母的音节） */
+internal fun String?.parseSyllables(): List<String> =
+    this?.trim()?.split("\\s+".toRegex())
+        ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+
+/** 候选词拼音注释中的字母数（不含空格） */
+internal fun String?.candidateLetterCount(): Int =
+    this?.count { it.isLetter() } ?: 0
+
+/** 候选词拼音注释中仅保留字母（去除空格） */
+internal fun String?.candidateLettersOnly(): String =
+    this?.filter { it.isLetter() } ?: ""
+
+// ── 消费计算 ──
+
 /**
  * 根据候选拼音注释计算数字段中被消费的位数。
  *
@@ -18,10 +35,13 @@ package com.kingzcheung.xime.rime
  * 若音节匹配失败（pinyinToDigitCode 返回 null 或无前缀匹配），
  * 回退到字母数（每个字母对应一位数字），最终回退到贪婪最长匹配。
  */
-fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): Int {
+fun computeConsumedDigitsFromPinyin(
+    segment: String,
+    candidatePinyin: String?,
+    allowLongestPrefix: Boolean = false,
+): Int {
     if (!candidatePinyin.isNullOrEmpty()) {
-        val syllables = candidatePinyin.trim().split("\\s+".toRegex())
-            .filter { it.any { c -> c.isLetter() } }
+        val syllables = candidatePinyin.parseSyllables()
         if (syllables.isNotEmpty()) {
             var consumed = 0
             var remaining = segment
@@ -32,10 +52,37 @@ fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): 
                     consumed += sylCode.length
                     remaining = remaining.drop(sylCode.length)
                 } else {
-                    // 前缀匹配：声母场景，用户只输入了音节首字母对应的数字
                     var matchLen = 0
-                    for (len in 1..minOf(sylCode.length, remaining.length)) {
-                        if (remaining.startsWith(sylCode.take(len))) matchLen = len
+                    if (remaining.length >= sylCode.length) {
+                        // 精确匹配失败。derive rule 场景（digitSegment）使用最长公共前缀，
+                        // 避免 RIME 扩展拼音导致 T9 码不匹配（如 "yong"→"9664" vs "966"）。
+                        // apostrophe 场景仅 1 字符声母匹配，防止过度消费。
+                        if (allowLongestPrefix) {
+                            for (len in (sylCode.length - 1) downTo 1) {
+                                if (remaining.startsWith(sylCode.take(len))) {
+                                    matchLen = len
+                                    break
+                                }
+                            }
+                        }
+                        if (matchLen == 0 && remaining.startsWith(sylCode.take(1))) {
+                            matchLen = 1
+                        }
+                    } else {
+                        // apostrophe 场景仅匹配 1 字符声母，防止过度消费。
+                        // 例："guang"(48264) 匹配剩余 "482" 时，仅匹配声母 "4"(1 位)，
+                        // 而非最长匹配 "482"(3 位)，否则 "64" 无法与输入序列对应。
+                        if (allowLongestPrefix) {
+                            // 统一递减方向：最长匹配优先，找到即 break，与上方分支一致。
+                            for (len in remaining.length downTo 1) {
+                                if (sylCode.startsWith(remaining.take(len))) {
+                                    matchLen = len
+                                    break
+                                }
+                            }
+                        } else if (remaining.isNotEmpty() && sylCode.startsWith(remaining.take(1))) {
+                            matchLen = 1
+                        }
                     }
                     if (matchLen > 0) {
                         consumed += matchLen
@@ -45,10 +92,96 @@ fun computeConsumedDigitsFromPinyin(segment: String, candidatePinyin: String?): 
             }
             if (consumed > 0) return consumed
         }
-        val letterCount = candidatePinyin.count { it in 'a'..'z' || it in 'A'..'Z' }
+        val letterCount = candidatePinyin.candidateLetterCount()
         if (letterCount > 0 && letterCount <= segment.length) return letterCount
     }
     return T9PinyinMap.firstSyllableOptions(segment, maxResults = 1).firstOrNull()?.digitLength ?: 0
+}
+
+// ── 首音节跨越 selection 边界调整 ──
+
+/**
+ * 当第一音节跨越 selection 边界时，调整 consumedFromUnassigned 值。
+ *
+ * 第一音节的 digit code 精确匹配 effectiveSequence 前缀但长度超过
+ * 第一 selection 的 digit code 时，说明它跨越了 selection 边界，
+ * 错误地消费了后续 selection 的 digit code。此时限制只消费第一
+ * selection 的 digit code，剩余音节在剩余 effectiveSequence 中重匹配。
+ *
+ * 典型场景：54482 左选 j→g，右选"机构化(ji gou hua)"
+ *   "ji"(54) 精确匹配 "54482" 前缀（"j"+"g" 的拼接 "54"），
+ *   但应只消费 "j"(5) 而非 "j"+"g"(54)，否则后续消费错位。
+ *
+ * @param candidatePinyin 候选词拼音注释
+ * @param effectiveSequence selectionDigits 与 unassigned 的拼接
+ * @param selectionDigits 已确认 selection 的 digit code 拼接
+ * @param unassigned 未分配数字段
+ * @param currentConsumedFromUnassigned 当前计算的 consumedFromUnassigned
+ * @param firstSelectionPinyin 第一 selection 的拼音
+ * @return 调整后的 consumedFromUnassigned
+ */
+fun adjustConsumedForSelectionBoundary(
+    candidatePinyin: String?,
+    effectiveSequence: String,
+    selectionDigits: String,
+    unassigned: String,
+    currentConsumedFromUnassigned: Int,
+    firstSelectionPinyin: String,
+): Int {
+    if (currentConsumedFromUnassigned < 0) return currentConsumedFromUnassigned
+    val syls = candidatePinyin.parseSyllables()
+    if (syls.isEmpty()) return currentConsumedFromUnassigned
+
+    val firstSylCode = T9PinyinMap.pinyinToDigitCode(syls[0])
+    val firstSelCode = T9PinyinMap.pinyinToDigitCode(firstSelectionPinyin)
+    if (firstSylCode == null || firstSelCode == null) return currentConsumedFromUnassigned
+    if (firstSylCode.length <= firstSelCode.length) return currentConsumedFromUnassigned
+    if (!effectiveSequence.startsWith(firstSylCode)) return currentConsumedFromUnassigned
+
+    // 第一音节只消费第一 selection 的 digit code，剩余音节重匹配
+    val remainingSyls = syls.drop(1).joinToString(" ")
+    val remainingEff = effectiveSequence.drop(firstSelCode.length)
+    val restConsumed = computeConsumedDigitsFromPinyin(remainingEff, remainingSyls)
+    val newTotalConsumed = firstSelCode.length + restConsumed
+    return maxOf(0, newTotalConsumed - selectionDigits.length)
+}
+
+/**
+ * 首音节完全匹配守卫：当第一音节完全匹配 effectiveSequence 前缀但第二音节
+ * 无法匹配剩余 unassigned 时，限制消费仅到第一音节在 unassigned 中的部分。
+ *
+ * 避免声母前缀过度消费。典型场景：54482 左选 j → 右选"机会 ji hui"
+ * "ji"(54) 完全匹配 "54482" 但 "5" 已被 selection 消费，
+ * "hui"(484) 前缀匹配 "482" 的 "4" → 过度消费 → 需拦截。
+ *
+ * @param candidatePinyin 候选词拼音注释
+ * @param effectiveSequence selectionDigits 与 unassigned 的拼接
+ * @param selectionDigits 已确认 selection 的 digit code 拼接
+ * @param unassigned 未分配数字段
+ * @param consumedFromUnassigned 当前计算的 consumedFromUnassigned
+ * @return 调整后的 consumedFromUnassigned
+ */
+fun adjustForSecondSyllableMismatch(
+    candidatePinyin: String?,
+    effectiveSequence: String,
+    selectionDigits: String,
+    unassigned: String,
+    consumedFromUnassigned: Int,
+): Int {
+    if (consumedFromUnassigned <= 0) return consumedFromUnassigned
+    val syls = candidatePinyin.parseSyllables()
+    if (syls.size <= 1) return consumedFromUnassigned
+
+    val first = T9PinyinMap.pinyinToDigitCode(syls[0])
+    val second = T9PinyinMap.pinyinToDigitCode(syls[1])
+    if (first == null || second == null) return consumedFromUnassigned
+    if (!effectiveSequence.startsWith(first)) return consumedFromUnassigned
+
+    val firstFromUnassign = maxOf(0, first.length - selectionDigits.length)
+    if (firstFromUnassign <= 0) return consumedFromUnassigned
+    if (unassigned.drop(firstFromUnassign).startsWith(second)) return consumedFromUnassigned
+
+    return firstFromUnassign
 }
 
 /**
@@ -91,6 +224,109 @@ fun isFullCommitByJianpinAlignment(
         val sylCode = T9PinyinMap.pinyinToDigitCode(commentSyllables[i])
         sylCode != null && sylCode.take(1) == bufferDigits[i].toString()
     }
+}
+
+// ── 三层消费算法核心计算 ──
+
+/**
+ * 计算右侧候选选词时消费的数字段和剩余段。
+ *
+ * 三层消费算法：
+ *   层级1：apostrophe 模式（selections 非空 && unassigned 非空）
+ *     从 unassigned 中按候选词数字码匹配 digit_sequence 计算消费
+ *   层级2：digitSegment 模式（selections 为空 && unassigned 非空）
+ *     从 candidatePinyin 逐音节匹配 unassigned 前缀
+ *   层级3：letterBuffer 模式（selections 非空 && unassigned 为空）
+ *     通过 pinyinToDigitCode 回退转为数字，再按数字段模式处理
+ *
+ * @param buf 当前 T9Buffer
+ * @param candidatePinyin 候选词拼音注释
+ * @return Pair<consumedDigits, remainingDigits>
+ */
+fun computeRightCommitConsumption(
+    buf: T9Buffer,
+    candidatePinyin: String?,
+): Pair<String, String> {
+    val hasSelections = buf.selections.isNotEmpty()
+    val unassigned = buf.unassigned
+
+    // apostrophe 模式：基于候选词实际数字码匹配 digit_sequence 计算消费
+    if (hasSelections && unassigned.isNotEmpty()) {
+        val selectionDigits = buf.selections.joinToString("") {
+            T9PinyinMap.pinyinToDigitCode(it.pinyin) ?: ""
+        }
+        val effectiveSequence = selectionDigits + unassigned
+        val totalConsumed = computeConsumedDigitsFromPinyin(effectiveSequence, candidatePinyin)
+        if (totalConsumed > 0) {
+            var consumedFromUnassigned = totalConsumed - selectionDigits.length
+
+            // 首音节完全匹配守卫：当第一个音节完全匹配 effectiveSequence 前缀时，
+            // 需要确保第二个音节在剩余 unassigned 中有对应匹配（避免过度消费）。
+            if (consumedFromUnassigned > 0) {
+                consumedFromUnassigned = adjustForSecondSyllableMismatch(
+                    candidatePinyin = candidatePinyin,
+                    effectiveSequence = effectiveSequence,
+                    selectionDigits = selectionDigits,
+                    unassigned = unassigned,
+                    consumedFromUnassigned = consumedFromUnassigned,
+                )
+            }
+
+            // 首音节跨越 selection 边界守卫：当第一音节 digit code 精确匹配
+            // effectiveSequence 前缀且长度超过第一 selection 的 digit code 时，
+            // 限制只消费第一 selection 的 digit code，剩余音节在剩余序列中重匹配。
+            if (buf.selections.isNotEmpty()) {
+                consumedFromUnassigned = adjustConsumedForSelectionBoundary(
+                    candidatePinyin = candidatePinyin,
+                    effectiveSequence = effectiveSequence,
+                    selectionDigits = selectionDigits,
+                    unassigned = unassigned,
+                    currentConsumedFromUnassigned = consumedFromUnassigned,
+                    firstSelectionPinyin = buf.selections.first().pinyin,
+                )
+            }
+
+            if (consumedFromUnassigned in 1..unassigned.length) {
+                return unassigned.take(consumedFromUnassigned) to unassigned.drop(consumedFromUnassigned)
+            }
+            return "" to unassigned
+        }
+        // fallback：数字码匹配失败，回退到字母数差值
+        val candidateLetterCount = candidatePinyin.candidateLetterCount()
+        val consumedAfter = (candidateLetterCount - buf.selectedPinyin.length)
+            .coerceAtMost(unassigned.length)
+        if (consumedAfter > 0) {
+            return unassigned.take(consumedAfter) to unassigned.drop(consumedAfter)
+        }
+        return "" to unassigned
+    }
+
+    // digitSegment 模式
+    if (!hasSelections && unassigned.isNotEmpty()) {
+        val segment = unassigned
+        val consumedCount = computeConsumedDigitsFromPinyin(segment, candidatePinyin, allowLongestPrefix = true)
+        return segment.take(consumedCount) to segment.drop(consumedCount)
+    }
+
+    // letterBuffer 模式
+    val selectedPinyin = buf.selectedPinyin
+    val effectiveLetterCount = candidatePinyin.candidateLetterCount()
+    if (effectiveLetterCount > 0 && effectiveLetterCount < selectedPinyin.length) {
+        val consumedDig = T9PinyinMap.pinyinToDigitCode(selectedPinyin.take(effectiveLetterCount)) ?: ""
+        val remainingDig = T9PinyinMap.pinyinToDigitCode(selectedPinyin.drop(effectiveLetterCount)) ?: ""
+        return consumedDig to remainingDig
+    }
+    if (effectiveLetterCount >= selectedPinyin.length) return "" to ""
+
+    val digits = T9PinyinMap.pinyinToDigitCode(selectedPinyin)
+    if (digits != null) {
+        val consumedDigitCount = T9PinyinMap.firstSyllableOptions(digits, maxResults = 1)
+            .firstOrNull()?.digitLength ?: 0
+        if (consumedDigitCount in 1..<digits.length) {
+            return digits.take(consumedDigitCount) to digits.drop(consumedDigitCount)
+        }
+    }
+    return "" to ""
 }
 
 /**
@@ -143,8 +379,7 @@ fun shouldFullCommitInSelection(
 ): Boolean {
     if (consumedFromNonSelected < nonSelectedPinyinLength) return false
     if (remainingAfterCommit.isNotEmpty()) return false
-    val commentSyllables = candidatePinyin?.trim()?.split("\\s+".toRegex())
-        ?.filter { it.any { c -> c.isLetter() } } ?: emptyList()
+    val commentSyllables = candidatePinyin.parseSyllables()
     return commentSyllables.any { T9PinyinMap.areDigitCodesMatching(it, selectedPinyin) }
 }
 
@@ -179,4 +414,106 @@ fun resolveRimeCandidateIndex(
     if (selectedCandidate == null) return uiIndex
     val rawIdx = rawCandidates.indexOf(selectedCandidate)
     return if (rawIdx >= 0) rawIdx else uiIndex
+}
+
+// ── T9Buffer 扩展 ──
+
+/**
+ * 构造纯数字 T9Buffer（用于 digitSegment 模式的剩余数字）。
+ * 保留原始 digitSequence 和 totalDigitsEntered。
+ *
+ * consumedCount 计算为"原有已消费数 + 本次新消费数"，
+ * 即 originalBuf.consumedCount + (originalBuf.unassigned.length - remainingDigits.length)，
+ * 语义上等价于 originalBuf.digitSequence.length - remainingDigits.length，
+ * 但更清晰地表达了"追加消费"的意图。
+ */
+fun T9Buffer.withRemainingDigits(
+    remainingDigits: String,
+    originalBuf: T9Buffer,
+): T9Buffer {
+    if (remainingDigits.isEmpty()) return T9Buffer.EMPTY
+    val newlyConsumed = originalBuf.unassigned.length - remainingDigits.length
+    return T9Buffer(
+        digitSequence = originalBuf.digitSequence,
+        selections = emptyList(),
+        consumedCount = originalBuf.consumedCount + newlyConsumed,
+        totalDigitsEntered = originalBuf.totalDigitsEntered,
+    )
+}
+
+// ── 音节覆盖判定 ──
+
+/**
+ * 判断候选词音节数是否足以覆盖所有已确认选择及未分配数字段。
+ * apostrophe 模式下未分配数字至少需要一个额外音节。
+ */
+internal fun canCoverAllBySyllableCount(
+    commentSyllables: List<String>,
+    selectionCount: Int,
+    hasUnassigned: Boolean,
+): Boolean = commentSyllables.size >= selectionCount + (if (hasUnassigned) 1 else 0)
+
+// ── SELECTION 态消费计算 ──
+
+/**
+ * 计算非选中部分被候选词消费的位数（基于音节数溢出或字母数模型）。
+ */
+fun computeSelectionConsumedCount(
+    hasSyllableBoundaries: Boolean,
+    candidateTextLength: Int,
+    commentSyllables: List<String>,
+    effectiveLetterCount: Int,
+    prevSelectedOption: T9PinyinMap.SyllableOption,
+    nonSelectedDigits: String,
+    candidatePinyin: String?,
+): Int {
+    if (hasSyllableBoundaries && candidateTextLength > 0 && commentSyllables.size > candidateTextLength) {
+        return consumeBySyllableOverflow(commentSyllables, candidateTextLength)
+    }
+    return consumeByLetterOrDigits(
+        hasSyllableBoundaries, effectiveLetterCount, prevSelectedOption,
+        commentSyllables, nonSelectedDigits, candidatePinyin,
+    )
+}
+
+/** 音节数溢出：按候选字数对应的音节数字码总长度消费 */
+fun consumeBySyllableOverflow(
+    commentSyllables: List<String>,
+    candidateTextLength: Int,
+): Int {
+    var consumed = 0
+    for (i in 0 until minOf(candidateTextLength, commentSyllables.size)) {
+        consumed += T9PinyinMap.pinyinToDigitCode(commentSyllables[i])?.length ?: 0
+    }
+    return consumed
+}
+
+/**
+ * 字母数模型消费：以 (有效字母数 - 选中项拼音长度) 为基础，
+ * 有音节边界时用音节数字码总长度校验，避免字母数低估消费量。
+ */
+fun consumeByLetterOrDigits(
+    hasSyllableBoundaries: Boolean,
+    effectiveLetterCount: Int,
+    prevSelectedOption: T9PinyinMap.SyllableOption,
+    commentSyllables: List<String>,
+    nonSelectedDigits: String,
+    candidatePinyin: String?,
+): Int {
+    val candidateNonSelectedLetters = effectiveLetterCount - prevSelectedOption.pinyin.length
+    if (candidateNonSelectedLetters !in 1..nonSelectedDigits.length) {
+        return computeConsumedDigitsFromPinyin(nonSelectedDigits, candidatePinyin)
+    }
+    if (!hasSyllableBoundaries) return candidateNonSelectedLetters
+
+    val nonSelectedSyllables = if (commentSyllables.lastOrNull() == prevSelectedOption.pinyin)
+        commentSyllables.dropLast(1) else commentSyllables
+    val totalSyllableDigits = nonSelectedSyllables.sumOf {
+        T9PinyinMap.pinyinToDigitCode(it)?.length ?: 0
+    }
+    return if (totalSyllableDigits > candidateNonSelectedLetters) {
+        computeConsumedDigitsFromPinyin(nonSelectedDigits, candidatePinyin)
+    } else {
+        candidateNonSelectedLetters
+    }
 }

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -119,7 +119,12 @@ fun KeyboardView(
 
     SideEffect {
         callbacks.onT9RightCandidateWillBeSelected = { pinyin, textLength ->
-            t9Controller.onRightCandidateSelected(pinyin, textLength)
+            if (pinyin.isNullOrBlank()) {
+                // emoji/符号等无拼音注释的候选词：直接提交上屏，不走消耗算法
+                t9Controller.onRightCandidateSelectedByDirectCommit()
+            } else {
+                t9Controller.onRightCandidateSelected(pinyin, textLength)
+            }
             t9Controller.inputBuffer.isEmpty
         }
         callbacks.onT9ForceSendToRime = {

--- a/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/rime/T9RightCommitHandlerTest.kt
@@ -92,6 +92,20 @@ class T9RightCommitHandlerTest {
     // ── bug4 集成测试：SELECTION 态下纯字母 buffer 右选 ──
 
     @Test
+    fun `digitSegment mode - right candidate emoji without comment should direct commit all digits`() {
+        val ctrl = createController()
+        // Input 5482 without any left selection
+        for (d in listOf("5", "4", "8", "2")) ctrl.onDigitPressed(d)
+        assertEquals("5482", ctrl.bufferString)
+        // Direct-commit emoji 🎸 (no comment)
+        // RIME 引擎已匹配输入序列到候选词，emoji 无拼音注释应直接提交上屏
+        val result = ctrl.onRightCandidateSelectedByDirectCommit()
+        assertTrue("Emoji without comment should direct commit — RIME matched the candidate", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    @Test
     fun `bug4 - pure letter buffer in selection state should not full commit when comment covers whole buffer`() {
         val ctrl = createController()
         // 步骤1-4: 输入 23744 → 右选"策" → 左选"pi" → 左选"h"
@@ -806,6 +820,259 @@ class T9RightCommitHandlerTest {
         assertTrue("fei should full commit on selected f", result)
         assertEquals("", ctrl.bufferString)
         assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景：5143→左选k→右选"开关 kai guan"，剩余数字3不应被消费
+    //
+    // Bug 复现（来自用户报告）：
+    //   1. 输入 5143 → buffer="j'43"
+    //   2. 左选 k → buffer="k'43", SELECTION(k, "5")
+    //   3. 右选"开关 kai guan"(comment="kai guan", textLength=2)
+    //      预期：partial commit — "kai"匹配已选k(digit5)，"guan"只匹配digit 4，
+    //            剩余digit 3应保留 → buffer="3"
+    //      Bug：full commit，digit 3丢失
+    //
+    // 根因：computeRightCommitConsumption apostrophe 模式用字母数减法
+    //   (candidateLetterCount - selectedPinyin.length = 7-1=6)，直接消费全部unassigned，
+    //   没有调用 computeConsumedDigitsFromPinyin 做逐音节数字码匹配。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `scenario 5143-k-kai-guan - single left select then right select preserves remaining digit 3`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143 → buffer="j'43"
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k → buffer="k'43", SELECTION(k, "5")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("k", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 右选"开关 kai guan"(comment="kai guan", textLength=2)
+        // "kai"匹配已选k(digit5)，"guan"只匹配digit 4（来自"43"），
+        // digit 3 不应被消费 → partial commit
+        val result = ctrl.onRightCandidateSelected("kai guan", 2)
+        assertFalse("Should be partial commit — digit 3 remains unconsumed", result)
+        assertEquals("剩余数字3应保留", "3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `scenario 5143-k-kai-hu - single left select then right select preserves remaining digit 3`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 5143 → buffer="j'43"
+        ctrl.onDigitPressed("5"); ctrl.onDigitPressed("1")
+        ctrl.onDigitPressed("4"); ctrl.onDigitPressed("3")
+        assertEquals("j'43", ctrl.bufferString)
+
+        // 步骤2: 左选 k → buffer="k'43", SELECTION(k, "5")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("k", 1))
+        assertEquals("k'43", ctrl.bufferString)
+
+        // 步骤3: 右选"开户 kai hu"(comment="kai hu", textLength=2)
+        // "kai"匹配已选k(digit5)，"hu"只匹配digit 4（来自"43"），
+        // digit 3 不应被消费 → partial commit
+        val result = ctrl.onRightCandidateSelected("kai hu", 2)
+        assertFalse("Should be partial commit — digit 3 remains unconsumed", result)
+        assertEquals("剩余数字3应保留", "3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 多音节候选词在 multi-selection 上下文的音节级匹配
+    //
+    // 对应 C++ LetterBufferStrategy::Handle 子路径 B：
+    //   syllable_count > 1 && syllable_count < selection_count → HSLBC
+    //
+    // Bug："几个 ji ge"(2音节4字母) 在 [j,g,hu,b] 上，字母数模型取4字符"jghu"，
+    //   消费了 j+g+hu，只剩 b。应仅消费2个 selection [j,g]，保留 [hu,b]。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `multi-syllable ji ge on multi-selection j-g-hu-b preserves hu-b`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+
+        // 右选"几个 ji ge" — 2音节，只消费 j+g，保留 hu+b
+        val result = ctrl.onRightCandidateSelected("ji ge", 2)
+        assertFalse("ji ge should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(2, ctrl.inputBuffer.selections.size)  // hu, b
+        assertEquals("hu", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("b", ctrl.inputBuffer.selections[1].pinyin)
+    }
+
+    @Test
+    fun `multi-syllable ju ge on multi-selection j-g-hu-b preserves hu-b`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+
+        // 右选"举个 ju ge" — 2音节，只消费 j+g，保留 hu+b
+        val result = ctrl.onRightCandidateSelected("ju ge", 2)
+        assertFalse("ju ge should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(2, ctrl.inputBuffer.selections.size)
+        assertEquals("hu", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("b", ctrl.inputBuffer.selections[1].pinyin)
+    }
+
+    @Test
+    fun `multi-syllable ji ge on multi-selection j-g-hua preserves hua selection`() {
+        // Bug：54482 → j→g→hua → 右选"几个 ji ge"
+        // ji(54) 消费 j(5)，ge(43) 消费 g(4)，剩余选择"hua"应保持在 SELECTION 态。
+        // tryShengmuFallback 不应额外消费 hua 的 h→4（ge 已消费 g→4 满足自身）。
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("jghua", ctrl.bufferString)
+
+        val result = ctrl.onRightCandidateSelected("ji ge", 2)
+        assertFalse("ji ge should be partial commit", result)
+        assertFalse("selections should not be empty", ctrl.inputBuffer.selections.isEmpty())
+        assertEquals(1, ctrl.inputBuffer.selections.size)
+        assertEquals("hua", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 单音节候选词在 multi-selection 上下文的消费边界测试
+    //
+    // 对应 C++ 测试：
+    //   SingleSyllableNoCrossBoundary_54482_Jin
+    //   SingleSyllableNoCrossBoundary_54482_Jiang
+    //   SingleSyllableNoCrossBoundary_54482_Jiong
+    //   LetterBufferWithUnassigned_54482_Jin
+    //
+    // Bug：单音节候选词（如"金 jin"）在 multi-selection 上下文中，
+    //   贪婪数字前缀匹配跨越 selection 边界。如"jin"→"546"匹配"54482"→
+    //   "i"→4碰巧等于下一selection "g"→4，贪婪匹配消费j+g(2位)，实际应只消费j(1位)。
+    // 同样"jiang"(5字母)等于selectedPinyin.length(5)时走else分支→
+    //   computeSelectionConsumedCount用candidateNonSelectedLetters=4消费了全部非选中部分。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `single syllable jin on multi-selection j-g-hu-b preserves g-hu-b`() {
+        val ctrl = createController()
+        // 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        // 依次左选 j → g → hu → b
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+
+        // 右选"金"(jin) — 单音节，不应跨越 selection 边界
+        val result = ctrl.onRightCandidateSelected("jin", 1)
+        assertFalse("jin should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(3, ctrl.inputBuffer.selections.size)  // g, hu, b
+        assertEquals("g", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("hu", ctrl.inputBuffer.selections[1].pinyin)
+        assertEquals("b", ctrl.inputBuffer.selections[2].pinyin)
+    }
+
+    @Test
+    fun `single syllable jiang on multi-selection j-g-hu-b preserves g-hu-b`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+
+        // 右选"将"(jiang) — 5字母单音节 = selectedPinyin长度，不应全消费
+        val result = ctrl.onRightCandidateSelected("jiang", 1)
+        assertFalse("jiang should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(3, ctrl.inputBuffer.selections.size)
+        assertEquals("g", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("hu", ctrl.inputBuffer.selections[1].pinyin)
+        assertEquals("b", ctrl.inputBuffer.selections[2].pinyin)
+    }
+
+    @Test
+    fun `single syllable jiong on multi-selection j-g-hu-b preserves g-hu-b`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+
+        // 右选"囧"(jiong) — 5字母单音节
+        val result = ctrl.onRightCandidateSelected("jiong", 1)
+        assertFalse("jiong should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(3, ctrl.inputBuffer.selections.size)
+        assertEquals("g", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("hu", ctrl.inputBuffer.selections[1].pinyin)
+        assertEquals("b", ctrl.inputBuffer.selections[2].pinyin)
+    }
+
+    @Test
+    fun `single syllable ji on multi-selection j-g-hu-b preserves g-hu-b`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+
+        // 右选"几"(ji) — 2字母单音节
+        val result = ctrl.onRightCandidateSelected("ji", 1)
+        assertFalse("ji should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(3, ctrl.inputBuffer.selections.size)
+        assertEquals("g", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("hu", ctrl.inputBuffer.selections[1].pinyin)
+        assertEquals("b", ctrl.inputBuffer.selections[2].pinyin)
+    }
+
+    @Test
+    fun `single syllable jin on multi-selection j-g-hu with unassigned 2 preserves g-hu`() {
+        // 场景2：54482 → 左选 j→g→hu（末尾2不选），右选"金 jin"
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        assertEquals("jghu'2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hu", 2), ctrl.selectedOption)
+
+        // 右选"金"(jin) — 单音节，只消费 j，保留 g, hu + unassigned "2"
+        val result = ctrl.onRightCandidateSelected("jin", 1)
+        assertFalse("jin should be partial commit", result)
+        assertFalse(ctrl.inputBuffer.isEmpty)
+        assertEquals(2, ctrl.inputBuffer.selections.size)  // g, hu
+        assertEquals("g", ctrl.inputBuffer.selections[0].pinyin)
+        assertEquals("hu", ctrl.inputBuffer.selections[1].pinyin)
+        assertEquals("2", ctrl.inputBuffer.unassigned)  // unassigned 保留
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -1570,10 +1837,906 @@ class T9RightCommitHandlerTest {
         assertEquals(7, resolveRimeCandidateIndex(6, "看会儿", rawCandidates))
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // 场景：输入54482，左选全选 j→g→hu→b，右选"价格湖北"(jia ge hu bei)
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j → g → hu → b（全部选完）
+    //   3. 右选"价格湖北"(comment="jia ge hu bei", textLength=4)
+    //
+    // 预期：full commit → buffer清空, IDLE态
+    // 实际（修复前）：预编辑变为"价格湖北hu'b"，消费错误
+    //
+    // 根因：HSLBC 中 wouldTriggerShengmu=true 阻塞了音节匹配块，
+    //   导致"bei"(234)的声母"b"(2)无法匹配选中项"b"(2)，
+    //   代码跳入数字码 fallback 路径，消费计算错误。
+    //
+    // 修复：在 wouldTriggerShengmu 检查中添加例外条件：
+    //   commentSyllables.size >= selectionHistory.size 时仍进入音节匹配块
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `full commit - 54482 j g hu b right select jia ge hu bei`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j → g → hu → b
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("b", 1))
+        assertEquals("jghub", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("b", 1), ctrl.selectedOption)
+        assertEquals("2", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 右选"价格湖北"(comment="jia ge hu bei", textLength=4)
+        // 候选词4个音节正好对应4个选择：jia→j, ge→g, hu→hu, bei→b
+        // 应 full commit
+        val result = ctrl.onRightCandidateSelected("jia ge hu bei", 4)
+        assertTrue("价格湖北 should be full commit — 4 syllables cover 4 selections", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertTrue(ctrl.selectionHistory.isEmpty())
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 场景：输入54482，左选部分 j→g→hu（末尾2不选），右选"价格湖北"(jia ge hu bei)
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j → g → hu（末尾"2"不选）
+    //   3. 右选"价格湖北"(comment="jia ge hu bei", textLength=4)
+    //
+    // 预期：full commit → buffer清空, IDLE态
+    // 实际（修复前）：预编辑变为"价格湖北hu b"，消费错误
+    //
+    // 根因：apostrophe 模式中 computeRightCommitConsumption 返回
+    //   remainingDigits="2"非空，导致 shouldFullCommitInSelection 失败。
+    //   候选词4个音节覆盖3个selection+1个unassigned数字"2"，
+    //   应触发 full commit，但消费计算错误导致 partial commit。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `full commit - 54482 j g hu right select jia ge hu bei with unassigned 2`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j → g → hu（末尾"2"不选）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hu", 2))
+        assertEquals("jghu'2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hu", 2), ctrl.selectedOption)
+        assertEquals("48", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 右选"价格湖北"(comment="jia ge hu bei", textLength=4)
+        // 候选词4个音节覆盖3个selection(j,g,hu)+1个unassigned(2)
+        // 应 full commit
+        val result = ctrl.onRightCandidateSelected("jia ge hu bei", 4)
+        assertTrue("价格湖北 should be full commit — 4 syllables cover 3 selections + 1 unassigned", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertTrue(ctrl.selectionHistory.isEmpty())
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 新场景：输入54482，左选j，右选各种候选词
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j（仅选一个）
+    //   3. 右选不同类型的候选词
+    //
+    // 结构化(jie gou hua)：j=5, g=4, hua=482 → 全部消费 → full commit
+    // 结婚后(jie hun hou)：j=5, h=4, 剩余82 → partial commit, 保留"ta"
+    // 建国后(jian guo hou)：j=5, g=4, 剩余82 → partial commit, 保留"ta"
+    // 脚后跟(jiao hou gen)：j=5, h=4, 剩余82 → partial commit, 保留"ta"
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `full commit - 54482 j right select jie gou hua`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("j", 1), ctrl.selectedOption)
+
+        // 步骤3: 右选"结构化"(comment="jie gou hua", textLength=3)
+        // jie(543)前缀匹配j(5), gou(468)前缀匹配g(4), hua(482)精确匹配482
+        // 全部5位数字被消费 → full commit
+        val result = ctrl.onRightCandidateSelected("jie gou hua", 3)
+        assertTrue("结构化 should be full commit — jie+gou+hua covers all 5 digits", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+        assertNull(ctrl.selectedOption)
+        assertTrue(ctrl.selectionHistory.isEmpty())
+    }
+
+    @Test
+    fun `partial commit - 54482 j right select jie hun hou`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤3: 右选"结婚后"(comment="jie hun hou", textLength=3)
+        // jie(543)前缀匹配j(5), hun(486)前缀匹配h(4), hou(468)前缀匹配h(4)
+        // 消费3位数字(544), 剩余82(ta) → partial commit
+        // 预期bufferString="82"
+        val result = ctrl.onRightCandidateSelected("jie hun hou", 3)
+        assertFalse("结婚后 should be partial commit — 82 remains", result)
+        assertEquals("82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `partial commit - 54482 j right select jian guo hou`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤3: 右选"建国后"(comment="jian guo hou", textLength=3)
+        // jian(5426)前缀匹配j(5), guo(486)前缀匹配g(4), hou(468)前缀匹配h(4)
+        // 消费3位数字(544), 剩余82(ta) → partial commit
+        val result = ctrl.onRightCandidateSelected("jian guo hou", 3)
+        assertFalse("建国后 should be partial commit — 82 remains", result)
+        assertEquals("82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    @Test
+    fun `partial commit - 54482 j right select jiao hou gen`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤3: 右选"脚后跟"(comment="jiao hou gen", textLength=3)
+        // jiao(5426)前缀匹配j(5), hou(468)前缀匹配h(4), gen(436)前缀匹配g(4)
+        // 消费3位数字(544), 剩余82(ta) → partial commit
+        val result = ctrl.onRightCandidateSelected("jiao hou gen", 3)
+        assertFalse("脚后跟 should be partial commit — 82 remains", result)
+        assertEquals("82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：输入54482，左选j，右选"机会ji hui"消费错误
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j → buffer="j'4482", SELECTION(j, "5")
+    //   3. 右选"机会"(comment="ji hui", textLength=2)
+    //
+    // 预期：partial commit — "ji"(54)消费已选j(5)+首位未分配4, 剩余482(hua/gua)
+    // Bug（修复前）：第一个音节"ji"(54)完全匹配digitSequence前缀"54"(2位)，
+    //   其中"5"已被selection消费(consumedCount=1)，但computeConsumedDigitsFromPinyin
+    //   仍计入2位；第二个音节"hui"(484)前缀匹配"482"首字母"4"(1位)。
+    //   总消费=3, consumedFromUnassigned=3-1=2 → 剩余"82"(ta)。
+    //   正确：第一个音节完全匹配后，后续音节应完全匹配或停止。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j right select ji hui should leave 482 not 82`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("j", 1), ctrl.selectedOption)
+        assertEquals("5", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 右选"机会ji hui"(comment="ji hui", textLength=2)
+        // ji(54)消费已选j(5)+1位未分配(4), 剩余"482"(hua/gua) → partial commit
+        val result = ctrl.onRightCandidateSelected("ji hui", 2)
+        assertFalse("ji hui should be partial commit — 482 remains", result)
+        assertEquals("剩余应为482(hua/gua)", "482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：输入54482，左选j→g（两个selection），右选"建国后jian guo hou"
+    //      声母回退后 consumedCount 未更新，剩余数字错误
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j → g（两个 selection）→ buffer="jg'482", SELECTION(g,"4")
+    //   3. 右选"建国后"(comment="jian guo hou", textLength=3)
+    //
+    // 预期：partial commit — "jian"消费j(5), "guo"消费g(4),
+    //   "hou"声母h(4)消费未分配首位 → consumedCount=3, 剩余"82"(ta)
+    // Bug（修复前）：isShengmuMatch 分支仅移除最后 selection("g"),
+    //   未更新 consumedCount → buffer.toBufferString() 仍输出 "482"(gua)
+    //
+    // 根因：handleApostropheRightCommit 中 isShengmuMatch 分支
+    //   (line 389-399) 通过 `copy(selections.dropLast(1))` 移除选中项，
+    //   但未同步更新 consumedCount，导致 RIME 收到错误的剩余数字段。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j g right select jian guo hou shengmu fallback consumedCount`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j → buffer="j'4482", SELECTION(j,"5")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤3: 左选 g → buffer="jg'482", SELECTION(g,"4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤4: 右选"建国后jian guo hou"(comment="jian guo hou", textLength=3)
+        // jian→j(5), guo→g(4), hou→h(4,从未分配"482"首字母)
+        // 消费3位(544), 剩余82(ta) → partial commit
+        val result = ctrl.onRightCandidateSelected("jian guo hou", 3)
+        assertFalse("jian guo hou should be partial commit — 82 remains", result)
+        assertEquals("剩余应为82(ta)", "82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：两步右选 — 第一步右选"及"后 buffer 含残留 selection，
+    //      第二步右选"规划"时 computeConsumedDigitsFromPinyin 用全量
+    //      digitSequence 匹配，候选音节从已消费位置开始匹配导致错位。
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j→g（两个 selection）
+    //   3. 右选"及"(ji) → partial commit, 残留 selection=[g], unassigned="482"
+    //   4. 右选"规划"(gui hua) → 应 full commit
+    //
+    // 预期：步骤4 full commit — gui 匹配 g(4), hua 完全消费 482
+    // Bug（修复前）：computeConsumedDigitsFromPinyin("54482", "gui hua")
+    //   从 digitSequence 开头匹配，"gui"(484)首字母"4"≠"5"→断匹配→回退
+    //   firstSyllableOptions→consumedFromUnassigned=0→partial commit→残留
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - two step right select ji then gui hua should full commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g → buffer="jg'482", SELECTION(g,"4")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+
+        // 步骤3: 右选"及"(ji) → partial commit, consumedCount 应反映 j 已提交
+        val step3Result = ctrl.onRightCandidateSelected("ji", 1)
+        assertFalse("及 should be partial commit — g'482 remains", step3Result)
+        assertEquals("g'482", ctrl.bufferString)
+
+        // 步骤4: 右选"规划"(gui hua) → 应 full commit
+        // gui(484)匹配g(4), hua(482)完全消费unassigned"482"
+        val step4Result = ctrl.onRightCandidateSelected("gui hua", 2)
+        assertTrue("规划(gui hua) should be full commit — all input consumed", step4Result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：letterBuffer 多 selection + 场景18守卫误判
+    //
+    // 操作流程：
+    //   1. 输入 54482 → 左选 j→g → 右选"及" → 左选 gua/hua → 右选"给(gei)"
+    //
+    // 预期："给(gei)" 消费第一个 selection "g"，保留选中项 gua/hua。
+    //   左侧候选区应保持在 SELECTION 态，gua/hua 高亮。
+    //
+    // Bug（修复前）：gua 场景下，场景18守卫用 consumedPinyin="g"（第一个 selection）
+    //   与 prevSelectedOption="gua" 比较，"gua".startsWith("g")=true → 错误触发
+    //   场景18路径 → 清空 selectionHistory → 进入 INPUT 态 → gua 选中丢失。
+    //   hua 场景不受影响："hua".startsWith("g")=false → 守卫不触发。
+    //
+    // 根因：场景18守卫应比较候选词拼音与选中项，而非被消费的第一个 selection。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - letterBuffer gua then right select gei should preserve gua selection`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+
+        // 步骤3: 右选"及"(ji) → partial commit
+        ctrl.onRightCandidateSelected("ji", 1)
+        assertEquals("g'482", ctrl.bufferString)
+
+        // 步骤4: 左选 gua → buffer="ggua", SELECTION(gua,"482")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ggua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("gua", 3), ctrl.selectedOption)
+
+        // 步骤5: 右选"给(gei)" → consumer 第一个 selection "g"，保留 gua
+        val result = ctrl.onRightCandidateSelected("gei", 1)
+        assertFalse("gei should be partial commit", result)
+        // gua 应保持选中态
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("gua", 3), ctrl.selectedOption)
+        assertEquals("gua", ctrl.bufferString)
+    }
+
+    @Test
+    fun `bug - letterBuffer hua then right select gei should preserve hua selection`() {
+        val ctrl = createController()
+
+        // 步骤1-3 同上
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onRightCandidateSelected("ji", 1)
+        assertEquals("g'482", ctrl.bufferString)
+
+        // 步骤4: 左选 hua → buffer="ghua", SELECTION(hua,"482")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("ghua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hua", 3), ctrl.selectedOption)
+
+        // 步骤5: 右选"给(gei)" → 消费第一个 selection "g"，保留 hua
+        val result = ctrl.onRightCandidateSelected("gei", 1)
+        assertFalse("gei should be partial commit", result)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hua", 3), ctrl.selectedOption)
+        assertEquals("hua", ctrl.bufferString)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：letterBuffer shengmu fallback — remainingFromSelected 仅丢弃首字母
+    //
+    // 操作流程：
+    //   1. 输入 54482 → 左选 j→g → 右选"及" → 左选 gua → 右选"个股(ge gu)"
+    //
+    // 预期："及"对应 j, "个股"对应 ge(43)→g(4) + gu(48)→gu(4,8)
+    //   ge 消费非选中 g(4), gu 完整匹配 gua 前缀 "48" → 剩余 "2"(a/b/c)
+    //
+    // Bug（修复前）：tryShengmuFallback 用 `selDigits.drop(initialCode.length)`
+    //   仅丢弃首字母 1 位，未考虑 gu 数字码"48"完全匹配 selDigits="482" 前缀。
+    //   → remainingFromSelected = "482".drop(1) = "82" → "ta" ❌
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - letterBuffer ge gu shengmu fallback should consume full syllable code not just initial`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+
+        // 步骤3: 右选"及"(ji) → partial commit
+        ctrl.onRightCandidateSelected("ji", 1)
+        assertEquals("g'482", ctrl.bufferString)
+
+        // 步骤4: 左选 gua → buffer="ggua", SELECTION(gua,"482")
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("gua", 3))
+        assertEquals("ggua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("gua", 3), ctrl.selectedOption)
+        assertEquals("482", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 右选"个股(ge gu)" → ge消费g, gu完整匹配gua前缀"48"
+        // 剩余应为 "2"(a/b/c)
+        val result = ctrl.onRightCandidateSelected("ge gu", 2)
+        assertFalse("ge gu should be partial commit", result)
+        assertEquals("剩余应为2(a/b/c)", "2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：apostrophe 多音节候选词在 selection 数>音节数时过度消费
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j→g→g→t（末位 2 不选）→ buffer="jggt'2", SELECTION(t,"8")
+    //   3. 右选"价格 jia ge"
+    //
+    // 预期：jia→j(5), ge→第一个g(4)，保留第二个g+t+2 → "gt'2"
+    // Bug（修复前）：multi-selection 下 apostrophe 路径用 candidateLetterCount(5)
+    //   计算 consumedFromNonSelected → minOf(5, 3)=3 → 消费全部3个非选中
+    //   selection "jgg"，实际只应消费前2个音节对应的2个 selection "jg"。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j g g t right select jia ge should preserve g t`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g→g→t（末位 2 不选）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("t", 1))
+        assertEquals("jggt'2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("t", 1), ctrl.selectedOption)
+        assertEquals("8", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 右选"价格 jia ge" → jia→j(5), ge→第一个g(4)
+        // 应保留第二个 g + t + 2 → "gt'2"
+        val result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertFalse("jia ge should be partial commit — gt'2 remains", result)
+        assertEquals("保留gt'2", "gt'2", ctrl.bufferString)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：apostrophe isShengmuMatch 在多 selection 下无多余音节时误消费
+    //
+    // 操作流程：
+    //   1. 输入 54482
+    //   2. 左选 j→g→g（不选 82）→ buffer="jgg'82", SELECTION(g,"4")
+    //   3. 右选"价格 jia ge"
+    //
+    // 预期：jia→j(5), ge→第一个g(4)，保留第二个g+82 → "g'82"
+    // Bug（修复前）："ge"(43) 声母"g"(4) 匹配选中项 g(4) → isShengmuMatch=true
+    //   但 "ge" 已用于消费非选中部分的第一个 g，无多余音节消费选中项。
+    //   结果 buffer 变为纯数字 "82"(ta) ← 第二个 g 丢失。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j g g right select jia ge should preserve second g`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g→g（不选 82）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jgg'82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤3: 右选"价格 jia ge" → jia→j, ge→第一个g
+        // 应保留第二个 g + 82 → "g'82"
+        val result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertFalse("jia ge should be partial commit — g'82 remains", result)
+        assertEquals("保留g'82", "g'82", ctrl.bufferString)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：有效序列中 selection 数字码干扰候选拼音匹配 — "ta"(82) 在 "482" 中
+    // 声母匹配失败后 letterCount fallback 只消费"8"留下"2" → "a"残留
+    //
+    // 操作流程：
+    //   1. 输入 54482，左选 j→g→g（不选 82）→ buffer="jgg'82"
+    //   2. 右选"价格 jia ge" → buffer="g'82"
+    //   3. 右选"光 guang" → partial commit, buffer="82"
+    //   4. 右选"他 ta" → 应 full commit（"ta"完全匹配"82"）
+    //
+    // Bug（修复前）：effectiveSequence="482"+"82"=... 不对，此为简化版。
+    //   buffer="82"（纯数字），点击"ta"应完全消费"82"。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - g'82 then right select ta should full commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g→g（不选 82）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jgg'82", ctrl.bufferString)
+
+        // 步骤3: 右选"价格 jia ge" → 保留"g'82"
+        val step3Result = ctrl.onRightCandidateSelected("jia ge", 2)
+        assertEquals("step3 should be partial commit", false, step3Result)
+        assertEquals("step3 buffer", "g'82", ctrl.bufferString)
+        assertEquals("step3 state", T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤4: 右选"光 guang" → 消费选中项，剩余"82"进入 INPUT 态
+        ctrl.onRightCandidateSelected("guang", 1)
+        assertEquals("step4 buffer", "82", ctrl.bufferString)
+        assertEquals("step4 state", T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+
+        // 步骤5: 右选"他 ta" → 应完全消费"82"，full commit
+        val result = ctrl.onRightCandidateSelected("ta", 1)
+        assertTrue("ta should full commit — '82' completely consumed", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：hasExtraSyllableForSelected 仅检查最后一个音节，遗漏中间音节
+    //
+    // 操作流程：
+    //   1. 输入 54482，左选 j→g（不选 482）→ 右选"广"→ 左选 g → gg'82
+    //   2. 右选"广告条 guang gao tiao"
+    //
+    // 预期：3 音节覆盖 2 个 selection + unassigned 首位：
+    //   guang→第一个g, gao→第二个g(中间音节消费选中项), tiao→unassigned"8"
+    //   剩余 buffer="2"(纯数字), INPUT 态
+    //
+    // Bug（修复前）：仅检查 commentSyllables.last()="tiao" 是否匹配选中项，
+    //   "tiao"(8426)声母"t"(8)≠"g"(4) → 不匹配 → 选中项保留在 SELECTION 态。
+    //   实际上中间音节 "gao"(426)声母"g"(4)==选中项"g"(4) → 应消费选中项。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - g'82 then right select guang gao tiao intermediate syllable consumes selection`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+
+        // 步骤2: 左选 j→g（不选 482）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // 步骤3: 右选"广 guang" → 声母匹配消费 j→g
+        ctrl.onRightCandidateSelected("guang", 1)
+        assertEquals("g'482", ctrl.bufferString)
+
+        // 步骤4: 左选 g → gg'82
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("gg'82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+        assertEquals("4", ctrl.selectionCandidateDigits)
+
+        // 步骤5: 右选"广告条 guang gao tiao"
+        // guang→第一个g, gao→第二个g(中间音节消费选中项), tiao→unassigned"8"
+        // 剩余 "2"(纯数字), INPUT 态
+        val result = ctrl.onRightCandidateSelected("guang gao tiao", 3)
+        assertFalse("guang gao tiao should be partial commit", result)
+        assertEquals("剩余2(a/b/c)", "2", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：derive-rule expansion 场景 — RIME 候选词注释拼音的 T9 数字码
+    // 长于输入数字（如 "yong"→9664 但输入仅 "96636"），导致消费计算不全。
+    //
+    // 操作流程：
+    //   1. 输入 96636 → buffer="96636"
+    //   2. 右选"涌动 yong dong" → 应 full commit
+    //
+    // 预期："yong dong" 覆盖全部 digitSequence "96636" → full commit
+    //
+    // Bug（修复前）："yong"→"9664" 不匹配 "96636" 前缀（"9663"≠"9664"），
+    //   仅声母"9"匹配（+1），"dong"→"3664" 无法匹配剩余 "6636"，
+    //   总计只消费1位 → 部分提交 → 错误预编辑。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 96636 then right select yong dong should full commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 96636（无分词键）
+        for (d in listOf("9", "6", "6", "3", "6")) ctrl.onDigitPressed(d)
+        assertEquals("96636", ctrl.bufferString)
+
+        // 步骤2: 右选"涌动 yong dong" → 应完全消费"96636"
+        val result = ctrl.onRightCandidateSelected("yong dong", 2)
+        assertTrue("yong dong should full commit — '96636' completely consumed", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // lua filter 日期候选词复用触发词 comment 后 full commit（需求一+二）
+    //
+    // 操作流程：
+    //   1. 输入 54674（digitSegment 模式）
+    //   2. 右选日期候选词（由 date_hint.lua 生成，comment 复用触发词"jin ri"）
+    //
+    // 预期：T9 消费逻辑用"jin ri"匹配"54674" → 完全匹配 → full commit
+    // 方案：lua filter 层设置正确 comment，Kotlin 层无需特殊守卫
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - right select date_hint candidate with trigger comment should full commit`() {
+        val ctrl = createController()
+
+        // 步骤1: 输入 54674（digitSegment 模式，无左选）
+        for (d in listOf("5", "4", "6", "7", "4")) ctrl.onDigitPressed(d)
+        assertEquals("54674", ctrl.bufferString)
+
+        // 步骤2: 右选日期候选词（date_hint.lua 设置 comment="jin ri" 复用触发词）
+        // "jin ri" 逐音节匹配 "54674"：jin→546(3位), ri→74(2位) → 全匹配 → full commit
+        val result = ctrl.onRightCandidateSelected("jin ri", 5)
+        assertTrue("Date_hint candidate with comment='jin ri' should full commit", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：effectiveSequence 首音节跨越 selection 边界，导致消费错位
+    //
+    // 场景1：54482 → 左选 j→g（不选482）→ 右选"机构化(ji gou hua)"
+    //   "ji"(54) 精确匹配 effectiveSequence 前缀"54"(j+g)，但"ji"应只消费
+    //   第一 selection "j"(5)，而非"j"+"g"(54)。"gou"(468) 应消费"g"(4)，
+    //   "hua"(482) 消费"482" → 全消费 5 位 → full commit。
+    //
+    // 若"ji"错误消费 2 位（j+g），剩余"482"给"gou"前缀匹配"4"消费 1 位，
+    //   "hua"无法匹配"82" → 仅消费 1 位 unassigned → 错误 partial commit。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j g right select ji gou hua should full commit`() {
+        val ctrl = createController()
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        assertEquals("54482", ctrl.bufferString)
+
+        // 步骤2: 左选 j→g（不选 482）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("g", 1), ctrl.selectedOption)
+
+        // 步骤3: 右选"机构化 ji gou hua"
+        // "ji"(54)→j(5), "gou"(468)→g(4), "hua"(482)→"482" → 全消费 5 位
+        val result = ctrl.onRightCandidateSelected("ji gou hua", 3)
+        assertTrue("ji gou hua should full commit — j+g+hua covers all 54482", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Bug：与上同理，仅左选 j（不选 4482）→ 右选"鸡冠花(ji guan hua)"
+    //
+    // 场景2：54482 → 左选 j（不选 4482）→ 右选"鸡冠花(ji guan hua)"
+    //   "ji"(54) 精确匹配 effectiveSequence 前缀"54482"的"5"+"4"，
+    //   但"ji"应只消费"j"(5)，"guan"(4826)→"g"(4)，
+    //   "hua"(482)→"482" → 全消费 5 位 → full commit。
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j right select ji guan hua should full commit`() {
+        val ctrl = createController()
+        // 步骤1: 输入 54482
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        assertEquals("54482", ctrl.bufferString)
+
+        // 步骤2: 左选 j（不选 4482）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        assertEquals("j'4482", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("j", 1), ctrl.selectedOption)
+
+        // 步骤3: 右选"鸡冠花 ji guan hua"
+        // "ji"(54)→j(5), "guan"(4826)→g(4), "hua"(482)→"482" → 全消费 5 位
+        val result = ctrl.onRightCandidateSelected("ji guan hua", 3)
+        assertTrue("ji guan hua should full commit — j+g+hua covers all 54482", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
     // ── 辅助方法 ──
 
     private fun createController(): T9InputController {
         return T9InputController(onReplaceFullPinyin = { /* no-op */ })
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 验证："结构光(jie gou guang)" 应 partial commit，不触发 full commit
+    //
+    // 左选 j→g（不选 482），右选"结构光(jie gou guang)"
+    //   "jie"(543) 不精确匹配 "54482" 前缀 → prefix "5" → 1 位
+    //   "gou"(468) → prefix "4" → 1 位
+    //   "guang"(48264) → "482" 前缀匹配 "4" → 1 位
+    //   totalConsumed=3, consumedFromUnassigned=1, 剩余"82"
+    //   → 应 partial commit，返回 "82" 作为剩余数字段
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun `bug - 54482 j g right select jie gou guang should partial commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        assertEquals("54482", ctrl.bufferString)
+
+        // 左选 j→g（不选 482）
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        assertEquals("jg'482", ctrl.bufferString)
+
+        // 右选"结构光 jie gou guang"
+        // "guang"(48264) 只能前缀匹配 "482" 的 "4"，剩余 "82" 未消费
+        val result = ctrl.onRightCandidateSelected("jie gou guang", 3)
+        assertFalse("jie gou guang should NOT full commit — guang(48264) can't match '482'", result)
+        // 验证：buffer 应保留 "82" 数字段，进入 INPUT 态
+        // "guang"(48264) 只能前缀匹配 "482" 的 "4"，剩余 "82" 未消费
+        // 同时 j→g 的 selection 被消费，剩余 "82" 为纯数字段
+        assertEquals("82", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 覆盖率补全：5个未覆盖分支的 @Test 用例
+    //
+    // 覆盖目标：
+    //   1. handleConsumedAllNonSelected — 数字码全匹配分支 (L780-784)
+    //   2. handleConsumedAllNonSelected — 精确全拼匹配 (L786-798)
+    //   3. handleConsumedAllNonSelected — 非选中覆盖音节 ≥ commentSyllables (L817-822)
+    //   4. handlePartialConsumedNonSelected — confirmedPinyin 路径 (L902-917)
+    //   5. handleSelectionLetterBufferCommit — wouldTriggerShengmu → false 分支 (L709-727)
+    // ═══════════════════════════════════════════════════════════════
+
+    // ── 场景 #1: 数字码全匹配分支 (L780-784) ──
+    // 候选词注释的完整字母数字码 == buffer 完整 selectedPinyin 的数字码
+    // buffer=jihua(54482), candidate="jihua"(54482) → full commit
+
+    @Test
+    fun `coverage - candidate digit code equals full buffer digit code triggers full commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        // 左选 ji(2) → hua(3)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ji", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("jihua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hua", 3), ctrl.selectedOption)
+
+        // "ji hua" 的 candidateClean="jihua" digitCode="54482" == buffer digitCode="54482"
+        val result = ctrl.onRightCandidateSelected("ji hua", 2)
+        assertTrue("digit code match should full commit", result)
+        assertEquals("", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.IDLE, ctrl.leftPanelState)
+    }
+
+    // ── 场景 #2: 精确全拼匹配 (L786-798) ──
+    // 候选词最后一个音节数字码与 prevSelectedOption 完全相同
+    // buffer=jghua, 右选 candidate with lastSyl matching hua(482) + 3+ syllables to bypass isAllSelectedConsumed
+    //
+    // 注：本地词库无"寄挂 ji gua"，但测试框架允许任意 candidatePinyin
+
+    @Test
+    fun `coverage - exact full pinyin match of selected option triggers full commit`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("jghua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hua", 3), ctrl.selectedOption)
+
+        // "ji gua": candidateClean="jigua"(54482) == buffer "jghua"(54482)
+        // commentSyllables=2, selectionHistory=3 → bypass isAllSelectedConsumed
+        // But matching happens in handleConsumedAllNonSelected when consumedCount >= nonSelectedDigits
+        val result = ctrl.onRightCandidateSelected("ji gua", 2)
+        // nonSelected="jg", consumedCount=2 >= 2 → handleConsumedAllNonSelected
+        // matchedNonSelectedCount=2 >= commentSyllables.size=2 → preserve hua
+        assertFalse("ji gua should partial commit — preserve hua selection", result)
+        assertEquals("hua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+    }
+
+    // ── 场景 #3: 非选中覆盖所有音节不触发声母回退 (L817-822) ──
+    // 候选词音节数 ≤ 非选中selection数，所有非选中selection被覆盖 → 不触发shengmu回退
+
+    @Test
+    fun `coverage - non selected fully covers comment syllables skips shengmu fallback`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("jghua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+
+        // "ji ge" 2音节完全被非选中 j+g 覆盖 → 跳过 shengmu 回退
+        val result = ctrl.onRightCandidateSelected("ji ge", 2)
+        assertFalse("ji ge should partial commit — preserve hua", result)
+        assertEquals("hua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hua", 3), ctrl.selectedOption)
+    }
+
+    // ── 场景 #4: handlePartialConsumedNonSelected confirmedPinyin 路径 ──
+    // prevConfirmedPinyin 非空且 nonSelectedPart == prevConfirmedPinyin → 走字母反转路径
+
+    @Test
+    fun `coverage - partial consumed non selected with confirmed pinyin path`() {
+        val ctrl = createController()
+        // 输入 5343 (=k e h e → kehe)
+        for (d in listOf("5", "3", "4", "3")) ctrl.onDigitPressed(d)
+
+        // 左选 ke(2) → he(2)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("ke", 2))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("he", 2))
+        assertEquals("kehe", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("he", 2), ctrl.selectedOption)
+
+        // "ke hen" isPrefixMatchAllSelected=false (hen(436)!=he(43))
+        // consumedCount in handleSelectionLetterBufferCommit = computeConsumedDigits("53", "ke hen") = 2
+        // nonSelectedDigits="53", consumedCount=2 == len → handleConsumedAllNonSelected
+        // → tryShengmuFallback: hen(436) initial h(4) == he(43) initial h(4)
+        //   → shengmu fallback: consumedFromSelected=1, remainingFromSelected="3"
+        //   → partial commit, remaining digit "3"
+        val result = ctrl.onRightCandidateSelected("ke hen", 2)
+        assertFalse("ke hen should partial commit via shengmu fallback", result)
+        assertEquals("3", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.INPUT, ctrl.leftPanelState)
+    }
+
+    // ── 场景 #5: wouldTriggerShengmu=false → syllable-boundary 按选择消费 ──
+    // 候选最后一个音节首字母与选中项首字母不同 → 走 selection 消费路径
+
+    @Test
+    fun `coverage - syllable boundary selection consumption when shengmu mismatch`() {
+        val ctrl = createController()
+        for (d in listOf("5", "4", "4", "8", "2")) ctrl.onDigitPressed(d)
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("j", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("g", 1))
+        ctrl.onChoiceSelected(T9PinyinMap.SyllableOption("hua", 3))
+        assertEquals("jghua", ctrl.bufferString)
+
+        // "jie gou lai": lastSyl="lai"(524), lastSylInitial="l"(5)
+        // optInitial="h"(4) → wouldTriggerShengmu=false → 按 selection 消费 (#715-719)
+        // nonSelectedSyllables = ["jie","gou","lai"] (last != hua)
+        // consumedSelections=3 >= nonSelectedHistory.size=2 → 消费全部非选中
+        val result = ctrl.onRightCandidateSelected("jie gou lai", 3)
+        assertFalse("jie gou lai should partial commit — preserve hua", result)
+        assertEquals("hua", ctrl.bufferString)
+        assertEquals(T9InputController.LeftPanelState.SELECTION, ctrl.leftPanelState)
+        assertEquals(T9PinyinMap.SyllableOption("hua", 3), ctrl.selectedOption)
     }
 
     private fun assertPinyins(controller: T9InputController, vararg expected: String) {


### PR DESCRIPTION
@kingzcheung 
关联issue #500

## 背景

在九键 T9 输入模式下，用户通过左侧候选区选择拼音分段（左选）后，再通过右侧候选词列表选择候选词（右选）时，消费算法在 multi-selection 上下文中存在多个边界 Bug，导致预编辑文本错误消费、候选词列表不更新等问题。

完整内容见issue描述。

## 根因与修复

### 核心消费算法重构（T9RightCommitHandler.kt / T9RightCommitUtils.kt）

1. **单音节候选词跨越 selection 边界** — 贪婪数字前缀匹配错误地消费了多个 selection。引入 `CapToFirstSelection` 单音节边界保护，仅消费第一个 selection 对应数字。

2. **字母数代理指标替换为音节数代理** — 原 `effectiveLetterCount` 作为核心代理指标在语义上错误（`CountLetters("ji")=2` 不代表应消费 2 个 selection）。改为 `parseSyllables()` 音节数判断，结合 `canCoverAllBySyllableCount` 进行音节覆盖验证。

3. **derive-rule expansion 消费不全** — RIME 扩展拼音导致 T9 数字码不匹配（如 `"yong"→"9664"` vs 输入 `"96636"`）。`computeConsumedDigitsFromPinyin` 新增 `allowLongestPrefix` 参数，digitSegment 模式使用最长公共前缀匹配，apostrophe 模式仅匹配 1 字符声母防止过度消费。

4. **中间音节遗漏** — 仅检查最后一个音节，遗漏可匹配的中间音节。`handleApostropheRightCommit` 新增音节覆盖检查，在 `canCoverAllBySyllableCount` 为 true 且 `remainingDigits` 非空时，验证候选词多余音节是否能覆盖剩余未分配数字。

5. **统一状态提交入口** — 引入 `commitState()` 替代分散的状态同步逻辑，消除 buffer 与 stateMachine 状态不一致。

### 候选词 emoji 处理（T9InputController.kt / KeyboardView.kt）

新增 `onRightCandidateSelectedByDirectCommit` 方法：当候选词拼音注释为空（如 emoji `🎸`）时，直接提交上屏并清空缓冲区，不走三层消费算法。

### date_hint.lua 重构

- 仅保留双字触发词（"今日"/"明日"/"昨日"），去掉单字（"今"/"明"/"昨"）避免误触发
- 单遍流式处理（替换双缓冲 O(2n) 设计）
- 日期候选词复用触发词 comment（如 `"jin ri"`），使 T9 消费逻辑能通过正常拼音匹配数字序列 → full commit
- 格式改为 `今日(07月23日)` 提升可读性

## 修改文件

| 文件 | 变更 |
|------|------|
| `T9RightCommitHandler.kt` | 476 行重构：统一 commitState、音节数代理、multi-selection 边界保护 |
| `T9RightCommitUtils.kt` | 355 行新增：parseSyllables、canCoverAllBySyllableCount、computeSelectionConsumedCount、allowLongestPrefix |
| `T9InputController.kt` | +11 行：新增 onRightCandidateSelectedByDirectCommit |
| `KeyboardView.kt` | 7 行修改：emoji 候选词路由到 direct commit |
| `date_hint.lua` | 102 行重构：单遍流式、双字触发词、复用 comment |
| `T9RightCommitHandlerTest.kt` | 1169 行新增：37 个回归测试用例 |

## 测试

- 项目总测试用例：582 个（新增 37 个）
- `./gradlew test` — 全部通过
- `./gradlew assembleDebug` — 构建通过