### PR TITLE
chore(version): 升级版本号至2.6.0-beta1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -311,7 +311,7 @@ android {
         minSdk = 28
         targetSdk = 35
         versionCode = 20260724
-        versionName = "2.5.5"
+        versionName = "2.6.0-beta1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
- 将应用版本从2.5.5升级到2.6.0-beta1
- 更新版本代码为20260724
- 标记子项目librime、librime-lua、librime-lua-deps为dirty状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
