### PR TITLE
fix(onnx): 实现tokenizer最长匹配算法以提升编码准确性，对齐联想功能python 版本实验。

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -11,8 +11,8 @@ xime_index:
   # 可替换为自建代理/镜像，下载器按顺序依次尝试，直到成功为止。
   # 末尾需要 /。
   base_urls:
-    - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index@master/"
-    - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    # - "https://cdn.jsdelivr.net/gh/ximeiorg/xime-index@master/"
+    # - "https://fastly.jsdelivr.net/gh/ximeiorg/xime-index@master/"
     - "https://index.ximei.me/"
     - "https://raw.githubusercontent.com/ximeiorg/xime-index/refs/heads/main/"
 

--- a/app/src/main/jni/onnx_jni.cc
+++ b/app/src/main/jni/onnx_jni.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #define LOG_TAG "OnnxJNI"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
@@ -25,6 +26,49 @@ static std::unordered_map<std::string, int64_t> g_vocab;
 static std::vector<std::string> g_id2word;
 static int64_t g_bos_id = 1;
 static int64_t g_unk_id = 3;
+
+// 多字 token 最长匹配索引：key = token 首字符，value = 该首字符下的多字 token，按长度降序。
+// 与 Python SimpleTokenizer 的 _build_multi_index 逻辑一致，用于 encode 时最长匹配优先。
+static std::unordered_map<std::string, std::vector<std::string>> g_multi_index;
+static size_t g_max_multi_len = 0;
+
+// 计算一个 UTF-8 字符串的字符数（不是字节数），与 Python len() 一致。
+static size_t Utf8CharCount(const std::string& s) {
+    size_t count = 0;
+    for (unsigned char c : s) {
+        if ((c & 0xC0) != 0x80) count++;  // 非续字节即新字符开头
+    }
+    return count;
+}
+
+// 构建多字 token 索引，与 Python SimpleTokenizer._build_multi_index 对齐。
+static void BuildMultiIndex() {
+    g_multi_index.clear();
+    g_max_multi_len = 0;
+    for (const auto& pair : g_vocab) {
+        const std::string& token = pair.first;
+        if (token.empty()) continue;
+        size_t char_len = Utf8CharCount(token);
+        if (char_len <= 1) continue;
+        if (token == "[PAD]" || token == "[BOS]" || token == "[EOS]" || token == "[UNK]") continue;
+        // 取 token 的首字符（UTF-8）
+        unsigned char c0 = static_cast<unsigned char>(token[0]);
+        int first_len;
+        if ((c0 & 0x80) == 0) first_len = 1;
+        else if ((c0 & 0xE0) == 0xC0) first_len = 2;
+        else if ((c0 & 0xF0) == 0xE0) first_len = 3;
+        else first_len = 4;
+        std::string first = token.substr(0, first_len);
+        g_multi_index[first].push_back(token);
+        if (char_len > g_max_multi_len) g_max_multi_len = char_len;
+    }
+    for (auto& entry : g_multi_index) {
+        std::sort(entry.second.begin(), entry.second.end(),
+                  [](const std::string& a, const std::string& b) {
+                      return Utf8CharCount(a) > Utf8CharCount(b);
+                  });
+    }
+}
 
 // Lazily create a CPU-only fallback session. Used when the NNAPI/GPU session
 // fails at runtime on devices without a working NNAPI driver, so inference
@@ -91,8 +135,10 @@ Java_com_kingzcheung_xime_association_NativeOnnxEngine_nativeInitVocab(
 
     g_bos_id = g_vocab.count("[BOS]") ? g_vocab["[BOS]"] : 1;
     g_unk_id = g_vocab.count("[UNK]") ? g_vocab["[UNK]"] : 3;
+    BuildMultiIndex();
 
-    LOGI("Vocab loaded: %zu tokens, max_id=%lld", g_vocab.size(), (long long)max_id);
+    LOGI("Vocab loaded: %zu tokens, max_id=%lld, multi-token groups=%zu",
+         g_vocab.size(), (long long)max_id, g_multi_index.size());
 
     env->ReleaseIntArrayElements(values, val_arr, JNI_ABORT);
 }
