### PR TITLE
feat(service): 添加键盘模式切换前候选词提交功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1153,6 +1153,27 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                             commitFirstCandidateAndClearT9()
                                         }
                                     },
+                                    onCommitCandidateBeforeModeChange = {
+                                        val cs = candidateState.value
+                                        if (cs.pendingEnglishText.isNotEmpty()) {
+                                            commitText(cs.pendingEnglishText)
+                                            candidateState.value = cs.copy(
+                                                pendingEnglishText = "",
+                                                associationCandidates = emptyList()
+                                            )
+                                        } else if (!isT9Schema(uiState.value.currentSchemaId)
+                                            && cs.isComposing) {
+                                            if (cs.candidates.isNotEmpty()) {
+                                                if (rimeEngine.selectCandidate(0)) {
+                                                    val text = rimeEngine.commit()
+                                                    if (text.isNotEmpty()) commitText(text)
+                                                }
+                                            } else if (cs.preeditText.isNotEmpty()) {
+                                                commitText(cs.preeditText)
+                                                rimeEngine.clearComposition()
+                                            }
+                                        }
+                                    },
                                     onShowQuickSendForm = {
                                         val current = uiState.value
                                         uiState.value = current.copy(
@@ -1778,11 +1799,9 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
             displayComments = display.displayComments
             isComposing = display.isComposing
         } else {
-            val lowerInput = inputText.lowercase()
-            val hasExtraContent = preeditText.any { c ->
-                !c.isWhitespace() && c != '\'' && !lowerInput.contains(c.lowercaseChar())
-            }
-            displayText = if (preeditText.isNotEmpty() && hasExtraContent) preeditText else inputText
+            // 非 T9 方案（如双拼）使用原始输入文本显示，
+            // 避免显示 rime speller 展开后的编码（如双拼 vjv → zhan b）
+            displayText = inputText
             displayCandidates = filteredTexts
             displayComments = filteredComments
             isComposing = inputText.isNotEmpty()
@@ -2206,7 +2225,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     calculatorEngine.clear()
                     updateCalculatorCandidates()
                     if (candState.isComposing) {
-                        val input = candState.inputText
+                        val input = rimeEngine.getInput()
                         if (input.isNotEmpty()) {
                             withContext(Dispatchers.Main) {
                                 commitText(input)

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.PowerManager
 import android.util.Log
+import com.kingzcheung.xime.util.FileLogger
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import com.charleskorn.kaml.YamlList
@@ -218,74 +219,95 @@ object SchemaManager {
         dependencies: List<String> = emptyList(),
         resolveDepUrl: (String) -> String? = { null },
     ): InstallFromDirResult = withContext(Dispatchers.IO) {
-        val dir = getMarketDir(context, packageId)
-        if (!dir.exists() || dir.listFiles()?.none { it.isFile } != false) {
-            return@withContext InstallFromDirResult(success = false, failureReason = "压缩包不存在")
-        }
+        try {
+            val dir = getMarketDir(context, packageId)
+            if (!dir.exists() || dir.listFiles()?.none { it.isFile } != false) {
+                FileLogger.w(TAG, "installPackageFromMarketDir: dir not found or empty: $dir")
+                return@withContext InstallFromDirResult(success = false, failureReason = "压缩包不存在")
+            }
 
-        val targetFiles = listInstallTargetFiles(context, packageId)
-        if (targetFiles.isEmpty()) {
-            return@withContext InstallFromDirResult(success = false, failureReason = "归档中没有文件")
-        }
+            val targetFiles = listInstallTargetFiles(context, packageId)
+            if (targetFiles.isEmpty()) {
+                FileLogger.w(TAG, "installPackageFromMarketDir: no target files in $packageId")
+                return@withContext InstallFromDirResult(success = false, failureReason = "归档中没有文件")
+            }
+            FileLogger.i(TAG, "installPackageFromMarketDir: found ${targetFiles.size} target files for $packageId")
 
-        val sha256Map = computeTargetSha256Map(context, packageId)
-        val conflicts = SchemaManifestManager.detectConflicts(context, packageId, targetFiles, sha256Map)
-        if (conflicts.isNotEmpty()) {
-            return@withContext InstallFromDirResult(success = false, conflicts = conflicts)
-        }
+            val sha256Map = computeTargetSha256Map(context, packageId)
+            FileLogger.i(TAG, "installPackageFromMarketDir: computed sha256 for ${sha256Map.size} files")
 
-        val before = discoverSchemas(context).map { it.schemaId }.toSet()
-        val ok = installFromMarketToRime(context, packageId)
-        if (!ok) return@withContext InstallFromDirResult(success = false, failureReason = "安装失败")
+            val conflicts = SchemaManifestManager.detectConflicts(context, packageId, targetFiles, sha256Map)
+            if (conflicts.isNotEmpty()) {
+                FileLogger.w(TAG, "installPackageFromMarketDir: conflicts detected: ${conflicts.map { "${it.fileName} (${it.claimedBy})" }}")
+                return@withContext InstallFromDirResult(success = false, conflicts = conflicts)
+            }
 
-        val after = discoverSchemas(context).map { it.schemaId }.toSet()
-        val newIds = (after - before).toList()
+            val before = discoverSchemas(context).map { it.schemaId }.toSet()
+            FileLogger.i(TAG, "installPackageFromMarketDir: schemas before install: $before")
 
-        // 检查 target 中的 .schema.yaml 是否都解析成功
-        val targetSchemaIds = targetFiles
-            .filter { it.endsWith(".schema.yaml") }
-            .map { it.removeSuffix(".schema.yaml") }
-            .toSet()
-        val failedIds = targetSchemaIds - after
-        val parseFailures = if (failedIds.isEmpty()) emptyList()
-            else failedIds.map { "$it.schema.yaml 解析失败" }
+            val ok = installFromMarketToRime(context, packageId)
+            if (!ok) {
+                FileLogger.e(TAG, "installPackageFromMarketDir: installFromMarketToRime returned false")
+                return@withContext InstallFromDirResult(success = false, failureReason = "安装失败")
+            }
 
-        var unresolved = emptyList<String>()
-        var dependencyIds = emptyList<String>()
-        if (dependencies.isNotEmpty()) {
-            val completion = RimeDependencyResolver.complete(
+            val after = discoverSchemas(context).map { it.schemaId }.toSet()
+            val newIds = (after - before).toList()
+            FileLogger.i(TAG, "installPackageFromMarketDir: schemas after install: $after, new: $newIds")
+
+            // 检查 target 中的 .schema.yaml 是否都解析成功
+            val targetSchemaIds = targetFiles
+                .filter { it.endsWith(".schema.yaml") }
+                .map { it.removeSuffix(".schema.yaml") }
+                .toSet()
+            val failedIds = targetSchemaIds - after
+            val parseFailures = if (failedIds.isEmpty()) emptyList()
+                else failedIds.map { "$it.schema.yaml 解析失败" }
+            if (parseFailures.isNotEmpty()) {
+                FileLogger.w(TAG, "installPackageFromMarketDir: some schemas failed to parse: $parseFailures")
+            }
+
+            var unresolved = emptyList<String>()
+            var dependencyIds = emptyList<String>()
+            if (dependencies.isNotEmpty()) {
+                val completion = RimeDependencyResolver.complete(
+                    context = context,
+                    schemaId = newIds.firstOrNull() ?: packageId,
+                    dependencies = dependencies,
+                    resolveUrl = resolveDepUrl,
+                )
+                unresolved = (completion.unresolved + completion.stillMissingFiles).distinct()
+                dependencyIds = completion.downloaded
+            }
+
+            SchemaManifestManager.createManifest(
                 context = context,
-                schemaId = newIds.firstOrNull() ?: packageId,
-                dependencies = dependencies,
-                resolveUrl = resolveDepUrl,
+                schemeId = packageId,
+                displayName = displayName,
+                version = version,
+                fromMarket = fromMarket,
+                extractedFiles = targetFiles,
+                dependencyIds = dependencyIds,
             )
-            unresolved = (completion.unresolved + completion.stillMissingFiles).distinct()
-            dependencyIds = completion.downloaded
+
+            if (fromMarket) {
+                SettingsPreferences.addInstalledMarketId(context, packageId)
+            }
+
+            // 至少启用一个新方案，避免 RimeEngine 因 schema_list 为空而挂起
+            val firstSchema = newIds.firstOrNull()
+                ?: targetFiles.firstOrNull { it.endsWith(".schema.yaml") }
+                    ?.removeSuffix(".schema.yaml")
+            if (firstSchema != null) {
+                setEnabledSchemas(context, listOf(firstSchema))
+            }
+
+            FileLogger.i(TAG, "installPackageFromMarketDir: success for $packageId, firstSchema=$firstSchema")
+            InstallFromDirResult(success = true, newSchemaIds = newIds, unresolvedDeps = unresolved, parseFailures = parseFailures)
+        } catch (e: Exception) {
+            FileLogger.e(TAG, "installPackageFromMarketDir: UNCAUGHT exception for $packageId", e)
+            return@withContext InstallFromDirResult(success = false, failureReason = "安装异常: ${e.message}")
         }
-
-        SchemaManifestManager.createManifest(
-            context = context,
-            schemeId = packageId,
-            displayName = displayName,
-            version = version,
-            fromMarket = fromMarket,
-            extractedFiles = targetFiles,
-            dependencyIds = dependencyIds,
-        )
-
-        if (fromMarket) {
-            SettingsPreferences.addInstalledMarketId(context, packageId)
-        }
-
-        // 至少启用一个新方案，避免 RimeEngine 因 schema_list 为空而挂起
-        val firstSchema = newIds.firstOrNull()
-            ?: targetFiles.firstOrNull { it.endsWith(".schema.yaml") }
-                ?.removeSuffix(".schema.yaml")
-        if (firstSchema != null) {
-            setEnabledSchemas(context, listOf(firstSchema))
-        }
-
-        InstallFromDirResult(success = true, newSchemaIds = newIds, unresolvedDeps = unresolved, parseFailures = parseFailures)
     }
 
     /** 解析单个归档（或普通文件）将被释放到 rime/ 的目标文件名列表。 */
@@ -351,7 +373,7 @@ object SchemaManager {
                 val isArchive = name.endsWith(".zip", ignoreCase = true) ||
                     name.endsWith(".tar.gz", ignoreCase = true) || name.endsWith(".tgz", ignoreCase = true)
                 if (isArchive && !validateArchive(file)) {
-                    Log.e(TAG, "installFromMarketToRime: ${file.name} is corrupted for $schemeId, deleting")
+                    FileLogger.e(TAG, "installFromMarketToRime: ${file.name} is corrupted for $schemeId, deleting")
                     file.delete()
                     allOk = false
                     continue
@@ -363,17 +385,17 @@ object SchemaManager {
                     else -> {
                         val target = File(rimeDir, file.name)
                         file.copyTo(target, overwrite = true)
-                        Log.i(TAG, "Copied ${file.name} to rime dir")
+                        FileLogger.i(TAG, "Copied ${file.name} to rime dir")
                         true
                     }
                 }
                 if (!ok) {
-                    Log.e(TAG, "installFromMarketToRime: failed to process ${file.name} for $schemeId, deleting")
+                    FileLogger.e(TAG, "installFromMarketToRime: failed to process ${file.name} for $schemeId, deleting")
                     file.delete()
                     allOk = false
                 }
             } catch (e: Exception) {
-                Log.e(TAG, "installFromMarketToRime: error processing ${file.name} for $schemeId, deleting", e)
+                FileLogger.e(TAG, "installFromMarketToRime: error processing ${file.name} for $schemeId, deleting", e)
                 file.delete()
                 allOk = false
             }
@@ -778,10 +800,10 @@ object SchemaManager {
                 inputStream.use { input ->
                     archiveFile.outputStream().use { output -> input.copyTo(output) }
                 }
-                Log.i(TAG, "Imported $name -> $importId (not installed yet)")
+                FileLogger.i(TAG, "Imported $name -> $importId (not installed yet)")
                 ImportResult(true)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to import archive $name", e)
+                FileLogger.e(TAG, "Failed to import archive $name", e)
                 try { if (pkgDir.exists()) pkgDir.deleteRecursively() } catch (_: Exception) {}
                 ImportResult(false)
             }
@@ -803,10 +825,10 @@ object SchemaManager {
                         setEnabledSchemas(context, enabled)
                     }
                 }
-                Log.i(TAG, "Imported $name -> rime/ (direct)")
+                FileLogger.i(TAG, "Imported $name -> rime/ (direct)")
                 ImportResult(true, installedDirect = true)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to import $name directly", e)
+                FileLogger.e(TAG, "Failed to import $name directly", e)
                 ImportResult(false)
             }
         }
@@ -1039,7 +1061,7 @@ object SchemaManager {
                 else -> true // 非归档文件无法校验
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Archive validation failed for ${file.name}", e)
+            FileLogger.e(TAG, "Archive validation failed for ${file.name}", e)
             false
         }
     }
@@ -1159,21 +1181,21 @@ object SchemaManager {
                     val name = originalName.removePrefix(baseDir)
                     val file = if (isProtectedImportName(name)) null else safeChild(targetDir, name)
                     if (file == null) {
-                        Log.d(TAG, "Skip protected/unsafe entry: $name")
+                        FileLogger.d(TAG, "Skip protected/unsafe entry: $name")
                     } else {
                         file.parentFile?.mkdirs()
                         zip.getInputStream(entry).use { input ->
                             FileOutputStream(file).use { output -> input.copyTo(output) }
                         }
                         count++
-                        Log.d(TAG, "Extracted zip entry: $name")
+                        FileLogger.d(TAG, "Extracted zip entry: $name")
                     }
                 }
             }
-            Log.i(TAG, "Extracted $count files from zip stream")
+            FileLogger.i(TAG, "Extracted $count files from zip stream")
             count > 0
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to extract zip file", e)
+            FileLogger.e(TAG, "Failed to extract zip file", e)
             false
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -595,10 +595,26 @@ object SchemaManifestManager {
             if (allFiles.has(relPath)) return@forEach
             untracked[relPath] = f
         }
-        if (untracked.isEmpty()) return@withContext
 
         val existingManifest = loadManifest(context, BUILTIN_PACKAGE_ID)
         val fileEntries = existingManifest?.optJSONObject("files") ?: JSONObject()
+
+        // 同步 registry 中 builtin 声明的文件到 manifest（防止 manifest 与 registry 不同步）
+        val keysIt = allFiles.keys()
+        while (keysIt.hasNext()) {
+            val fn = keysIt.next() as String
+            if (fileEntries.has(fn)) continue
+            val entry = allFiles.optJSONObject(fn) ?: continue
+            val claimants = entry.optJSONArray("claimedBy")
+            if (claimants != null && jsonArrayToList(claimants).contains(BUILTIN_PACKAGE_ID)) {
+                fileEntries.put(fn, JSONObject().apply {
+                    put("sha256", entry.optString("sha256", ""))
+                    put("size", entry.optLong("size", 0))
+                })
+            }
+        }
+
+        if (untracked.isEmpty() && fileEntries.length() == (existingManifest?.optJSONObject("files")?.length() ?: 0)) return@withContext
 
         for ((relPath, file) in untracked) {
             val sha256 = SchemaManager.fileSha256(file) ?: continue

--- a/app/src/main/java/com/kingzcheung/xime/settings/WirelessImportHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/WirelessImportHelper.kt
@@ -137,18 +137,23 @@ class WirelessImportHelper(private val context: Context) {
                     name.endsWith(".tar.gz", ignoreCase = true) ||
                     name.endsWith(".tgz", ignoreCase = true) ||
                     name.endsWith(".yaml") || name.endsWith(".schema.yaml") || name.endsWith(".dict.yaml") -> {
-                        // 先读到内存再调用统一 saveImportedFile（因 raf 需 seek 回内容起始）
-                        raf.seek(contentStart)
-                        val buf = ByteArray(contentLen.toInt())
-                        raf.readFully(buf)
-                        val result = SchemaManager.saveImportedFile(
-                            context, name, buf.inputStream(), autoEnable = false
-                        )
-                        saved = result.success
-                        _uploadResults.trySend(
-                            if (result.success) UploadResult(fileName = name, success = true)
-                            else UploadResult(fileName = name, success = false, error = "保存失败")
-                        )
+                        // 经临时文件传递给 saveImportedFile，避免大文件 ByteArray OOM
+                        val partFile = File.createTempFile("part_", "_$name", context.cacheDir)
+                        try {
+                            partFile.outputStream().use { out ->
+                                raf.channel.transferTo(contentStart, contentLen, out.channel)
+                            }
+                            val result = SchemaManager.saveImportedFile(
+                                context, name, partFile.inputStream(), autoEnable = false
+                            )
+                            saved = result.success
+                            _uploadResults.trySend(
+                                if (result.success) UploadResult(fileName = name, success = true)
+                                else UploadResult(fileName = name, success = false, error = "保存失败")
+                            )
+                        } finally {
+                            partFile.delete()
+                        }
                     }
                     else -> {
                         _uploadResults.trySend(UploadResult(fileName = name, success = false, error = "不支持的文件类型"))

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -65,4 +65,9 @@ data class KeyboardCallbacks(
     val onHideQuickSendForm: (() -> Unit)? = null,
     val onQuickSendEditItem: ((Long, String) -> Unit)? = null,
     val onQuickSendFormFocusChange: ((Boolean) -> Unit)? = null,
+    /**
+     * 全键盘（中文/英文）切离至其他键盘（数字/符号）时调用。
+     * 服务层负责上屏首位候选词或待确认英文，再由键盘层切换布局。
+     */
+    val onCommitCandidateBeforeModeChange: (() -> Unit)? = null,
 )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -436,6 +436,7 @@ fun KeyboardView(
                                 "shift_single" -> viewModel.singleTapShift()
                                 "shift_caps" -> viewModel.doubleTapShift()
                                 "mode_change" -> {
+                                    callbacks.onCommitCandidateBeforeModeChange?.invoke()
                                     viewModel.setKeyboardState(keyboardState.transition(
                                         modeChangeTarget, state.isAsciiMode
                                     ))
@@ -443,11 +444,13 @@ fun KeyboardView(
                                 }
                                 "mode_change_symbol" -> viewModel.showOverlay(OverlayRoute.Symbol)
                                 "mode_change_number" -> {
+                                    callbacks.onCommitCandidateBeforeModeChange?.invoke()
                                     modeChangeTarget = KeyboardLayoutAction.SwitchToNumber
                                     SettingsPreferences.setModeChangeTargetIsNumber(context, true)
                                     viewModel.setKeyboardState(KeyboardLayoutState.Number)
                                 }
                                 "mode_change_common_symbol" -> {
+                                    callbacks.onCommitCandidateBeforeModeChange?.invoke()
                                     modeChangeTarget = KeyboardLayoutAction.SwitchToCommonSymbol
                                     SettingsPreferences.setModeChangeTargetIsNumber(context, false)
                                     viewModel.setKeyboardState(keyboardState.transition(
@@ -499,6 +502,7 @@ fun KeyboardView(
                                     initialKeyboardLayoutState(state.isAsciiMode, state.currentSchemaId)
                                 )
                                 "?123" -> {
+                                    callbacks.onCommitCandidateBeforeModeChange?.invoke()
                                     viewModel.setKeyboardState(keyboardState.transition(
                                         KeyboardLayoutAction.SwitchToNumber, state.isAsciiMode
                                     ))

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
@@ -3,8 +3,10 @@ package com.kingzcheung.xime.viewmodel
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.kingzcheung.xime.settings.FileConflictInfo
 import com.kingzcheung.xime.settings.SchemaManifestManager
 import com.kingzcheung.xime.settings.SchemaManager
+import com.kingzcheung.xime.settings.SchemaManager.InstallFromDirResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -111,14 +113,19 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
             }
 
             // 直接安装（后续由 UI 提示用户部署）
-            val result = withContext(Dispatchers.IO) {
-                SchemaManager.installPackageFromMarketDir(
-                    context = context,
-                    packageId = item.packageId,
-                    displayName = item.displayName,
-                    version = item.version,
-                    fromMarket = !item.isImport,
-                )
+            val result = try {
+                withContext(Dispatchers.IO) {
+                    SchemaManager.installPackageFromMarketDir(
+                        context = context,
+                        packageId = item.packageId,
+                        displayName = item.displayName,
+                        version = item.version,
+                        fromMarket = !item.isImport,
+                    )
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("SchemaLocalViewModel", "installPackage exception", e)
+                InstallFromDirResult(success = false, failureReason = "安装异常: ${e.message}")
             }
             _uiState.update { st -> st.copy(installingId = null) }
             if (result.success) {
@@ -130,6 +137,25 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
                     }
                 }
                 showToast(msg)
+            } else if (result.conflicts.isNotEmpty()) {
+                // 注册表冲突 → 进入冲突解决流程
+                val otherInstalled = withContext(Dispatchers.IO) {
+                    SchemaManifestManager.getInstalledPackages(context)
+                        .map { it.packageId }
+                        .filter { it != item.packageId }
+                }
+                val targetIds = result.conflicts
+                    .flatMap { it.claimedBy }
+                    .distinct()
+                    .filter { it != item.packageId }
+                    .ifEmpty { otherInstalled }
+                    .ifEmpty { listOf("builtin") }
+                _uiState.update {
+                    it.copy(
+                        conflictPackageId = item.packageId,
+                        conflictingSchemeIds = targetIds,
+                    )
+                }
             } else {
                 showToast(result.failureReason ?: "安装失败")
             }
@@ -150,14 +176,19 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
                     SchemaManifestManager.uninstallWithManifest(context, sid)
                 }
             }
-            val result = withContext(Dispatchers.IO) {
-                SchemaManager.installPackageFromMarketDir(
-                    context = context,
-                    packageId = pkgId,
-                    displayName = item.displayName,
-                    version = item.version,
-                    fromMarket = !item.isImport,
-                )
+            val result = try {
+                withContext(Dispatchers.IO) {
+                    SchemaManager.installPackageFromMarketDir(
+                        context = context,
+                        packageId = pkgId,
+                        displayName = item.displayName,
+                        version = item.version,
+                        fromMarket = !item.isImport,
+                    )
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("SchemaLocalViewModel", "confirmInstallWithUninstall exception", e)
+                InstallFromDirResult(success = false, failureReason = "安装异常: ${e.message}")
             }
             _uiState.update { st -> st.copy(installingId = null, conflictingSchemeIds = emptyList()) }
             if (result.success) {
@@ -170,7 +201,14 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
                 }
                 showToast(msg)
             } else {
-                showToast(result.failureReason ?: "安装失败")
+                val reason = if (result.failureReason != null) {
+                    result.failureReason
+                } else if (result.conflicts.isNotEmpty()) {
+                    result.conflicts.joinToString("、") { "${it.fileName}（已被 ${it.claimedBy.joinToString("、")} 使用）" }
+                } else {
+                    "安装失败"
+                }
+                showToast(reason)
             }
             loadLocalPackages()
         }


### PR DESCRIPTION
添加 onCommitCandidateBeforeModeChange 回调，在全键盘切离至其他键盘时自动提交首位候选词或待确认英文， 确保输入内容不会丢失。该功能支持 T9 输入法和非 T9 方案（如双拼）的正确处理。

fix(display): 修复非 T9 方案显示问题

移除复杂的预编辑文本显示逻辑，非 T9 方案（如双拼）直接使用原始输入文本显示，
避免显示 rime speller 展开后的编码（如双拼 vjv → zhan b），提升用户体验。

refactor(engine): 使用 rime 引擎接口获取输入文本

将候选状态中的输入文本获取方式从 candState.inputText 改为 rimeEngine.getInput()， 确保获取到的是引擎当前最新的输入状态。

feat(manifest): 同步内置包声明文件到清单

实现 registry 中内置包声明文件的自动同步到 manifest，防止 manifest 与 registry 不同步的问题，确保文件追踪的准确性。

refactor(import): 优化无线导入大文件处理

修改无线导入功能，使用临时文件传递大文件内容给 saveImportedFile，
避免大文件 ByteArrary 导致 OOM 错误，提高导入稳定性。

feat(logging): 替换系统日志为文件日志

将 SchemaManager 中的日志记录从系统 Log 改为 FileLogger，
提供更好的日志管理和调试能力，便于问题追踪和分析。

feat(install): 增强方案包安装错误处理和冲突检测

增强方案包安装过程的异常处理，添加 try-catch 包装；完善冲突检测机制，
当出现文件冲突时引导用户进入冲突解决流程，并提供详细的冲突信息提示。

chore(deps): 更新子项目依赖

更新 librime、librime-lua 和 librime-lua-deps 子项目的提交引用。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
