### PR TITLE
fix(t9): 实现退格先回退半提交（预编辑恢复为拼音）再删除输入序列的功能

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,7 @@ android {
         applicationId = "com.kingzcheung.xime"
         minSdk = 28
         targetSdk = 35
-        versionCode = 20260802
+        versionCode = 20260803
         versionName = "2.6.0-beta3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/androidTest/java/com/kingzcheung/xime/rime/T9ProcessorIntegrationTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/rime/T9ProcessorIntegrationTest.kt
@@ -487,4 +487,90 @@ class T9ProcessorIntegrationTest {
         digits("5485426"); leftSelect("jiu", 3)
         android.util.Log.d(TAG, "scenario46: jiu jian partial, input='${input()}'")
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // 半提交（partial commit）退格回退回归测试
+    // 需求：九键拼音半提交上屏文字后按退格，应先回退半提交（预编辑恢复为拼音），
+    // 再删除输入序列末尾的拼音，由 t9WasCommitUndone() 标记半提交已回退。
+    // ═══════════════════════════════════════════════════════════
+
+    @Test fun test48_undoPartialCommitRestoresPreedit() {
+        // 54482 → 左选 ji → 右选"即"（partial commit，消费 54）→ 退格
+        // 期望：t9WasCommitUndone()==true，预编辑恢复为 54482 再删末尾=5448
+        digits("54482")
+        leftSelect("ji", 2)
+        if (rightSelectByText("即")) {
+            pressKey(0xff08)
+            assertTrue("backspace after partial commit should report commit undone",
+                engine.t9WasCommitUndone())
+            assertEquals("preedit should be full digits minus last pinyin",
+                "5448", input())
+        } else {
+            android.util.Log.w(TAG, "test48 skipped: candidate '即' not available")
+        }
+    }
+
+    @Test fun test49_secondBackspaceIsPlainDelete() {
+        // 半提交回退后，再一次退格只是删除拼音，不应再上报 commit undone
+        digits("54482")
+        leftSelect("ji", 2)
+        if (rightSelectByText("即")) {
+            pressKey(0xff08)
+            assertTrue(engine.t9WasCommitUndone())
+            pressKey(0xff08)
+            assertFalse("second backspace should be a plain pinyin delete",
+                engine.t9WasCommitUndone())
+        } else {
+            android.util.Log.w(TAG, "test49 skipped: candidate '即' not available")
+        }
+    }
+
+    @Test fun test50_plainBackspaceDoesNotUndoCommit() {
+        // 无半提交时，普通退格不应上报 commit undone
+        digits("54482")
+        pressKey(0xff08)
+        assertFalse("plain backspace should not report commit undone",
+            engine.t9WasCommitUndone())
+    }
+
+    @Test fun test51_chainedPartialUndo() {
+        // 连续两次半提交后，退格应逐次回退；最后一次退格为普通删除
+        digits("5143")
+        leftSelect("k", 1); leftSelect("g", 1)
+        if (rightSelectByText("客观")) {
+            press("3"); leftSelect("d", 1)
+            if (rightSelectByText("多")) {
+                pressKey(0xff08)
+                assertTrue("backspace 1 should undo '多'", engine.t9WasCommitUndone())
+                pressKey(0xff08)
+                assertTrue("backspace 2 should undo '客观'", engine.t9WasCommitUndone())
+                pressKey(0xff08)
+                assertFalse("backspace 3 should be plain delete", engine.t9WasCommitUndone())
+            } else {
+                android.util.Log.w(TAG, "test51 skipped: candidate '多' not available")
+            }
+        } else {
+            android.util.Log.w(TAG, "test51 skipped: candidate '客观' not available")
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // 回归：左选音节后右选候选，不得吞掉尾部未消费的拼音。
+    // 场景："给的吧"=4343322，选"给"半提交后剩 3322；左选 de(33) 后右选
+    // 一个 de 候选，尾部 22(吧) 必须保留为半提交，而非被 jianpin full commit 吞掉。
+    // ═══════════════════════════════════════════════════════════
+    @Test fun test52_jianpinSelectKeepsTrailingDigits() {
+        // 3322 = de ba。左选 de 消费 33，尾部 22 应为"吧"的拼音。
+        digits("3322")
+        leftSelect("de", 2)
+        val idx = candidates().indexOfFirst { it.second == "de" }
+        if (idx >= 0) {
+            val isFull = engine.t9SelectCandidate(idx)
+            assertFalse("选 de 候选时尾部 '22' 仍在，必须是 PARTIAL commit", isFull)
+            // 尾部 22 必须被保留在 digit buffer 中（partial commit 后 GetRemainingDigits）
+            assertEquals("尾部 '22'（吧）不能被吞掉", "22", engine.t9GetRemainingDigits())
+        } else {
+            android.util.Log.w(TAG, "test52 skipped: no 'de' candidate available")
+        }
+    }
 }

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -558,6 +558,7 @@ class RimeEngine {
     private external fun nativeT9GetSyllableCandidates(): Array<String>?
     private external fun nativeT9GetRemainingDigits(): String?
     private external fun nativeT9IsDisplayOriginalPreedit(): Boolean
+    private external fun nativeT9WasCommitUndone(): Boolean
 
     /**
      * 直接选择拼音：传入拼音和对应数字长度，t9_processor 替换 buffer。
@@ -589,6 +590,18 @@ class RimeEngine {
         if (!isInitialized) return false
         synchronized(rimeLock) {
             return nativeT9IsDisplayOriginalPreedit()
+        }
+    }
+
+    /**
+     * 查询并清除"最近一次退格撤销了 partial commit"标记。
+     * 返回 true 表示刚发生的退格先回退了半提交（上屏文字回到预编辑），
+     * 前端需据此清除累积的半提交文本，而不是当作普通删除未上屏拼音。
+     */
+    fun t9WasCommitUndone(): Boolean {
+        if (!isInitialized) return false
+        synchronized(rimeLock) {
+            return nativeT9WasCommitUndone()
         }
     }
 

--- a/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/T9InputController.kt
@@ -158,6 +158,13 @@ class T9InputController(
     fun onDeleted(): DeleteResult {
         val hadSelection = leftPanelState == LeftPanelState.SELECTION && selectedOption != null
         val result = rimeEngine.processKey(0xff08, 0)
+        // 退格可能先回退了半提交（上屏文字回到预编辑）再删除末尾拼音，
+        // 需优先返回 UNDO_COMMIT，让键盘层清除累积的半提交文本并刷新候选。
+        if (rimeEngine.t9WasCommitUndone()) {
+            onCompositionRefresh?.invoke()
+            updateFromRime()
+            return DeleteResult.UNDO_COMMIT
+        }
         onCompositionRefresh?.invoke()
         updateFromRime()
         // 退格撤销了左侧选择：从选择历史移除并清除选中高亮

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1159,14 +1159,15 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                             }
                                         }
                                     },
-                                    onT9RightCommitUndone = { count ->
+                                    onT9RightCommitUndone = {
                                         // 半提交文本在 composing 区域时无法用 deleteSurroundingText 删除，
                                         // 需通过 endComposingInputBox 清空，交由后续 applyComposition 重建。
+                                        val len = t9PartialCommitTexts.lastOrNull()?.length ?: 0
                                         if (SettingsPreferences.getInputTextLocation(this@XimeInputMethodService)
                                             == SettingsPreferences.INPUT_TEXT_INPUT_BOX) {
                                             endComposingInputBox()
-                                        } else {
-                                            currentInputConnection?.deleteSurroundingText(count, 0)
+                                        } else if (len > 0) {
+                                            currentInputConnection?.deleteSurroundingText(len, 0)
                                         }
                                         t9PartialCommitTexts.removeLastOrNull()
                                     },

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardCallbacks.kt
@@ -37,7 +37,11 @@ data class KeyboardCallbacks(
     val onFloatingKeyboardDrag: ((dx: Float, dy: Float) -> Unit)? = null,
     val onFloatingKeyboardDragEnd: (() -> Unit)? = null,
     val onT9ReplaceFullPinyin: ((String) -> Unit)? = null,
-    val onT9RightCommitUndone: ((Int) -> Unit)? = null,
+    /**
+     * 回退最近一次 T9 半提交：清除累积的半提交文本（及输入框中已上屏的文字）。
+     * 服务层根据 t9PartialCommitTexts 计算需回删的文本长度。
+     */
+    val onT9RightCommitUndone: (() -> Unit)? = null,
     /**
      * 右侧候选词即将被 RIME select 前同步通知 T9 控制器。
      * 返回 true 表示控制器判断输入序列已被该候选词完整消费。

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/T9KeyboardLayout.kt
@@ -114,7 +114,9 @@ fun T9KeyboardLayout(
     fun handleDelete() {
         when (val result = controller.onDeleted()) {
             T9InputController.DeleteResult.UNDO_COMMIT -> {
-                controller.clearRimeAndResend()
+                // 半提交回退：清除累积的半提交文本（及输入框中已上屏的文字），
+                // 控制器已在 onDeleted() 中重新同步 RIME 预编辑（恢复为拼音并删除末尾拼音）。
+                callbacks.onT9RightCommitUndone?.invoke()
             }
 
             T9InputController.DeleteResult.NOT_CONSUMED -> {

--- a/app/src/main/jni/librime-t9/src/t9_digit_buffer.cc
+++ b/app/src/main/jni/librime-t9/src/t9_digit_buffer.cc
@@ -39,6 +39,24 @@ bool T9DigitBuffer::UndoLastSelection() {
     return true;
 }
 
+void T9DigitBuffer::PushCommit(const std::string& consumed) {
+    commits_.push_back(consumed);
+}
+
+bool T9DigitBuffer::UndoLastCommit() {
+    if (commits_.empty()) return false;
+    const std::string prefix = commits_.back();
+    commits_.pop_back();
+    raw_digits_ = prefix + raw_digits_;
+    return true;
+}
+
+void T9DigitBuffer::ResetForPartial(const std::string& remaining) {
+    raw_digits_ = remaining;
+    selections_.clear();
+    separator_pending_ = false;
+}
+
 bool T9DigitBuffer::IsFullyConsumed() const {
     return ConsumedCount() >= static_cast<int>(raw_digits_.size());
 }
@@ -82,5 +100,6 @@ std::string T9DigitBuffer::GetRemainingDigits() const {
 void T9DigitBuffer::Clear() {
     raw_digits_.clear();
     selections_.clear();
+    commits_.clear();
     separator_pending_ = false;
 }

--- a/app/src/main/jni/librime-t9/src/t9_digit_buffer.h
+++ b/app/src/main/jni/librime-t9/src/t9_digit_buffer.h
@@ -18,6 +18,14 @@ public:
     bool SelectPinyin(const std::string& pinyin, int digit_length);
     bool UndoLastSelection();
 
+    // Partial commit 撤销支持：记录每次 partial commit 消费掉的数字前缀，
+    // 供退格先撤销半提交（把该段数字恢复到预编辑），再删除末尾拼音。
+    void PushCommit(const std::string& consumed);
+    bool UndoLastCommit();          // 撤销最近一次 partial commit，返回是否成功
+    bool HasCommits() const { return !commits_.empty(); }
+    // 仅清空 raw_digits_ / selections_ / separator，保留 commits_（供 partial commit 重建 buffer 用）
+    void ResetForPartial(const std::string& remaining);
+
     bool IsEmpty() const { return raw_digits_.empty(); }
     bool IsFullyConsumed() const;
     int ConsumedCount() const;
@@ -31,6 +39,7 @@ public:
 private:
     std::string raw_digits_;
     std::vector<SyllableSelection> selections_;
+    std::vector<std::string> commits_;
     bool separator_pending_ = false;
 };
 

--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -57,6 +57,7 @@ ProcessResult T9Processor::ProcessKeyEvent(const KeyEvent& key_event) {
         T9LOG("State sync: clearing stale digit buffer ('%s')", digit_buffer_.ToInput().c_str());
         digit_buffer_.Clear();
     }
+    commit_undone_ = false;
 
     // Digit keys: push to input through normal RIME pipeline
     if (ch >= '2' && ch <= '9') {
@@ -87,11 +88,31 @@ ProcessResult T9Processor::ProcessKeyEvent(const KeyEvent& key_event) {
         return kNoop;
     }
 
-    // BackSpace: remove last digit
+    // BackSpace: remove last digit; if a partial commit is pending, first undo it
+    // (restore its consumed digits back to pre-edit), then delete the last pinyin.
     if (ch == 0xff08 || ch == 0x08) {
-        if (digit_buffer_.IsEmpty()) {
-            T9LOG("BackSpace: digit buffer empty, passing through");
+        commit_undone_ = false;
+        if (digit_buffer_.IsEmpty() && !digit_buffer_.HasCommits()) {
+            T9LOG("BackSpace: buffer empty, passing through");
             return kNoop;
+        }
+        if (digit_buffer_.HasCommits()) {
+            // 先回退半提交：把最近一次 partial commit 消费的数字段恢复到预编辑。
+            digit_buffer_.UndoLastCommit();
+            // 再删除输入序列末尾的拼音。
+            if (!digit_buffer_.IsEmpty()) {
+                digit_buffer_.PopLastDigit();
+            }
+            std::string new_input = digit_buffer_.ToInput();
+            if (new_input.empty()) {
+                ctx->Clear();
+                T9LOG("BackSpace: undo commit, buffer empty, cleared");
+            } else {
+                ctx->set_input(new_input);
+                T9LOG("BackSpace: undo commit -> set_input('%s')", new_input.c_str());
+            }
+            commit_undone_ = true;
+            return kAccepted;
         }
         if (digit_buffer_.PopLastDigit()) {
             string before = ctx->input();
@@ -277,17 +298,18 @@ bool T9Processor::SelectCandidate(int candidate_index) {
         string remaining = digit_buffer_.raw_digits().substr(consumed);
         T9LOG("SelectCandidate: releasing excess, covered=%zu consumed=%d remaining='%s'",
               covered, consumed, remaining.c_str());
-        digit_buffer_.Clear();
-        for (char d : remaining) {
-            digit_buffer_.AppendDigit(d);
-        }
+        digit_buffer_.PushCommit(digit_buffer_.raw_digits().substr(0, consumed));
+        digit_buffer_.ResetForPartial(remaining);
         return false;
     }
 
-    // Jianpin alignment: selection initials match comment syllable initials
-    // Full commit only when comment syllables cover ALL remaining digits
+    // Jianpin alignment: selection initials match comment syllable initials.
+    // Full commit only when the comment's full pinyin covers ALL input digits
+    // (raw_digits), so trailing unconsumed digits (the next syllable's pinyin)
+    // are NOT swallowed. Comparing against remaining_digits here is wrong: that
+    // counts the digits AFTER the selections, which the comment does not cover.
     if (comment_syllables.size() >= digit_buffer_.selections().size() &&
-        comment_digit_count >= remaining_digits) {
+        comment_digit_count >= static_cast<int>(digit_buffer_.raw_digits().size())) {
         bool jianpin_aligned = true;
         for (size_t i = 0; i < digit_buffer_.selections().size(); ++i) {
             char sel_initial = digit_buffer_.selections()[i].pinyin[0];
@@ -318,6 +340,8 @@ bool T9Processor::SelectCandidate(int candidate_index) {
             remaining = unconsumed.substr(consumed_by_comment);
             T9LOG("SelectCandidate: partial commit, consuming=%d resetting buffer to remaining='%s'",
                   consumed_by_comment, remaining.c_str());
+            digit_buffer_.PushCommit(unconsumed.substr(0, consumed_by_comment));
+            digit_buffer_.ResetForPartial(remaining);
         } else {
             // The candidate comment covers all digits → full commit.
             T9LOG("SelectCandidate: partial commit consumed all digits, full commit");
@@ -350,10 +374,8 @@ bool T9Processor::SelectCandidate(int candidate_index) {
         remaining = digit_buffer_.raw_digits().substr(consumed);
         T9LOG("SelectCandidate: partial commit (selections), covered=%zu consumed=%d remaining='%s'",
               covered, consumed, remaining.c_str());
-    }
-    digit_buffer_.Clear();
-    for (char d : remaining) {
-        digit_buffer_.AppendDigit(d);
+        digit_buffer_.PushCommit(digit_buffer_.raw_digits().substr(0, consumed));
+        digit_buffer_.ResetForPartial(remaining);
     }
     return false;
 }

--- a/app/src/main/jni/librime-t9/src/t9_processor.h
+++ b/app/src/main/jni/librime-t9/src/t9_processor.h
@@ -20,6 +20,9 @@ public:
     std::string GetRemainingDigits() const;
     void GetSyllableCandidates(std::vector<std::string>& out) const;
 
+    // 返回并清除"最近一次退格撤销了 partial commit"标记，供前端感知半提交回退。
+    bool WasCommitUndone() { bool v = commit_undone_; commit_undone_ = false; return v; }
+
     // 第三方方案兼容：t9/isDisplayOriginalPreedit 控制 preedit 是否显示原始数字。
     // true  → 不处理 preedit，显示 rime 原始数字串（默认）。
     // false → 前端根据候选 comment 将 preedit 重建为拼音（由调用方处理）。
@@ -34,6 +37,7 @@ private:
 
     T9DigitBuffer digit_buffer_;
     bool display_original_preedit_ = true;
+    bool commit_undone_ = false;
 };
 
 T9Processor* T9ProcessorRequire();

--- a/app/src/main/jni/librime_jni/rime_jni.cc
+++ b/app/src/main/jni/librime_jni/rime_jni.cc
@@ -1642,4 +1642,15 @@ Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9IsDisplayOriginalPreedit(
     return proc->IsDisplayOriginalPreedit() ? JNI_TRUE : JNI_FALSE;
 }
 
+// 查询并清除"最近一次退格撤销了 partial commit"标记。
+JNIEXPORT jboolean JNICALL
+Java_com_kingzcheung_xime_rime_RimeEngine_nativeT9WasCommitUndone(
+    JNIEnv* env,
+    jobject thiz
+) {
+    rime::T9Processor* proc = rime::T9ProcessorRequire();
+    if (!proc) return JNI_FALSE;
+    return proc->WasCommitUndone() ? JNI_TRUE : JNI_FALSE;
+}
+
 } // extern "C"


### PR DESCRIPTION
新增 t9WasCommitUndone() 接口用于检测退格是否撤销了半提交状态，
实现退格先回退半提交（预编辑恢复为拼音）再删除输入序列的功能。

添加四个新的集成测试用例：
- test48_undoPartialCommitRestoresPreedit: 测试半提交回退后预编辑恢复
- test49_secondBackspaceIsPlainDelete: 测试第二次退格为普通删除
- test50_plainBackspaceDoesNotUndoCommit: 测试普通退格不撤销提交
- test51_chainedPartialUndo: 测试连续半提交回退功能

JNI 层面扩展 T9DigitBuffer 类，增加 commits_ 记录栈和相关操作方法，
修改 T9Processor 处理退格逻辑以支持半提交撤销机制。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
