### PR TITLE
feat(service): 优化输入框模式下的光标和编码显示逻辑

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1057,6 +1057,19 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     onCursorMove = { direction ->
                                         val ic = currentInputConnection
                                         if (ic != null && direction != 0) {
+                                            if (SettingsPreferences.getInputTextLocation(this@XimeInputMethodService) == SettingsPreferences.INPUT_TEXT_INPUT_BOX &&
+                                                candidateState.value.isComposing
+                                            ) {
+                                                // 输入框模式：移动光标前先结束 composing 并清空 RIME 组成，
+                                                // 避免再次输入时 composing 区域与光标位置错乱
+                                                ic.finishComposingText()
+                                                postRimeJob {
+                                                    rimeEngine.clearComposition()
+                                                    withContext(Dispatchers.Main) {
+                                                        mainHandler.post { updateUI() }
+                                                    }
+                                                }
+                                            }
                                             var movedBySelection = false
                                             try {
                                                 val req = android.view.inputmethod.ExtractedTextRequest()
@@ -1835,10 +1848,22 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         if (codeInInputBox) {
             val ic = currentInputConnection
             if (isComposing && displayText.isNotEmpty()) {
-                ic?.setComposingText(displayText, displayText.length)
+                showInputBoxComposition(ic, displayText)
             } else {
                 ic?.finishComposingText()
             }
+        }
+    }
+
+    /** 在输入框模式向编辑器写入编码文本。 */
+    private fun showInputBoxComposition(ic: android.view.inputmethod.InputConnection, displayText: String) {
+        // 第二参数为 1：光标相对编码起始偏移 1 个字符，使光标落在编码末尾，
+        // 避免传 displayText.length 时被 AOSP 钳制到整段文本末尾（光标跑到最右边）。
+        ic.beginBatchEdit()
+        try {
+            ic.setComposingText(displayText, 1)
+        } finally {
+            ic.endBatchEdit()
         }
     }
 
@@ -1923,7 +1948,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         if (SettingsPreferences.getInputTextLocation(this) == SettingsPreferences.INPUT_TEXT_INPUT_BOX) {
             val ic = currentInputConnection
             if (isComposing && displayText.isNotEmpty()) {
-                ic?.setComposingText(displayText, displayText.length)
+                showInputBoxComposition(ic, displayText)
             } else {
                 ic?.finishComposingText()
             }


### PR DESCRIPTION
在输入框模式下，当用户移动光标时先结束 composing 状态并清空 RIME
组成，避免再次输入时 composing 区域与光标位置错乱。

同时改进了输入框模式下的编码文本显示方式，使用 batch edit
包装 setComposingText 操作，并将光标相对编码起始偏移设为 1，
使光标准确落在编码末尾而非整段文本末尾。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
