### PR TITLE
feat(plugin): 添加字段必填选项和改进信任等级判定

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/plugin/ws/WsHostApiImpl.kt
+++ b/app/src/main/java/com/kingzcheung/xime/plugin/ws/WsHostApiImpl.kt
@@ -115,6 +115,15 @@ class WsHostApiImpl(
 
     override fun lastError(): String? = lastErrorMsg
 
+    private fun extractServerError(body: String): String? {
+        if (body.isBlank()) return null
+        return try {
+            org.json.JSONObject(body).optString("error").takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     private val wsListener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
             state = STATE_OPEN
@@ -130,9 +139,14 @@ class WsHostApiImpl(
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-            Log.e(TAG, "WS failure: ${t.message}")
+            val serverMsg = response?.let { r ->
+                val body = try { r.body?.string() ?: "" } catch (e: Exception) { "" }
+                val reason = extractServerError(body) ?: "HTTP ${r.code}"
+                "HTTP ${r.code}: $reason"
+            } ?: ""
+            Log.e(TAG, "WS failure: ${t.message} | $serverMsg")
             state = STATE_CLOSED
-            listener?.onError(t.message ?: "连接失败")
+            listener?.onError(serverMsg.ifEmpty { t.message ?: "连接失败" })
         }
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/PluginConfigFormScreen.kt
@@ -144,7 +144,7 @@ fun PluginConfigFormScreen(
                     onClick = {
                         var allValid = true
                         fields.forEach { field ->
-                            if (field.type == PluginFieldType.SECRET) {
+                            if (field.type == PluginFieldType.SECRET && field.required) {
                                 val current = configStore.get(field.key)
                                 if (current.isNullOrBlank()) allValid = false
                             }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/config/IPluginConfigurable.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/config/IPluginConfigurable.kt
@@ -10,7 +10,8 @@ data class PluginSettingField(
     val defaultValue: String? = null,
     val options: List<String> = emptyList(),
     val helpText: String? = null,
-    val section: String? = null
+    val section: String? = null,
+    val required: Boolean = true
 )
 
 interface IPluginConfigurable {

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaPluginAdapter.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/LuaPluginAdapter.kt
@@ -33,7 +33,8 @@ open class LuaPluginAdapter(
                 defaultValue = map["defaultValue"]?.tojstring(),
                 options = stringList(map["options"] ?: LuaValue.NIL),
                 helpText = map["helpText"]?.tojstring(),
-                section = map["section"]?.tojstring()
+                section = map["section"]?.tojstring(),
+                required = map["required"]?.toboolean() ?: true
             )
         }
     }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/sdk/LuaHostApi.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/lua/sdk/LuaHostApi.kt
@@ -114,6 +114,6 @@ class LuaHostApiImpl(
     }
 
     override fun uuid(): String {
-        return java.util.UUID.randomUUID().toString().replace("-", "")
+        return java.util.UUID.randomUUID().toString()
     }
 }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -107,7 +107,7 @@ class InstallerManager(
                 source = source,
                 minHostVersion = pluginConfig.minHostVersion,
                 maxHostVersion = pluginConfig.maxHostVersion,
-                trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(pluginDir),
+                trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(source),
                 entryScript = entryScript,
                 declaredHosts = pluginConfig.declaredHosts
             )

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/XmlManager.kt
@@ -114,9 +114,7 @@ class XmlManager(private val context: Application) {
                 ?.map { it.trim() }
                 ?.filter { it.isNotBlank() }
                 ?: emptyList()
-            val trustLevel = extractTag(pluginContent, "trustLevel")
-                ?.let { runCatching { com.kingzcheung.xime.plugin.core.model.TrustLevel.valueOf(it) }.getOrNull() }
-                ?: com.kingzcheung.xime.plugin.core.model.TrustLevel.UNKNOWN
+            val trustLevel = com.kingzcheung.xime.plugin.core.util.PluginSignatureUtil.classifyLuaPlugin(source)
 
             if (id != null && path != null) {
                 plugins[id] = PluginInfo(

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/util/PluginSignatureUtil.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/util/PluginSignatureUtil.kt
@@ -1,20 +1,25 @@
 package com.kingzcheung.xime.plugin.core.util
 
+import com.kingzcheung.xime.plugin.core.model.PluginSource
 import com.kingzcheung.xime.plugin.core.model.TrustLevel
 
 /**
  * 插件信任等级判定。
  *
- * Lua 脚本插件无 APK 签名，信任由 UI 展示（官方/第三方/未知来源）与来源控制承担；
+ * Lua 脚本插件无 APK 签名，信任由来源判定：
+ * 内置（ASSET / SYSTEM）视为官方（TRUSTED），用户导入（FILE）视为第三方（THIRD_PARTY）。
  * 后续可扩展为"脚本哈希白名单"判定官方插件。
  */
 object PluginSignatureUtil {
 
     /**
-     * Lua 脚本插件信任判定：脚本插件无 APK 签名，一律视为第三方，
-     * 由插件中心展示信任标记并承担安全职责。
+     * Lua 脚本插件信任判定：按插件来源分类，
+     * 内置插件（随宿主分发）标记为官方，用户导入的插件标记为第三方。
      */
-    fun classifyLuaPlugin(pluginDir: java.io.File): TrustLevel {
-        return TrustLevel.THIRD_PARTY
+    fun classifyLuaPlugin(source: PluginSource): TrustLevel {
+        return when (source) {
+            PluginSource.SYSTEM, PluginSource.ASSET -> TrustLevel.TRUSTED
+            PluginSource.FILE -> TrustLevel.THIRD_PARTY
+        }
     }
 }

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/config/PluginConfigStoreTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/config/PluginConfigStoreTest.kt
@@ -88,6 +88,20 @@ class PluginSettingFieldTest {
         assertNull(field.defaultValue)
         assertTrue(field.options.isEmpty())
         assertNull(field.helpText)
+        assertNull(field.section)
+        assertTrue("SECRET 字段默认必填", field.required)
+    }
+
+    @Test
+    fun `PluginSettingField can be optional`() {
+        val field = PluginSettingField(
+            key = "appKey",
+            label = "App Key",
+            type = PluginFieldType.SECRET,
+            required = false
+        )
+
+        assertFalse(field.required)
     }
 
     @Test

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaVolcAsrPluginTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/lua/LuaVolcAsrPluginTest.kt
@@ -5,6 +5,8 @@ import com.kingzcheung.xime.plugin.core.config.PluginConfigStore
 import com.kingzcheung.xime.plugin.core.lua.ws.WsHostApi
 import com.kingzcheung.xime.plugin.core.lua.ws.WsHostListener
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.luaj.vm2.LuaString
@@ -114,9 +116,14 @@ class LuaVolcAsrPluginTest {
         // 设置 schema 非空（插件中心渲染表单的前提）
         val schema = LuaScriptRuntime.tableToList(runtime.call("getSettingsSchema"))
         assertTrue("getSettingsSchema 应非空", schema.isNotEmpty())
-        val schemaKeys = schema.mapNotNull { LuaScriptRuntime.tableToMap(it)["key"]?.tojstring() }
+        val schemaFields = schema.map { LuaScriptRuntime.tableToMap(it) }
+        val schemaKeys = schemaFields.mapNotNull { it["key"]?.tojstring() }
         assertTrue("schema 应含 apiKey", schemaKeys.contains("apiKey"))
         assertTrue("schema 应含 resourceId", schemaKeys.contains("resourceId"))
+        val apiKeyField = schemaFields.first { it["key"]?.tojstring() == "apiKey" }
+        val appKeyField = schemaFields.first { it["key"]?.tojstring() == "appKey" }
+        assertNull("apiKey 未声明 required（默认必填）", apiKeyField["required"])
+        assertFalse("appKey 旧鉴权应为可选", appKeyField["required"]?.toboolean() == true)
 
         val collector = ResultCollector()
         runtime.asrResultCallback = collector
@@ -130,8 +137,10 @@ class LuaVolcAsrPluginTest {
         assertTrue("start 应成功", runtime.call("start").toboolean())
         assertTrue("连接地址应为火山域名", mock.connectedUrl?.contains("openspeech.bytedance.com") == true)
         assertEquals("test-api-key", mock.connectedHeaders["X-Api-Key"])
-        assertEquals("volc.bigasr.sauc.duration", mock.connectedHeaders["X-Api-Resource-Id"])
+        assertEquals("volc.seedasr.sauc.duration", mock.connectedHeaders["X-Api-Resource-Id"])
         assertTrue("应带 X-Api-Request-Id", mock.connectedHeaders["X-Api-Request-Id"].isNullOrEmpty().not())
+        assertEquals("应带 X-Api-Sequence=-1", "-1", mock.connectedHeaders["X-Api-Sequence"])
+        assertTrue("应带 X-Api-Connect-Id", mock.connectedHeaders["X-Api-Connect-Id"].isNullOrEmpty().not())
 
         // onOpen → Lua 组装 full client request 帧（0x1, flags=POS_SEQUENCE, json, gzip）
         mock.hostListener?.onOpen()

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/util/PluginSignatureUtilTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/util/PluginSignatureUtilTest.kt
@@ -1,0 +1,20 @@
+package com.kingzcheung.xime.plugin.core.util
+
+import com.kingzcheung.xime.plugin.core.model.PluginSource
+import com.kingzcheung.xime.plugin.core.model.TrustLevel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PluginSignatureUtilTest {
+
+    @Test
+    fun `内置插件标记为官方`() {
+        assertEquals(TrustLevel.TRUSTED, PluginSignatureUtil.classifyLuaPlugin(PluginSource.ASSET))
+        assertEquals(TrustLevel.TRUSTED, PluginSignatureUtil.classifyLuaPlugin(PluginSource.SYSTEM))
+    }
+
+    @Test
+    fun `用户导入的插件标记为第三方`() {
+        assertEquals(TrustLevel.THIRD_PARTY, PluginSignatureUtil.classifyLuaPlugin(PluginSource.FILE))
+    }
+}

--- a/plugins/volc-asr/main.lua
+++ b/plugins/volc-asr/main.lua
@@ -31,7 +31,7 @@ local KEY_API_KEY = "apiKey"
 local KEY_APP_KEY = "appKey"
 local KEY_ACCESS_KEY = "accessKey"
 local KEY_RESOURCE_ID = "resourceId"
-local DEFAULT_RESOURCE = "volc.bigasr.sauc.duration"
+local DEFAULT_RESOURCE = "volc.seedasr.sauc.duration"
 
 local MSG_FULL_CLIENT_REQ = 0x1
 local MSG_AUDIO_ONLY = 0x2
@@ -92,6 +92,7 @@ function plugin.getSettingsSchema()
             key = KEY_APP_KEY,
             label = "App Key（旧鉴权）",
             type = "secret",
+            required = false,
             placeholder = "旧版 App Key（可选）",
             section = "旧鉴权",
         },
@@ -99,6 +100,7 @@ function plugin.getSettingsSchema()
             key = KEY_ACCESS_KEY,
             label = "Access Key（旧鉴权）",
             type = "secret",
+            required = false,
             placeholder = "旧版 Access Key（可选）",
             section = "旧鉴权",
         },
@@ -108,7 +110,7 @@ function plugin.getSettingsSchema()
             type = "text",
             defaultValue = DEFAULT_RESOURCE,
             placeholder = DEFAULT_RESOURCE,
-            helpText = "默认流式识别 1.0；2.0 模型填 volc.seedasr.sauc.duration",
+            helpText = "默认流式识别 2.0（volc.seedasr.sauc.duration）；1.0 模型填 volc.bigasr.sauc.duration",
         },
     }
 end
@@ -222,6 +224,8 @@ function plugin.start()
     end
     headers["X-Api-Resource-Id"] = host.config.get(KEY_RESOURCE_ID) or DEFAULT_RESOURCE
     headers["X-Api-Request-Id"] = taskId
+    headers["X-Api-Connect-Id"] = host.uuid()
+    headers["X-Api-Sequence"] = "-1"
 
     local ok = host.ws.connect(WS_URL, headers, {
         onOpen = function() plugin.onWsOpen() end,

--- a/plugins/volc-asr/manifest.yaml
+++ b/plugins/volc-asr/manifest.yaml
@@ -44,16 +44,18 @@ configSchema:
   - key: appKey
     label: App Key（旧鉴权）
     type: secret
+    required: false
     placeholder: 旧版 App Key（可选）
     section: 旧鉴权
   - key: accessKey
     label: Access Key（旧鉴权）
     type: secret
+    required: false
     placeholder: 旧版 Access Key（可选）
     section: 旧鉴权
   - key: resourceId
     label: 模型资源 ID
     type: text
-    defaultValue: volc.bigasr.sauc.duration
-    placeholder: volc.bigasr.sauc.duration
-    helpText: 默认流式识别 1.0；2.0 模型填 volc.seedasr.sauc.duration
+    defaultValue: volc.seedasr.sauc.duration
+    placeholder: volc.seedasr.sauc.duration
+    helpText: 默认流式识别 2.0（volc.seedasr.sauc.duration）；1.0 模型填 volc.bigasr.sauc.duration

--- a/scripts/build-plugins.ps1
+++ b/scripts/build-plugins.ps1
@@ -31,6 +31,12 @@ foreach ($pluginDir in Get-ChildItem -Path $PLUGINS_DIR -Directory) {
         ForEach-Object { ($_ -replace '^\s*version:\s*', '').Trim('"', "'") }
     if (-not $version) { $version = "0.0.0" }
 
+    # 清理该插件旧版本产物，避免残留（版本升级后旧 xipk 不再保留）
+    Get-ChildItem -Path $OUTPUT_DIR -Filter "$name-*.xipk" -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force
+    Get-ChildItem -Path $OUTPUT_DIR -Filter "$name-*.zip" -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force
+
     $out = Join-Path $OUTPUT_DIR "$name-$version.xipk"
     Remove-Item -Path $out -Force -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
- 为PluginSettingField添加required字段，默认为true，允许配置字段为可选项
- 修改WebSocket错误处理，提取服务器返回的错误信息进行显示
- 改进Lua插件信任等级判定逻辑，根据插件来源（系统/内置/文件）进行分类
- 优化UUID生成，移除不必要的字符替换
- 更新火山ASR插件配置，将旧版鉴权字段设为可选，并更新资源ID默认值
- 构建脚本中添加清理旧版本插件包的功能

fix(config): SECRET类型字段仅在必填时才验证非空值

refactor(ws): 改进WebSocket错误处理机制，解析服务器返回的错误信息

chore(build): 清理构建脚本，自动删除旧版本插件包文件

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
