### PR TITLE
feat(settings): 添加Rime配置导出功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/RimeExportManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/RimeExportManager.kt
@@ -1,0 +1,162 @@
+package com.kingzcheung.xime.settings
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.core.content.FileProvider
+import java.io.File
+import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+enum class ExportMode(val label: String) {
+    CONFIG_ONLY("仅配置文件"),
+    FULL_BACKUP("完整备份")
+}
+
+data class ExportResult(
+    val uri: Uri?,
+    val fileName: String,
+    val savedToDownloads: Boolean
+)
+
+object RimeExportManager {
+
+    private const val TAG = "RimeExportManager"
+
+    fun shareSingleFile(context: Context, file: File) {
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = inferMimeType(file)
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            clipData = android.content.ClipData.newRawUri(null, uri)
+        }
+        val chooser = Intent.createChooser(intent, "分享文件")
+        context.startActivity(chooser)
+    }
+
+    fun exportArchive(context: Context, mode: ExportMode): Result<ExportResult> {
+        try {
+            val dateStr = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+            val fileName = "Xime配置-$dateStr.zip"
+            val rimeDir = File(context.filesDir, "rime")
+            if (!rimeDir.exists()) {
+                return Result.failure(Exception("Rime 目录不存在"))
+            }
+
+            val tempZip = File(context.cacheDir, fileName)
+            ZipOutputStream(FileOutputStream(tempZip)).use { zos ->
+                rimeDir.walkTopDown().forEach { file ->
+                    if (file.isDirectory) return@forEach
+                    val relativePath = file.relativeTo(rimeDir).path.replace('\\', '/')
+                    if (!shouldInclude(relativePath, mode)) return@forEach
+                    zos.putNextEntry(ZipEntry(relativePath))
+                    file.inputStream().use { it.copyTo(zos) }
+                    zos.closeEntry()
+                }
+            }
+
+            if (tempZip.length() == 0L) {
+                tempZip.delete()
+                return Result.failure(Exception("没有可导出的文件"))
+            }
+
+            val savedToDownloads = saveToDownloads(context, tempZip, fileName)
+            tempZip.delete()
+
+            val resultUri = if (savedToDownloads) {
+                resolveDownloadsUri(context, fileName)
+            } else {
+                null
+            }
+
+            return Result.success(ExportResult(resultUri, fileName, savedToDownloads))
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "exportArchive failed", e)
+            return Result.failure(e)
+        }
+    }
+
+    private fun saveToDownloads(context: Context, zipFile: File, fileName: String): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val values = ContentValues().apply {
+                    put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+                    put(MediaStore.Downloads.MIME_TYPE, "application/zip")
+                    put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+                }
+                val uri = context.contentResolver.insert(
+                    MediaStore.Downloads.EXTERNAL_CONTENT_URI, values
+                )
+                if (uri == null) return false
+                context.contentResolver.openOutputStream(uri)?.use { output ->
+                    zipFile.inputStream().use { it.copyTo(output) }
+                }
+                true
+            } else {
+                @Suppress("DEPRECATION")
+                val destDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                if (!destDir.exists()) destDir.mkdirs()
+                val dest = File(destDir, fileName)
+                zipFile.copyTo(dest, overwrite = true)
+                true
+            }
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "saveToDownloads failed", e)
+            false
+        }
+    }
+
+    private fun resolveDownloadsUri(context: Context, fileName: String): Uri? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+            val projection = arrayOf(MediaStore.Downloads._ID)
+            val selection = "${MediaStore.Downloads.DISPLAY_NAME} = ?"
+            val selectionArgs = arrayOf(fileName)
+            context.contentResolver.query(collection, projection, selection, selectionArgs, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Downloads._ID))
+                    return Uri.withAppendedPath(collection, id.toString())
+                }
+            }
+        }
+        return null
+    }
+
+    private fun shouldInclude(relativePath: String, mode: ExportMode): Boolean {
+        if (mode == ExportMode.FULL_BACKUP) return true
+        return when {
+            relativePath.startsWith("build/") -> false
+            relativePath.startsWith("opencc/") -> true
+            relativePath.endsWith(".bin") -> false
+            relativePath.endsWith(".gram") -> false
+            relativePath.endsWith(".db") -> false
+            relativePath.endsWith(".db-wal") -> false
+            relativePath.endsWith(".db-shm") -> false
+            else -> true
+        }
+    }
+
+    private fun inferMimeType(file: File): String {
+        return when {
+            file.name.endsWith(".yaml") -> "text/vnd.yaml"
+            file.name.endsWith(".txt") -> "text/plain"
+            file.name.endsWith(".bin") -> "application/octet-stream"
+            file.name.endsWith(".gram") -> "application/octet-stream"
+            file.name.endsWith(".zip") -> "application/zip"
+            else -> "application/octet-stream"
+        }
+    }
+}

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/RimeFileBrowserScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/RimeFileBrowserScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -25,25 +26,35 @@ import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.IosShare
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,6 +63,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.kingzcheung.xime.settings.ExportMode
+import com.kingzcheung.xime.settings.ExportResult
+import com.kingzcheung.xime.settings.RimeExportManager
 import com.kingzcheung.xime.settings.SchemaManager
 import io.github.rosemoe.sora.event.ContentChangeEvent
 import io.github.rosemoe.sora.langs.textmate.TextMateColorScheme
