### PR TITLE
feat(SchemaManifestManager): 添加内置备份文件复制功能并改进错误处理

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SchemaManifestManager.kt
@@ -413,9 +413,7 @@ object SchemaManifestManager {
                 while (keys.hasNext()) {
                     val fn = keys.next() as String
                     val src = File(rimeDir, fn)
-                    if (src.exists()) {
-                        src.copyTo(File(builtinDir, fn), overwrite = true)
-                    }
+                    copyToBuiltinBackup(src, builtinDir, fn)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "failed to backup builtin", e)
@@ -511,7 +509,7 @@ object SchemaManifestManager {
                             put("sha256", sha256)
                             put("size", file.length())
                         })
-                        file.copyTo(File(builtinDir, fn), overwrite = true)
+                        copyToBuiltinBackup(file, builtinDir, fn)
                     }
 
                     if (fileEntries.length() == 0) return@withContext
@@ -570,6 +568,14 @@ object SchemaManifestManager {
         return false
     }
 
+    /** 备份文件到 market/builtin/，确保嵌套路径的父目录存在（如 lua/t9_preedit.lua）。 */
+    internal fun copyToBuiltinBackup(src: File, builtinDir: File, relPath: String) {
+        if (!src.exists()) return
+        val dest = File(builtinDir, relPath)
+        dest.parentFile?.mkdirs()
+        src.copyTo(dest, overwrite = true)
+    }
+
     /**
      * 扫描 rime/ 下未被任何包（registry）追踪的文件，追加到 builtin 清单和注册表中。
      *
@@ -580,9 +586,20 @@ object SchemaManifestManager {
      * 用户数据文件（.userdb/、*.custom.yaml、installation.yaml、custom_phrase.txt）
      * 不会被追踪，确保卸载时不被误删。
      */
