### PR TITLE
build(gradle): 升级NDK版本和Gradle包装器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ app/src/main/assets/plugins/*.apk
 fix_encoding.py
 perf.data
 xime_heap.hprof
+app/src/main/jni/ncnn-build
+app/src/main/jni/ncnn

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -381,7 +381,7 @@ android {
             useLegacyPackaging = true
         }
     }
-    ndkVersion = "28.2.13676358"
+    ndkVersion = "29.0.14206865"
 
     // 测试 classpath 包含 main assets，使 T9Decoder() 无参构造可加载 pinyin_lm.bin
     sourceSets {

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -22,7 +22,7 @@ include(Boost)
 
 option(WITH_GFLAGS "Use gflags" OFF)
 option(WITH_GTEST "Use googletest" OFF)
-option(WITH_UNWIND "Enable libunwind support" OFF)
+set(WITH_UNWIND "none" CACHE STRING "Enable libunwind support (values: none, unwind, libunwind)")
 add_subdirectory(librime/deps/glog)
 target_compile_options(glog_internal PRIVATE "-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,10 @@
 #Sat Mar 28 10:18:47 CST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
+#distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-9.5.0-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-9.5.0-bin.zip
+
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- 将NDK版本从28.2.13676358升级到29.0.14206865
- 将Gradle版本从9.3.1升级到9.5.0
- 更新Gradle分发包的SHA256校验和
- 使用腾讯云镜像源加速Gradle下载
- 在.gitignore中添加ncnn构建目录排除规则
- 更新子项目librime、librime-lua和librime-lua-deps的提交状态为dirty

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [x] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
