### PR TITLE
fix(t9): 修复多音节候选选择时多余音节数字未被消费的问题

### DIFF
--- a/app/src/androidTest/java/com/kingzcheung/xime/rime/T9ProcessorIntegrationTest.kt
+++ b/app/src/androidTest/java/com/kingzcheung/xime/rime/T9ProcessorIntegrationTest.kt
@@ -573,4 +573,23 @@ class T9ProcessorIntegrationTest {
             android.util.Log.w(TAG, "test52 skipped: no 'de' candidate available")
         }
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // 回归：仅左选第一音节后右选多音节候选，多余音节的数字必须一并消费。
+    // 场景："给的吧"：仅左选 gei，右选两字候选"给的"(gei de) 应消费 gei+de，
+    // 尾部 22(吧) 保留；否则"的"会被重复输入为"给的的吧"。
+    // 用 "哥哥"(ge ge) 等价复现：434322 左选 ge，右选 ge ge，尾部 22 保留。
+    // ═══════════════════════════════════════════════════════════
+    @Test fun test53_multisyllableSelectionConsumesExtraSyllable() {
+        digits("434322")  // ge ge + 22
+        leftSelect("ge", 2)
+        val idx = candidates().indexOfFirst { it.second == "ge ge" }
+        if (idx >= 0) {
+            val isFull = engine.t9SelectCandidate(idx)
+            assertFalse("选两音节候选(ge ge)后尾部 '22' 仍在，必须是 PARTIAL commit", isFull)
+            assertEquals("多余音节与尾部 '22' 必须正确处理", "22", engine.t9GetRemainingDigits())
+        } else {
+            android.util.Log.w(TAG, "test53 skipped: no 'ge ge' candidate available")
+        }
+    }
 }

--- a/app/src/main/jni/librime-t9/src/t9_processor.cc
+++ b/app/src/main/jni/librime-t9/src/t9_processor.cc
@@ -371,6 +371,19 @@ bool T9Processor::SelectCandidate(int candidate_index) {
         int consumed = 0;
         for (size_t i = 0; i < covered; ++i)
             consumed += digit_buffer_.selections()[i].digit_length;
+        // 候选词注释的音节数可能超过已左选（covered）的音节数，如仅左选 "gei" 后
+        // 右选两字候选 "给的"(gei de)。候选词文本已包含多余的 "de"，其数字也必须从
+        // 剩余数字前缀消费，否则 "的" 会在后续输入中重复（"给的的吧"）。
+        // 仅在 covered>0（注释与首个左选对齐）时才做该扩展消费，避免误消费。
+        if (covered > 0 && covered < comment_syllables.size()) {
+            std::vector<std::string> extra(comment_syllables.begin() + covered,
+                                           comment_syllables.end());
+            std::string seg = digit_buffer_.raw_digits().substr(consumed);
+            int extra_consumed = ComputeConsumedDigitsFromSyllables(seg, extra);
+            if (extra_consumed > 0) {
+                consumed += extra_consumed;
+            }
+        }
         remaining = digit_buffer_.raw_digits().substr(consumed);
         T9LOG("SelectCandidate: partial commit (selections), covered=%zu consumed=%d remaining='%s'",
               covered, consumed, remaining.c_str());


### PR DESCRIPTION
当仅左选第一音节后右选多音节候选词时，多余音节对应的数字必须一并消费。
例如在输入"给的吧"时，仅左选"gei"后右选两字候选"给的"(gei de)，应消费gei+de， 尾部2(吧)保留；否则"的"会被重复输入为"给的的吧"。

添加了回归测试用例验证此修复，并实现了在候选词注释音节数超过已左选音节数时
自动扩展消费剩余数字的逻辑。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
