### PR TITLE
feat(RimeConfigHelper): 为合并词典文件添加哈希计算支持

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -128,6 +128,12 @@ object RimeConfigHelper {
             if (customFile.exists()) {
                 fileUpdateDigest(digest, customFile)
             }
+            // merged dict 由 app 生成、librime 实际编译，计入 hash 以便其变更（如转发器展开修复）触发重编译
+            val mergedDictFile = File(rimeDir, "${schemaId}_merged.dict.yaml")
+            if (mergedDictFile.exists()) {
+                digest.update("${schemaId}_merged".toByteArray())
+                fileUpdateDigest(digest, mergedDictFile)
+            }
         }
 
         val defaultYaml = File(rimeDir, "default.yaml")

--- a/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/PersonalDictManager.kt
@@ -242,16 +242,11 @@ use_preset_vocabulary: false
             if (dictFile.exists()) dictFile.delete()
             return
         }
-        dictFile.writeText("""# Rime dict
----
-name: $mergedId
-version: "1.0"
-sort: original
-import_tables:
-  - $dictName
-  - $pkName
-...
-""", Charsets.UTF_8)
+        // 源词典若是转发器（自身仅 import_tables，无内联词条），需展开其叶子表，
+        // 否则 librime 只解析 merged dict 一层的 import_tables、不递归，导致收集到 0 词条编译失败。
+        val leafTables = readImportTables(srcDictFile)
+        val importTables = (if (leafTables.isNotEmpty()) leafTables else listOf(dictName)) + pkName
+        dictFile.writeText(buildMergedDictText(mergedId, importTables), Charsets.UTF_8)
         val customFile = java.io.File(rimeDir, "${schemaId}.custom.yaml")
         val entry = "  \"translator/dictionary\": $mergedId\n"
         if (customFile.exists()) {
@@ -266,6 +261,48 @@ import_tables:
             }
         }
         insertUnderPatch(customFile, entry)
+    }
+
+    /** 从源词典文件读取其 `import_tables` 列表（转发器场景）。没有则返回空。 */
+    internal fun readImportTables(dictFile: java.io.File): List<String> {
+        if (!dictFile.exists()) return emptyList()
+        return try {
+            val text = dictFile.readText(Charsets.UTF_8)
+            val tables = mutableListOf<String>()
+            var inImportTables = false
+            for (raw in text.lineSequence()) {
+                val trimmed = raw.trim()
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) continue
+                if (trimmed.startsWith("import_tables:")) {
+                    inImportTables = true
+                    continue
+                }
+                if (inImportTables && trimmed.startsWith("- ")) {
+                    val name = trimmed.removePrefix("- ").trim()
+                        .removeSurrounding("\"").removeSurrounding("'")
+                    if (name.isNotEmpty()) tables.add(name)
+                } else if (inImportTables && !trimmed.startsWith("- ")) {
+                    inImportTables = false
+                }
+            }
+            tables
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    /** 生成 merged dict 文件内容，import_tables 按给定列表展开。 */
+    private fun buildMergedDictText(mergedId: String, importTables: List<String>): String {
+        val tables = importTables.joinToString("\n") { "  - $it" }
+        return """# Rime dict
+---
+name: $mergedId
+version: "1.0"
+sort: original
+import_tables:
+$tables
+...
+"""
     }
 
     /** 提取 patch 块中本代码之前写入的 key 的值（user_* 或旧版 user_simp_*），没有则返回 null。 */

--- a/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/PersonalDictManagerTest.kt
@@ -666,6 +666,32 @@ speller:
         assertEquals(1, text.split("wubi86_merged").size - 1)
     }
 
+    @Test
+    fun `applyMergedDictConfig expands forwarder source dict import_tables`() {
+        val rimeDir = createTempDir()
+        // 转发器：源词典自身无内联词条，仅 import_tables 引用子目录叶子表
+        java.io.File(rimeDir, "wubi98_mint.dict.yaml").writeText(
+            "---\nname: wubi98_mint\nversion: \"1.0\"\nsort: by_weight\nimport_tables:\n  - dicts/wubi98_base\n  - dicts/other_kaomoji\n...\n",
+            Charsets.UTF_8
+        )
+        PersonalDictManager.applyMergedDictConfig(rimeDir, "wubi98_mint")
+        val dictText = File(rimeDir, "wubi98_mint_merged.dict.yaml").readText(Charsets.UTF_8)
+        // 必须展开叶子表，而非引用转发器自身
+        assertTrue(dictText.contains("- dicts/wubi98_base"))
+        assertTrue(dictText.contains("- dicts/other_kaomoji"))
+        assertTrue(dictText.contains("- user_wubi98_mint"))
+        assertFalse("merged dict must not reference the forwarder itself", dictText.contains("- wubi98_mint\n"))
+    }
+
+    @Test
+    fun `readImportTables returns empty for flat dict`() {
+        val rimeDir = createTempDir()
+        val flat = java.io.File(rimeDir, "wubi86.dict.yaml")
+        flat.writeText("name: wubi86\nversion: \"1.0\"\nsort: original\n...\n工\ta\n", Charsets.UTF_8)
+        val result = PersonalDictManager.run { readImportTables(flat) }
+        assertTrue(result.isEmpty())
+    }
+
     // ── insertUnderPatch 合入逻辑 ──
 
     @Test


### PR DESCRIPTION
当 schema 对应的 merged dict 文件存在时，将其纳入哈希计算，
确保转发器展开等变更能够触发重新编译

feat(PersonalDictManager): 支持展开转发器词典的 import_tables

修改合并词典生成功能，当源词典是转发器（仅有 import_tables 而无内联词条）
时，会递归解析并展开其叶子表，避免 librime 编译时因无法递归解析而失败

refactor(PersonalDictManager): 添加导入表解析和合并文本构建函数

新增 readImportTables 函数用于解析词典文件中的 import_tables 列表
新增 buildMergedDictText 函数用于按指定列表生成合并词典内容

test(PersonalDictManager): 添加转发器词典展开相关测试用例

增加测试验证转发器词典的 import_tables 展开功能和普通词典的处理

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
