### PR TITLE
feat(service): 添加方案开关支持和菜单栏动态显示

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/InputUIState.kt
@@ -4,12 +4,14 @@ import com.kingzcheung.xime.settings.SchemaInfo
 import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.speech.RecognitionState
 import com.kingzcheung.xime.keyboard.ToolbarButton
+import com.kingzcheung.xime.viewmodel.SchemaSwitchUiState
 
 data class InputUIState(
     val isAsciiMode: Boolean = false,
     val schemaName: String = "",
     val currentSchemaId: String = "",
     val schemas: List<SchemaInfo> = emptyList(),
+    val schemaSwitches: List<SchemaSwitchUiState> = emptyList(),
     val enterKeyText: String = "发送",
     val darkMode: Int = 0,
     val themeId: String = "ocean_blue",

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -913,6 +913,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 schemaName = state.schemaName,
                                 currentSchemaId = state.currentSchemaId,
                                 schemas = state.schemas,
+                                schemaSwitches = state.schemaSwitches,
                                 enterKeyText = state.enterKeyText,
                                 isDarkTheme = isDarkTheme,
                                 darkMode = state.darkMode,
@@ -1020,6 +1021,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                     onReloadConfig = { reloadConfig() },
                                     onSettings = { openSettings() },
                                     onSwitchSchema = { schemaId -> switchSchema(schemaId) },
+                                    onToggleSchemaSwitch = { sw -> toggleSchemaSwitch(sw) },
                                     onHideKeyboard = { hideKeyboard() },
                                     onSwitchKeyboard = {
                                         val imm = getSystemService(INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
@@ -2008,7 +2010,60 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                     currentSchemaId = currentSchemaId,
                     schemas = schemas
                 )
+                refreshSchemaSwitches()
             }
+        }
+    }
+
+    /** 读取当前引擎方案 `switches` 的实际取值，组装成菜单栏可展示的状态。 */
+    private fun loadSchemaSwitches(schemaId: String): List<com.kingzcheung.xime.viewmodel.SchemaSwitchUiState> {
+        if (schemaId.isEmpty()) return emptyList()
+        val defs = SchemaManager.getSchemaSwitches(this, schemaId)
+        return defs.map { def ->
+            val index = when {
+                def.name.isNotEmpty() && def.states.isNotEmpty() ->
+                    if (rimeEngine.getOption(def.name)) minOf(1, def.states.size - 1) else 0
+                def.options.isNotEmpty() -> {
+                    val active = def.options.indexOfFirst { rimeEngine.getOption(it) }
+                    if (active < 0) 0 else active
+                }
+                else -> 0
+            }
+            com.kingzcheung.xime.viewmodel.SchemaSwitchUiState(
+                name = def.name,
+                options = def.options,
+                states = def.states,
+                abbrev = def.abbrev,
+                currentIndex = index
+            )
+        }
+    }
+
+    /** 在引擎线程上刷新菜单栏方案开关状态。 */
+    private fun refreshSchemaSwitches() {
+        serviceScope.launch(keyProcessingDispatcher) {
+            val schemaId = rimeEngine.getCurrentSchema()
+            val switches = loadSchemaSwitches(schemaId)
+            withContext(Dispatchers.Main) {
+                uiState.value = uiState.value.copy(schemaSwitches = switches)
+            }
+        }
+    }
+
+    /** 菜单栏方案开关点击：切换引擎选项并刷新状态。 */
+    private fun toggleSchemaSwitch(sw: com.kingzcheung.xime.viewmodel.SchemaSwitchUiState) {
+        serviceScope.launch(keyProcessingDispatcher) {
+            if (sw.name == "ascii_mode") {
+                switchInputMethod()
+            } else if (sw.name.isNotEmpty()) {
+                rimeEngine.setOption(sw.name, !rimeEngine.getOption(sw.name))
+                updateUI()
+            } else if (sw.options.isNotEmpty()) {
+                val nextIndex = (sw.currentIndex + 1) % sw.options.size
+                sw.options.forEachIndexed { i, opt -> rimeEngine.setOption(opt, i == nextIndex) }
+                updateUI()
+            }
+            refreshSchemaSwitches()
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManager.kt
@@ -9,6 +9,7 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import com.charleskorn.kaml.YamlList
 import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlNode
 import com.charleskorn.kaml.YamlScalar
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -40,6 +41,19 @@ data class SchemaMeta(
     val version: String = "",
     val author: String = "",
     val description: String = ""
+)
+
+/**
+ * 方案中 `switches` 定义的一个开关项。
+ * - [name] 非空时表示布尔开关（如 ascii_mode / full_shape / ascii_punct）。
+ * - [options] 非空时表示多选一开关（如简繁切换，同一时刻只有一个 option 为 true）。
+ * - [abbrev] 自定义缩写（可能每个状态一个），供菜单栏展示用；为空时取 states 首字符。
+ */
+data class SchemaSwitch(
+    val name: String = "",
+    val options: List<String> = emptyList(),
+    val states: List<String> = emptyList(),
+    val abbrev: List<String> = emptyList(),
 )
 
 @Serializable
@@ -660,6 +674,77 @@ object SchemaManager {
             try { Log.e(TAG, "Failed to parse schema name for $schemaId", e) } catch (_: Exception) {}
             null
         }
+    }
+
+    /**
+     * 读取方案顶层 `switches:` 中可展示的开关项（name 或 options 存在且有 states）。
+     * `switches` 位于 schema 块之外，需单独解析。解析失败或不存在时返回空列表。
+     */
+    fun getSchemaSwitches(context: Context, schemaId: String): List<SchemaSwitch> {
+        val file = File(getRimeDir(context), "$schemaId.schema.yaml")
+        if (!file.exists()) return emptyList()
+        return parseSchemaSwitches(file)
+    }
+
+    /** 纯解析：从 .schema.yaml 读取 switches。 */
+    internal fun parseSchemaSwitches(file: File): List<SchemaSwitch> {
+        return try {
+            val text = file.readText().trimStart('\uFEFF')
+            val block = extractSwitchesBlock(text) ?: return emptyList()
+            val listNode = yaml.parseToYamlNode(block) as? YamlList ?: return emptyList()
+            listNode.items.mapNotNull { item ->
+                parseSwitchEntry(item as? YamlMap ?: return@mapNotNull null)
+            }
+        } catch (e: Exception) {
+            try { Log.w(TAG, "Failed to parse switches for ${file.name}: ${e.message}", e) } catch (_: Exception) {}
+            emptyList()
+        }
+    }
+
+    private fun parseSwitchEntry(entry: YamlMap): SchemaSwitch? {
+        val states = (entry["states"] as? YamlList)
+            ?.items?.mapNotNull { (it as? YamlScalar)?.content }
+            .orEmpty()
+        if (states.isEmpty()) return null
+        val name = (entry["name"] as? YamlScalar)?.content.orEmpty()
+        val options = (entry["options"] as? YamlList)
+            ?.items?.mapNotNull { (it as? YamlScalar)?.content }
+            .orEmpty()
+        val abbrev = parseAbbrev(entry["abbrev"])
+        return when {
+            name.isNotBlank() -> SchemaSwitch(name = name, options = emptyList(), states = states, abbrev = abbrev)
+            options.isNotEmpty() -> SchemaSwitch(name = "", options = options, states = states, abbrev = abbrev)
+            else -> null
+        }
+    }
+
+    /** abbrev 可以是单个字符串或每个状态一个的字符串列表。 */
+    private fun parseAbbrev(node: YamlNode?): List<String> = when (node) {
+        is YamlScalar -> listOf(node.content)
+        is YamlList -> node.items.mapNotNull { (it as? YamlScalar)?.content }
+        else -> emptyList()
+    }
+
+    /**
+     * 从 YAML 文本中提取顶层 `switches:` 的列表项内容（不含 `switches:` 头行），
+     * 返回一个可独立作为列表解析的 YAML 片段；不存在时返回 null。
+     */
+    internal fun extractSwitchesBlock(yamlText: String): String? {
+        val lines = yamlText.lines()
+        val idx = lines.indexOfFirst {
+            it.trimStart().let { t -> t == "switches:" || (t.startsWith("switches:") && t[9] == ' ') }
+        }
+        if (idx < 0) return null
+        val result = mutableListOf<String>()
+        for (i in idx + 1 until lines.size) {
+            val line = lines[i]
+            if (line.isBlank()) continue
+            val indent = line.length - line.trimStart().length
+            if (indent == 0) break
+            result.add(line)
+        }
+        if (result.isEmpty()) return null
+        return result.joinToString("\n")
     }
 
     fun getEnabledSchemas(context: Context): List<String> {

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -1,6 +1,7 @@
 package com.kingzcheung.xime.ui.keyboard
 
 import com.kingzcheung.xime.keyboard.GestureAction
+import com.kingzcheung.xime.viewmodel.SchemaSwitchUiState
 
 data class KeyboardCallbacks(
     val onKeyPress: (String, Boolean) -> Unit,
@@ -19,6 +20,7 @@ data class KeyboardCallbacks(
     val onReloadConfig: (() -> Unit)? = null,
     val onSettings: (() -> Unit)? = null,
     val onSwitchSchema: ((String) -> Unit)? = null,
+    val onToggleSchemaSwitch: ((SchemaSwitchUiState) -> Unit)? = null,
     val onHideKeyboard: (() -> Unit)? = null,
     val onSwitchKeyboard: (() -> Unit)? = null,
     val onToolbarEditingAction: ((String) -> Unit)? = null,

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -806,6 +806,7 @@ fun KeyboardView(
                             keyBgColor = keyBgColor,
                             keyTextColor = keyTextColor,
                             isFloatingMode = state.isFloatingMode,
+                            schemaSwitches = state.schemaSwitches,
                         ),
                         callbacks = MenuBarCallbacks(
                             onDismiss = { viewModel.closeOverlay() },
@@ -819,6 +820,7 @@ fun KeyboardView(
                             onToggleDarkMode = { callbacks.onToggleDarkMode?.invoke() },
                             onToolbarCustomize = { viewModel.showOverlay(OverlayRoute.ToolbarCustomize) },
                             onFloatingModeToggle = { callbacks.onFloatingModeChange?.invoke(!state.isFloatingMode); viewModel.closeOverlay() },
+                            onToggleSchemaSwitch = { sw -> callbacks.onToggleSchemaSwitch?.invoke(sw); viewModel.closeOverlay() },
                         ),
                         modifier = Modifier.fillMaxWidth().fillMaxHeight()
                     )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/MenuBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/MenuBar.kt
@@ -46,11 +46,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kingzcheung.xime.viewmodel.SchemaSwitchUiState
 
 data class MenuItem(
-    val icon: Painter,
+    val icon: Painter? = null,
     val label: String,
-    val action: () -> Unit
+    val action: () -> Unit,
+    val textIcon: String? = null,
 )
 
 data class MenuBarState(
@@ -61,6 +63,7 @@ data class MenuBarState(
     val keyBgColor: Color = Color.White,
     val keyTextColor: Color = Color(0xFF202124),
     val isFloatingMode: Boolean = false,
+    val schemaSwitches: List<SchemaSwitchUiState> = emptyList(),
 )
 
 data class MenuBarCallbacks(
@@ -75,6 +78,7 @@ data class MenuBarCallbacks(
     val onToggleDarkMode: () -> Unit,
     val onFloatingModeToggle: (() -> Unit)? = null,
     val onToolbarCustomize: () -> Unit = {},
+    val onToggleSchemaSwitch: ((SchemaSwitchUiState) -> Unit)? = null,
 )
 
 @Composable
@@ -121,18 +125,26 @@ fun MenuBar(
     val floatingLabel = if (state.isFloatingMode) "退出悬浮" else "悬浮模式"
     val floatingAction = callbacks.onFloatingModeToggle ?: {}
 
-    val menuItems = remember(darkModeIcon, darkModeLabel, state.isFloatingMode) {
+    // 动态方案开关：图标取第一个状态的首字；标题若有 abbrev 则用 abbrev（多个用 🔁 连接），否则用所有状态 🔁 连接
+    val switchItems = state.schemaSwitches.map { sw ->
+        val textIcon = sw.states.firstOrNull()?.firstOrNull()?.toString() ?: ""
+        val label = if (sw.abbrev.isNotEmpty()) sw.abbrev.joinToString("🔁")
+            else sw.states.joinToString("🔁")
+        MenuItem(icon = null, label = label, action = { callbacks.onToggleSchemaSwitch?.invoke(sw) }, textIcon = textIcon)
+    }
+
+    val menuItems = remember(darkModeIcon, darkModeLabel, state.isFloatingMode, state.schemaSwitches) {
         listOf(
             MenuItem(clipboardIcon, "剪贴板", callbacks.onClipboard),
             MenuItem(quickSendIcon, "快捷发送", callbacks.onQuickSend),
-            MenuItem(keyboardResizeIcon, "键盘调节", callbacks.onKeyboardResize),
-            MenuItem(emojiIcon, "表情", callbacks.onEmoji),
-            MenuItem(floatingIcon, floatingLabel, floatingAction),
-            MenuItem(darkModeIcon, darkModeLabel, callbacks.onToggleDarkMode),
-            MenuItem(deployIcon, "部署方案", callbacks.onReloadConfig),
             MenuItem(schemaIcon, "输入方案", callbacks.onSchemaList),
+            MenuItem(emojiIcon, "表情", callbacks.onEmoji),
+        ) + switchItems + listOf(
             MenuItem(customizeIcon, "定制工具栏", callbacks.onToolbarCustomize),
-            MenuItem(settingsIcon, "设置", callbacks.onSettings)
+            MenuItem(keyboardResizeIcon, "键盘调节", callbacks.onKeyboardResize),
+            MenuItem(darkModeIcon, darkModeLabel, callbacks.onToggleDarkMode),
+            MenuItem(floatingIcon, floatingLabel, floatingAction),
+            MenuItem(deployIcon, "部署方案", callbacks.onReloadConfig),
         )
     }
     Column(
@@ -141,12 +153,13 @@ fun MenuBar(
             .background(state.backgroundColor),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Box(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(50.dp)
                 .padding(horizontal = if (isLandscape) 50.dp else 8.dp),
-            contentAlignment = Alignment.CenterStart
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
@@ -159,6 +172,21 @@ fun MenuBar(
                 Icon(
                     imageVector = Icons.Default.KeyboardArrowUp,
                     contentDescription = "关闭菜单",
+                    tint = textColor,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                    .clickable { callbacks.onSettings() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = settingsIcon,
+                    contentDescription = "设置",
                     tint = textColor,
                     modifier = Modifier.size(24.dp)
                 )
@@ -270,12 +298,22 @@ fun MenuItemButton(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Icon(
-            painter = item.icon,
-            contentDescription = item.label,
-            tint = textColor.copy(alpha = 0.7f),
-            modifier = Modifier.size(if (isLandscape) 18.dp else 24.dp)
-        )
+        if (item.textIcon != null) {
+            Text(
+                text = item.textIcon,
+                color = textColor.copy(alpha = 0.7f),
+                fontSize = if (isLandscape) 18.sp else 24.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1
+            )
+        } else if (item.icon != null) {
+            Icon(
+                painter = item.icon,
+                contentDescription = item.label,
+                tint = textColor.copy(alpha = 0.7f),
+                modifier = Modifier.size(if (isLandscape) 18.dp else 24.dp)
+            )
+        }
         Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = item.label,

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/KeyboardViewModel.kt
@@ -24,6 +24,19 @@ import com.kingzcheung.xime.ui.keyboard.initialKeyboardLayoutState
 
 enum class ShiftMode { OFF, SINGLE, CAPS }
 
+/**
+ * 菜单栏中动态展示的一个方案开关（来自 schema 的 `switches`）。
+ * [name] 非空为布尔开关，[options] 非空为多选一开关；[currentIndex] 为当前状态在 [states] 中的下标。
+ * [abbrev] 为自定义缩写（可能每个状态一个），用于菜单栏标题展示。
+ */
+data class SchemaSwitchUiState(
+    val name: String = "",
+    val options: List<String> = emptyList(),
+    val states: List<String> = emptyList(),
+    val abbrev: List<String> = emptyList(),
+    val currentIndex: Int = 0,
+)
+
 data class KeyboardUiState(
     val candidates: List<String> = emptyList(),
     val candidateComments: List<String> = emptyList(),
@@ -37,6 +50,7 @@ data class KeyboardUiState(
     val schemaName: String = "",
     val currentSchemaId: String = "",
     val schemas: List<SchemaInfo> = emptyList(),
+    val schemaSwitches: List<SchemaSwitchUiState> = emptyList(),
     val enterKeyText: String = "发送",
     val isDarkTheme: Boolean = false,
     val darkMode: Int = 2,

--- a/app/src/test/java/com/kingzcheung/xime/settings/SchemaYamlParserTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/SchemaYamlParserTest.kt
@@ -1,7 +1,10 @@
 package com.kingzcheung.xime.settings
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -135,5 +138,194 @@ class SchemaYamlParserTest {
         """.trimIndent())
         val meta = SchemaManager.parseSchemaYaml(f)
         assertNull(meta)
+    }
+
+    @Test
+    fun `extract switches with name and states`() {
+        val content = """
+            schema:
+              schema_id: pinyin_simp
+              name: 简体拼音
+            switches:
+              - name: ascii_mode
+                reset: 0
+                states: [ 中文, 西文 ]
+              - name: full_shape
+                states: [ 半角, 全角 ]
+            engine:
+              processors:
+                - ascii_composer
+        """.trimIndent()
+        val block = SchemaManager.extractSwitchesBlock(content)
+        assertNotNull(block)
+        assertTrue(block!!.contains("- name: ascii_mode"))
+        assertTrue(block.contains("- name: full_shape"))
+        assertFalse(block.contains("engine:"))
+    }
+
+    @Test
+    fun `extract switches with options`() {
+        val content = """
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+            switches:
+              - options: [ zh_simp, zh_trad ]
+                states: [ 简, 繁 ]
+        """.trimIndent()
+        val block = SchemaManager.extractSwitchesBlock(content)
+        assertNotNull(block)
+        assertTrue(block!!.contains("- options:"))
+        assertTrue(block.contains("zh_simp"))
+    }
+
+    @Test
+    fun `extract switches null when absent`() {
+        val content = """
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+        """.trimIndent()
+        assertNull(SchemaManager.extractSwitchesBlock(content))
+    }
+
+    @Test
+    fun `getSchemaSwitches maps to public model`() {
+        val f = writeSchema("""
+            schema:
+              schema_id: pinyin_simp
+              name: 简体拼音
+            switches:
+              - name: ascii_mode
+                states: [ 中文, 西文 ]
+              - name: full_shape
+                states: [ 半角, 全角 ]
+              - options: [ zh_simp, zh_trad ]
+                states: [ 简, 繁 ]
+              - command: foo
+                states: [ A, B ]
+        """.trimIndent())
+        val switches = SchemaManager.parseSchemaSwitches(f)
+        assertEquals(3, switches.size)
+        assertEquals("ascii_mode", switches[0].name)
+        assertEquals(emptyList<String>(), switches[0].options)
+        assertEquals(listOf("中文", "西文"), switches[0].states)
+        assertEquals("full_shape", switches[1].name)
+        assertEquals(emptyList<String>(), switches[1].options)
+        assertEquals(listOf("半角", "全角"), switches[1].states)
+        assertEquals("", switches[2].name)
+        assertEquals(listOf("zh_simp", "zh_trad"), switches[2].options)
+        assertEquals(listOf("简", "繁"), switches[2].states)
+    }
+
+    @Test
+    fun `getSchemaSwitches ignores switches without states`() {
+        val f = writeSchema("""
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+            switches:
+              - name: no_states
+        """.trimIndent())
+        val switches = SchemaManager.parseSchemaSwitches(f)
+        assertEquals(emptyList<SchemaSwitch>(), switches)
+    }
+
+    @Test
+    fun `getSchemaSwitches parses abbrev as list`() {
+        val f = writeSchema("""
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+            switches:
+              - name: search_single_char
+                states: [ 正常, 单字 ]
+                abbrev: [ 词, 单 ]
+        """.trimIndent())
+        val switches = SchemaManager.parseSchemaSwitches(f)
+        assertEquals(1, switches.size)
+        assertEquals(listOf("词", "单"), switches[0].abbrev)
+        assertEquals(emptyList<String>(), switches[0].options)
+    }
+
+    @Test
+    fun `getSchemaSwitches parses abbrev as scalar`() {
+        val f = writeSchema("""
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+            switches:
+              - name: traditionalization
+                states: [ 简, 繁 ]
+                abbrev: 繁
+        """.trimIndent())
+        val switches = SchemaManager.parseSchemaSwitches(f)
+        assertEquals(1, switches.size)
+        assertEquals(listOf("繁"), switches[0].abbrev)
+    }
+
+    @Test
+    fun `getSchemaSwitches abbrev empty when absent`() {
+        val f = writeSchema("""
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+            switches:
+              - name: ascii_mode
+                states: [ 中, Ａ ]
+        """.trimIndent())
+        val switches = SchemaManager.parseSchemaSwitches(f)
+        assertEquals(1, switches.size)
+        assertEquals(emptyList<String>(), switches[0].abbrev)
+    }
+
+    @Test
+    fun `getSchemaSwitches empty when file missing`() {
+        val f = File(tempDir.root, "missing.schema.yaml")
+        assertEquals(emptyList<SchemaSwitch>(), SchemaManager.parseSchemaSwitches(f))
+    }
+
+    @Test
+    fun `parses realistic config with inline comments and option groups`() {
+        val f = writeSchema("""
+            schema:
+              schema_id: test_schema
+              name: Test Schema
+            switches:
+              - name: ascii_mode  # 中英输入状态
+                states: [中文, 英文]
+              - name: full_shape  #全角、半角字符输出
+                states: [半角, 全角]
+              - options: [raw_input, tone_display, full_pinyin]  # 归属 super_preedit.lua
+                states: [原编码, 有声调, 无声调]
+                #    reset: 2
+              - options: [s2s, s2t, s2hk, s2tw]  # 简繁转换开关组
+                states: [简体, 通繁, 港繁, 臺繁]
+              - name: abbrev
+                states: [简码关, 简码开]
+                reset: 1
+        """.trimIndent())
+        val switches = SchemaManager.parseSchemaSwitches(f)
+        assertEquals(5, switches.size)
+
+        // name 开关：states 保留完整字符串
+        assertEquals("ascii_mode", switches[0].name)
+        assertEquals(listOf("中文", "英文"), switches[0].states)
+
+        assertEquals("full_shape", switches[1].name)
+        assertEquals(listOf("半角", "全角"), switches[1].states)
+
+        // options 开关：3 个选项 3 个状态
+        assertEquals("", switches[2].name)
+        assertEquals(listOf("raw_input", "tone_display", "full_pinyin"), switches[2].options)
+        assertEquals(listOf("原编码", "有声调", "无声调"), switches[2].states)
+
+        // options 开关：4 个选项 4 个状态
+        assertEquals("", switches[3].name)
+        assertEquals(listOf("s2s", "s2t", "s2hk", "s2tw"), switches[3].options)
+        assertEquals(listOf("简体", "通繁", "港繁", "臺繁"), switches[3].states)
+
+        assertEquals("abbrev", switches[4].name)
+        assertEquals(listOf("简码关", "简码开"), switches[4].states)
     }
 }

--- a/docs/config_examples/theme/xime.custom.yaml
+++ b/docs/config_examples/theme/xime.custom.yaml
@@ -9,6 +9,8 @@ metadata:
 # `color_schemes` 配色方案：
 # - name / primary_color：必填
 # - keyboard_background：可选，背景类型（纯色/渐变/图片），不填则使用 keyboard.colors 全局默认
+# - key_bg_color / key_text_color / candidate_text_color 及其 _dark 变体：可选，覆盖按键、
+#   按键文字、候选文字颜色；不填则使用全局默认
 #
 # 纯色背景：
 #   keyboard_background:
@@ -21,14 +23,22 @@ metadata:
 #     type: gradient
 #     colors: [0xRRGGBB, ...]     # 亮色渐变断点（至少 2 个）
 #     colors_dark: [0xRRGGBB, ...] # 暗色渐变断点（可选）
-#     angle: 135                   # 角度制，0=左→右，90=下→上
+#     angle: 90                    # 角度制，0=左→右，90=下→上
 #
 # 图片背景：
 #   keyboard_background:
 #     type: image
-#     src: "themes/bg.png"          # 相对于 assets/
+#     src: "themes/bg.png"         # 相对于 rime/ 用户目录（优先）或 assets/（回退）
 #     src_dark: "themes/bg_night.png" # 暗色变体（可选）
-#     fit: cover                    # cover | contain | fill | fit_width | fit_height | none
+#     fit: cover                   # cover | contain | fill | fit_width | fit_height | none
+#     overlay_alpha: 0.35          # 背景遮罩强度（0~1），半透明黑色覆盖层压暗背景，改善文字可读性
+#     overlay_alpha_dark: 0.5      # 暗色模式下的遮罩强度（可选，不填则沿用 overlay_alpha）
+#
+# 自定义图片背景的两种方式：
+# 1. 在系统相册/文件管理中把图片「分享到 Xime」，图片自动存入 rime/themes/custom_<时间戳>.jpg，
+#    并把可用的 color_schemes 配置模板复制到剪贴板，粘贴到 xime.custom.yaml 即可在主题设置中选择。
+# 2. 手动把图片放入 rime/themes/（如通过 USB 或文件管理器），再在 xime.custom.yaml 中引用它。
+#    内置主题的同名文件会被用户目录中的文件覆盖。
 
 color_schemes:
 style:
@@ -71,3 +81,19 @@ color_schemes:
       type: solid
       color: 0xE8E8E8
       color_dark: 0x121212
+
+  zine_photo:
+    name: "夜幕之影"
+    primary_color: 0x8F73E2
+    keyboard_background:
+      type: image
+      src: "themes/llh-silhouette-bg.jpg"
+      fit: cover
+      overlay_alpha: 0.15
+      overlay_alpha_dark: 0.30
+    key_bg_color: 0x8cffffff
+    key_bg_color_dark: 0x5affffff
+    key_text_color: 0x232323
+    key_text_color_dark: 0xf2f2f2
+    candidate_text_color: 0x232323
+    candidate_text_color_dark: 0xf2f2f2


### PR DESCRIPTION
- 新增 SchemaSwitchUiState 数据类用于表示方案开关状态
- 在 InputUIState 中添加 schemaSwitches 字段
- 实现 loadSchemaSwitches、refreshSchemaSwitches 和 toggleSchemaSwitch 方法
- 支持解析 schema YAML 文件中的 switches 配置
- 在菜单栏中动态显示方案开关项

feat(settings): 扩展 SchemaManager 解析功能

- 添加 SchemaSwitch 数据类定义
- 实现 parseSchemaSwitches 方法解析 YAML 格式的 switches
- 添加 extractSwitchesBlock 方法提取开关配置块
- 提供 getSchemaSwitches 接口获取指定方案的开关配置

feat(ui): 增强菜单栏方案开关交互

- 在 MenuBar 组件中添加 schemaSwitches 支持
- 修改 MenuItem 数据结构支持文本图标显示
- 实现方案开关按钮的动态渲染和点击处理
- 调整菜单项布局顺序和样式

test: 添加方案开关解析相关单元测试

- 测试 extractSwitchesBlock 方法的各种场景
- 验证 getSchemaSwitches 对不同配置格式的解析
- 测试 abbrev 缩写字段的不同解析方式
- 验证真实配置文件的解析结果

docs: 更新自定义主题配置文档

- 补充键盘背景配置说明
- 添加自定义图片背景使用方法
- 说明 overlay_alpha 遮罩参数配置
- 增加配色方案颜色属性说明

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
