### PR TITLE
fix(keyboard): 修复候选词页面背景颜色显示问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidatePage.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidatePage.kt
@@ -255,7 +255,6 @@ fun CandidatePageItem(
 
         modifier = modifier
             .clip(RoundedCornerShape(6.dp))
-//            .background(textColor.copy(alpha = 0.1f))
             .clickable(onClick = onClick)
             .padding(horizontal = 4.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -930,7 +930,7 @@ fun KeyboardView(
                             candidates = state.candidates.toList(),
                             candidateComments = state.candidateComments.toList(),
                             associationCandidates = state.associationCandidates.toList(),
-                            backgroundColor = Color.Transparent,
+                            backgroundColor = keyboardBgColor,
                             textColor = candidateTextColor,
                             hasNextPage = state.hasNextPage,
                             hasPrevPage = state.hasPrevPage,


### PR DESCRIPTION
移除了CandidatePage中被注释的背景色设置，同时将KeyboardView中的
候选词背景颜色从透明改为使用键盘背景颜色变量，确保视觉一致性。

fix(jni): 更新子项目依赖到最新状态

更新librime、librime-lua和librime-lua-deps子项目的提交状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #555 （填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