-    suspend fun refreshBuiltinManifest(context: Context) = withContext(Dispatchers.IO) {
+    suspend fun refreshBuiltinManifest(context: Context) {
+        withContext(Dispatchers.IO) {
+            try {
+                refreshBuiltinManifestInternal(context)
+            } catch (e: Exception) {
+                // 备份/刷新失败不应中断安装流程或导致崩溃，只记录日志
+                Log.e(TAG, "refreshBuiltinManifest failed", e)
+            }
+        }
+    }
+
+    private suspend fun refreshBuiltinManifestInternal(context: Context) {
         val rimeDir = SchemaManager.getRimeDir(context)
-        if (!rimeDir.exists()) return@withContext
+        if (!rimeDir.exists()) return
 
         val registry = loadRegistry(context)
         val allFiles = registry.optJSONObject("files") ?: JSONObject()
@@ -616,7 +633,7 @@ object SchemaManifestManager {
             }
         }
 
-        if (untracked.isEmpty() && fileEntries.length() == (existingManifest?.optJSONObject("files")?.length() ?: 0)) return@withContext
+        if (untracked.isEmpty() && fileEntries.length() == (existingManifest?.optJSONObject("files")?.length() ?: 0)) return
 
         for ((relPath, file) in untracked) {
             val sha256 = SchemaManager.fileSha256(file) ?: continue
@@ -656,7 +673,7 @@ object SchemaManifestManager {
         val builtinDir = SchemaManager.getMarketDir(context, BUILTIN_PACKAGE_ID)
         builtinDir.mkdirs()
         for ((relPath, file) in untracked) {
-            file.copyTo(File(builtinDir, relPath), overwrite = true)
+            copyToBuiltinBackup(file, builtinDir, relPath)
         }
 
         Log.i(TAG, "refreshBuiltinManifest: added ${untracked.size} untracked files")

--- a/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
+++ b/app/src/main/java/com/kingzcheung/xime/viewmodel/SchemaLocalViewModel.kt
@@ -170,10 +170,23 @@ class SchemaLocalViewModel(application: Application) : AndroidViewModel(applicat
         viewModelScope.launch {
             _uiState.update { it.copy(conflictPackageId = null, installingId = pkgId) }
             for (sid in _uiState.value.conflictingSchemeIds) {
-                withContext(Dispatchers.IO) {
-                    // 先刷新 builtin 清单：APP 更新后可能新增了未被清单追踪的文件
-                    SchemaManifestManager.refreshBuiltinManifest(context)
-                    SchemaManifestManager.uninstallWithManifest(context, sid)
+                val uninstallOk = withContext(Dispatchers.IO) {
+                    try {
+                        // 先刷新 builtin 清单：APP 更新后可能新增了未被清单追踪的文件
+                        SchemaManifestManager.refreshBuiltinManifest(context)
+                        SchemaManifestManager.uninstallWithManifest(context, sid).success
+                    } catch (e: Exception) {
+                        android.util.Log.e("SchemaLocalViewModel", "uninstall $sid failed", e)
+                        false
+                    }
+                }
+                if (!uninstallOk) {
+                    _uiState.update {
+                        it.copy(installingId = null, conflictPackageId = null, conflictingSchemeIds = emptyList())
+                    }
+                    showToast("卸载冲突方案「$sid」失败，安装已取消")
+                    loadLocalPackages()
+                    return@launch
                 }
             }
             val result = try {

--- a/app/src/test/java/com/kingzcheung/xime/settings/SchemaManifestManagerTest.kt
+++ b/app/src/test/java/com/kingzcheung/xime/settings/SchemaManifestManagerTest.kt
@@ -1,0 +1,65 @@
+package com.kingzcheung.xime.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class SchemaManifestManagerTest {
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
+
+    @Test
+    fun `copyToBuiltinBackup creates nested parent dirs`() {
+        val builtinDir = tempDir.newFolder("builtin")
+        val src = tempDir.newFile("t9_preedit.lua")
+        src.writeText("local t9 = {}")
+
+        SchemaManifestManager.copyToBuiltinBackup(src, builtinDir, "lua/t9_preedit.lua")
+
+        val dest = File(builtinDir, "lua/t9_preedit.lua")
+        assertTrue("nested backup file should exist", dest.exists())
+        assertEquals("local t9 = {}", dest.readText())
+    }
+
+    @Test
+    fun `copyToBuiltinBackup flat path does not require parent creation`() {
+        val builtinDir = tempDir.newFolder("builtin")
+        val src = tempDir.newFile("default.yaml")
+        src.writeText("patch:")
+
+        SchemaManifestManager.copyToBuiltinBackup(src, builtinDir, "default.yaml")
+
+        val dest = File(builtinDir, "default.yaml")
+        assertTrue(dest.exists())
+        assertEquals("patch:", dest.readText())
+    }
+
+    @Test
+    fun `copyToBuiltinBackup skips missing source`() {
+        val builtinDir = tempDir.newFolder("builtin")
+        val missing = File(tempDir.root, "does_not_exist.lua")
+
+        SchemaManifestManager.copyToBuiltinBackup(missing, builtinDir, "lua/missing.lua")
+
+        assertTrue("no nested dir should be created for missing source", !File(builtinDir, "lua").exists())
+        assertTrue("no destination file should exist", !File(builtinDir, "lua/missing.lua").exists())
+    }
+
+    @Test
+    fun `copyToBuiltinBackup overwrites existing nested file`() {
+        val builtinDir = tempDir.newFolder("builtin")
+        val nested = File(builtinDir, "lua/uuid.lua")
+        nested.parentFile.mkdirs()
+        nested.writeText("old")
+        val src = tempDir.newFile("uuid.lua")
+        src.writeText("new content")
+
+        SchemaManifestManager.copyToBuiltinBackup(src, builtinDir, "lua/uuid.lua")
+
+        assertEquals("new content", nested.readText())
+    }
+}


### PR DESCRIPTION
为 SchemaManifestManager 添加 copyToBuiltinBackup 函数，用于安全地备份文件到 market/builtin/ 目录，确保嵌套路径的父目录存在。修改 refreshBuiltinManifest 方法， 将文件复制操作统一使用新函数，并添加异常处理避免因备份失败导致应用崩溃。

fix(SchemaLocalViewModel): 增强方案安装过程中的错误处理

在 SchemaLocalViewModel 的方案安装流程中添加异常捕获机制，当卸载冲突方案失
败时显示错误提示并取消当前安装操作，防止因单一操作失败影响整体用户体验。

refactor: 更新子项目依赖版本至最新

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