@@ -107,32 +153,58 @@ Java_com_kingzcheung_xime_association_NativeOnnxEngine_nativeEncode(
     const char* utf8_text = env->GetStringUTFChars(text, nullptr);
     jsize utf8_len = env->GetStringUTFLength(text);
 
+    // 先把 UTF-8 按字符切分成字符序列（与 Python 逐字符索引一致）
+    std::vector<std::string> chars;
+    {
+        const char* p = utf8_text;
+        const char* end = utf8_text + utf8_len;
+        while (p < end) {
+            unsigned char c = static_cast<unsigned char>(*p);
+            int char_len;
+            if ((c & 0x80) == 0) char_len = 1;
+            else if ((c & 0xE0) == 0xC0) char_len = 2;
+            else if ((c & 0xF0) == 0xE0) char_len = 3;
+            else if ((c & 0xF8) == 0xF0) char_len = 4;
+            else { chars.emplace_back(p, 1); p++; continue; }
+            if (p + char_len > end) char_len = static_cast<int>(end - p);
+            chars.emplace_back(p, char_len);
+            p += char_len;
+        }
+    }
+    env->ReleaseStringUTFChars(text, utf8_text);
+
     std::vector<int64_t> ids;
     ids.push_back(g_bos_id);
 
-    const char* p = utf8_text;
-    const char* end = utf8_text + utf8_len;
-    while (p < end) {
-        unsigned char c = static_cast<unsigned char>(*p);
-        int char_len;
-        if ((c & 0x80) == 0) char_len = 1;
-        else if ((c & 0xE0) == 0xC0) char_len = 2;
-        else if ((c & 0xF0) == 0xE0) char_len = 3;
-        else if ((c & 0xF8) == 0xF0) char_len = 4;
-        else {
-            ids.push_back(g_unk_id);
-            p++;
-            continue;
+    // 最长匹配优先：与 Python SimpleTokenizer.encode 一致
+    size_t i = 0, n = chars.size();
+    while (i < n) {
+        const std::string& c = chars[i];
+        bool matched = false;
+        auto it = g_multi_index.find(c);
+        if (it != g_multi_index.end() && n - i >= 2) {
+            for (const std::string& token : it->second) {
+                size_t tlen = Utf8CharCount(token);
+                if (i + tlen > n) continue;
+                // 拼接 chars[i..i+tlen) 与 token 比较
+                std::string joined;
+                joined.reserve(token.size());
+                for (size_t k = i; k < i + tlen; k++) joined += chars[k];
+                if (joined == token) {
+                    auto vit = g_vocab.find(token);
+                    ids.push_back(vit != g_vocab.end() ? vit->second : g_unk_id);
+                    i += tlen;
+                    matched = true;
+                    break;
+                }
+            }
         }
-        if (p + char_len > end) char_len = static_cast<int>(end - p);
-
-        std::string ch(p, char_len);
-        auto it = g_vocab.find(ch);
-        ids.push_back(it != g_vocab.end() ? it->second : g_unk_id);
-        p += char_len;
+        if (!matched) {
+            auto vit = g_vocab.find(c);
+            ids.push_back(vit != g_vocab.end() ? vit->second : g_unk_id);
+            i++;
+        }
     }
-
-    env->ReleaseStringUTFChars(text, utf8_text);
 
     jlongArray result = env->NewLongArray(ids.size());
     env->SetLongArrayRegion(result, 0, ids.size(), ids.data());


### PR DESCRIPTION
- 添加UTF-8字符计数函数Utf8CharCount，正确计算多字节字符数量
- 实现BuildMultiIndex函数构建多字token索引，支持最长匹配优先策略
- 在encode过程中先将文本按字符切分，再进行最长匹配查找
- 添加unordered_set头文件支持相关数据结构操作
- 更新日志输出显示多token组统计信息

refactor(yaml): 注释jsdelivr CDN链接避免网络访问问题

- 将CDN链接注释掉，保留备用镜像地址
- 维持原有配置结构不变

chore(submodules): 更新librime子模块状态标记

- 标记librime、librime-lua和librime-lua-deps为dirty状态
- 反映本地修改情况

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