@@ -86,6 +100,12 @@ fun RimeFileBrowserContent(onBack: () -> Unit) {
     var entries by remember { mutableStateOf(listOf<FileEntry>()) }
     var viewingFile by remember { mutableStateOf<File?>(null) }
     var showDeleteDialog by remember { mutableStateOf<File?>(null) }
+    var showExportDialog by remember { mutableStateOf(false) }
+    var exportMode by remember { mutableStateOf(ExportMode.CONFIG_ONLY) }
+    var exportInProgress by remember { mutableStateOf(false) }
+    var exportResult by remember { mutableStateOf<ExportResult?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     fun refresh() {
         entries = currentDir.listFiles()
@@ -149,13 +169,17 @@ fun RimeFileBrowserContent(onBack: () -> Unit) {
                     IconButton(onClick = { refresh() }) {
                         Icon(Icons.Default.Refresh, contentDescription = "刷新")
                     }
+                    IconButton(onClick = { showExportDialog = true }) {
+                        Icon(Icons.Default.IosShare, contentDescription = "导出")
+                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,
                     titleContentColor = MaterialTheme.colorScheme.onBackground
                 )
             )
-        }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { innerPadding ->
         if (entries.isEmpty()) {
             Box(modifier = Modifier.fillMaxSize().padding(innerPadding),
@@ -185,6 +209,9 @@ fun RimeFileBrowserContent(onBack: () -> Unit) {
                             } else {
                                 showDeleteDialog = entry.file
                             }
+                        },
+                        onShare = {
+                            RimeExportManager.shareSingleFile(context, entry.file)
                         }
                     )
                 }
@@ -208,6 +235,90 @@ fun RimeFileBrowserContent(onBack: () -> Unit) {
                     Text("取消")
                 }
             }
+        )
+    }
+
+    if (showExportDialog) {
+        AlertDialog(
+            onDismissRequest = { showExportDialog = false },
+            title = { Text("导出 Rime 配置") },
+            text = {
+                Column {
+                    Text("选择导出范围：")
+                    Spacer(Modifier.height(12.dp))
+                    ExportMode.entries.forEach { mode ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { exportMode = mode }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = exportMode == mode,
+                                onClick = { exportMode = mode }
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(mode.label, style = MaterialTheme.typography.bodyMedium)
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        if (exportMode == ExportMode.CONFIG_ONLY)
+                            "排除 build/ 目录和 .bin/.gram 等编译产物"
+                        else
+                            "包含 Rime 目录下所有文件和子目录",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showExportDialog = false
+                        exportInProgress = true
+                        scope.launch {
+                            val result = withContext(Dispatchers.IO) {
+                                RimeExportManager.exportArchive(context, exportMode)
+                            }
+                            exportInProgress = false
+                            result.fold(
+                                onSuccess = { exportResult ->
+                                    val msg = if (exportResult.savedToDownloads)
+                                        "已保存到 Downloads/${exportResult.fileName}"
+                                    else
+                                        "导出完成"
+                                    snackbarHostState.showSnackbar(msg)
+                                },
+                                onFailure = { error ->
+                                    snackbarHostState.showSnackbar("导出失败: ${error.message}")
+                                }
+                            )
+                        }
+                    },
+                    enabled = !exportInProgress
+                ) {
+                    Text(if (exportInProgress) "导出中..." else "开始导出")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showExportDialog = false },
+                    enabled = !exportInProgress
+                ) {
+                    Text("取消")
+                }
+            }
+        )
+    }
+
+    if (exportInProgress) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("导出中") },
+            text = { Text("正在打包 Rime 配置…") },
+            confirmButton = {}
         )
     }
 }
@@ -381,7 +492,7 @@ private fun YamlEditor(file: File, onDeleted: () -> Unit, onBack: () -> Unit) {
 private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
 
 @Composable
-private fun FileEntryRow(entry: FileEntry, onView: () -> Unit, onDelete: () -> Unit) {
+private fun FileEntryRow(entry: FileEntry, onView: () -> Unit, onDelete: () -> Unit, onShare: () -> Unit = {}) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -433,6 +544,14 @@ private fun FileEntryRow(entry: FileEntry, onView: () -> Unit, onDelete: () -> U
             }
         }
         if (!entry.isDirectory) {
+            IconButton(onClick = onShare, modifier = Modifier.size(36.dp)) {
+                Icon(
+                    Icons.Default.Share,
+                    contentDescription = "分享",
+                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
             IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
                 Icon(
                     Icons.Default.Delete,


### PR DESCRIPTION
- 在Rime文件浏览器界面添加导出按钮和对话框
- 支持选择导出模式（仅配置文件或全部文件）
- 实现压缩包导出功能并显示进度提示
- 添加单个文件分享功能
- 集成snackbar显示导出结果反馈

fix(jni): 更新子项目提交记录

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
