### PR TITLE
feat(plugin-core): 使用 kaml 替换 snakeyaml 解析 manifest.yaml

### DIFF
--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -56,8 +57,10 @@ dependencies {
 
     // Lua 脚本插件运行时（沙箱执行 main.lua，替代 DEX 加载）
     api("org.luaj:luaj-jse:3.0.1")
-    // manifest.yaml 解析（Lua 模式插件元数据）
-    api("org.yaml:snakeyaml:2.2")
+    // manifest.yaml 解析（Lua 模式插件元数据），与 app 统一使用 kaml 类型化解析，
+    // 避免引入 org.yaml:snakeyaml（其 java.beans 反射在 Android 上不可用）
+    implementation(libs.kaml)
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
     
     testImplementation("junit:junit:4.13.2")
 }

--- a/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
+++ b/plugin-core/src/main/java/com/kingzcheung/xime/plugin/core/runtime/installer/InstallerManager.kt
@@ -3,12 +3,52 @@ package com.kingzcheung.xime.plugin.core.runtime.installer
 import android.app.Application
 import android.net.Uri
 import android.util.Log
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlConfiguration
 import com.kingzcheung.xime.plugin.core.model.PluginInfo
 import com.kingzcheung.xime.plugin.core.model.PluginSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
 import java.io.File
 import java.util.zip.ZipFile
+
+/** manifest.yaml 解析结果。 */
+internal sealed class PluginParseResult {
+    data class Success(val config: PluginConfig) : PluginParseResult()
+    data class Failure(val reason: String) : PluginParseResult()
+}
+
+internal data class PluginConfig(
+    val id: String,
+    val name: String,
+    val version: String,
+    val description: String,
+    val type: String,
+    val minHostVersion: String?,
+    val maxHostVersion: String?,
+    val entryScript: String?,
+    val declaredHosts: List<String> = emptyList()
+)
+
+/** manifest.yaml 的类型化模型，与宿主一起用 kaml 解析。 */
+@Serializable
+internal data class PluginManifest(
+    val id: String,
+    val name: String? = null,
+    val type: String = "unknown",
+    val entry: String = "main.lua",
+    val version: String = "0.0.0",
+    val description: String? = null,
+    val minHostVersion: String? = null,
+    val maxHostVersion: String? = null,
+    val network: NetworkConfig? = null
+)
+
+@Serializable
+internal data class NetworkConfig(
+    val hosts: List<String> = emptyList()
+)
 
 /**
  * 插件安装器（Lua 脚本插件）。
@@ -28,6 +68,44 @@ class InstallerManager(
     companion object {
         private const val PLUGINS_DIR = "plugins"
         private const val MANIFEST_YAML = "manifest.yaml"
+
+        private val manifestYaml: Yaml by lazy {
+            Yaml(configuration = YamlConfiguration(strictMode = false))
+        }
+
+        /** 解析 manifest.yaml 文本（kam 类型化解析），失败时携带可读的错误提示。 */
+        internal fun parseManifestContent(content: String): PluginParseResult = try {
+            val manifest = manifestYaml.decodeFromString(PluginManifest.serializer(), content)
+            val declaredHosts = manifest.network?.hosts.orEmpty()
+                .filter { it.isNotBlank() }
+
+            PluginParseResult.Success(
+                PluginConfig(
+                    id = manifest.id,
+                    name = manifest.name ?: manifest.id,
+                    version = manifest.version,
+                    description = manifest.description ?: "",
+                    type = manifest.type,
+                    minHostVersion = manifest.minHostVersion?.takeIf { it.isNotBlank() },
+                    maxHostVersion = manifest.maxHostVersion?.takeIf { it.isNotBlank() },
+                    entryScript = manifest.entry,
+                    declaredHosts = declaredHosts
+                )
+            )
+        } catch (e: Exception) {
+            Log.e("InstallerManager", "parsePluginConfig yaml failed", e)
+            PluginParseResult.Failure(manifestError(e))
+        }
+
+        /** 把 manifest 解析异常整理成可读的提示（kaml 消息含行号/字段）。 */
+        private fun manifestError(e: Exception): String {
+            val detail = e.message
+                ?.lineSequence()
+                ?.firstOrNull { it.isNotBlank() }
+                ?.trim()
+                ?: e.javaClass.simpleName
+            return "manifest.yaml 解析失败：$detail"
+        }
     }
 
     sealed class InstallResult {
@@ -48,8 +126,10 @@ class InstallerManager(
             return@withContext InstallResult.Failure("插件文件不存在")
         }
 
-        val pluginConfig = parsePluginConfig(pluginFile)
-            ?: return@withContext InstallResult.Failure("插件配置解析失败（缺少 manifest.yaml）")
+        val pluginConfig = when (val parsed = parsePluginConfig(pluginFile)) {
+            is PluginParseResult.Failure -> return@withContext InstallResult.Failure(parsed.reason)
+            is PluginParseResult.Success -> parsed.config
+        }
         val pluginId = pluginConfig.id
         val pluginDir = getPluginDirectory(pluginId)
 
@@ -179,56 +259,18 @@ class InstallerManager(
         }
     }
 
-    private data class PluginConfig(
-        val id: String,
-        val name: String,
-        val version: String,
-        val description: String,
-        val type: String,
-        val minHostVersion: String?,
-        val maxHostVersion: String?,
-        val entryScript: String?,
-        val declaredHosts: List<String> = emptyList()
-    )
-
-    private fun parsePluginConfig(pluginFile: File): PluginConfig? {
+    private fun parsePluginConfig(pluginFile: File): PluginParseResult {
         val content = try {
             ZipFile(pluginFile).use { zip ->
-                val entry = zip.getEntry(MANIFEST_YAML) ?: return null
+                val entry = zip.getEntry(MANIFEST_YAML)
+                    ?: return PluginParseResult.Failure("插件配置解析失败（缺少 manifest.yaml）")
                 zip.getInputStream(entry).readBytes().toString(Charsets.UTF_8)
             }
         } catch (e: Exception) {
             Log.e("InstallerManager", "parsePluginConfig failed", e)
-            return null
+            return PluginParseResult.Failure("插件配置解析失败：${e.message}")
         }
 
-        return try {
-            val yaml = org.yaml.snakeyaml.Yaml().load<Map<String, Any>>(content) ?: return null
-            val id = yaml["id"] as? String ?: return null
-            val name = yaml["name"] as? String ?: id
-            val type = yaml["type"] as? String ?: "unknown"
-            val entry = yaml["entry"] as? String ?: "main.lua"
-            val version = yaml["version"] as? String ?: "0.0.0"
-            val minHostVersion = (yaml["minHostVersion"] as? String)?.takeIf { it.isNotBlank() }
-            val maxHostVersion = (yaml["maxHostVersion"] as? String)?.takeIf { it.isNotBlank() }
-            val hostsRaw = (yaml["network"] as? Map<*, *>)?.get("hosts")
-            val declaredHosts = (hostsRaw as? List<*>)?.mapNotNull { it as? String }
-                ?.filter { it.isNotBlank() } ?: emptyList()
-
-            PluginConfig(
-                id = id,
-                name = name,
-                version = version,
-                description = yaml["description"] as? String ?: "",
-                type = type,
-                minHostVersion = minHostVersion,
-                maxHostVersion = maxHostVersion,
-                entryScript = entry,
-                declaredHosts = declaredHosts
-            )
-        } catch (e: Exception) {
-            Log.e("InstallerManager", "parsePluginConfig yaml failed", e)
-            null
-        }
+        return parseManifestContent(content)
     }
 }

--- a/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
+++ b/plugin-core/src/test/java/com/kingzcheung/xime/plugin/core/runtime/installer/ManifestParseTest.kt
@@ -1,0 +1,98 @@
+package com.kingzcheung.xime.plugin.core.runtime.installer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ManifestParseTest {
+
+    @Test
+    fun `正常 manifest 解析成功且字段正确`() {
+        val content = """
+            id: kaomoji
+            name: 颜文字
+            version: 2.1.0
+            description: 内置颜文字
+            type: emoji
+            entry: main.lua
+            minHostVersion: 2.6.0
+            maxHostVersion: 3.0.0
+            network:
+              hosts:
+                - dashscope.aliyuncs.com
+        """.trimIndent()
+
+        val result = InstallerManager.parseManifestContent(content)
+        val config = (result as PluginParseResult.Success).config
+        assertEquals("kaomoji", config.id)
+        assertEquals("颜文字", config.name)
+        assertEquals("2.1.0", config.version)
+        assertEquals("emoji", config.type)
+        assertEquals("main.lua", config.entryScript)
+        assertEquals("2.6.0", config.minHostVersion)
+        assertEquals("3.0.0", config.maxHostVersion)
+        assertEquals(listOf("dashscope.aliyuncs.com"), config.declaredHosts)
+    }
+
+    @Test
+    fun `可选字段缺省时使用默认值`() {
+        val content = """
+            id: mini
+        """.trimIndent()
+
+        val config = (InstallerManager.parseManifestContent(content) as PluginParseResult.Success).config
+        assertEquals("mini", config.id)
+        assertEquals("mini", config.name)
+        assertEquals("0.0.0", config.version)
+        assertEquals("unknown", config.type)
+        assertEquals("main.lua", config.entryScript)
+        assertEquals("", config.description)
+        assertEquals(emptyList<String>(), config.declaredHosts)
+    }
+
+    @Test
+    fun `缺少必填 id 字段时返回可读错误`() {
+        val content = """
+            name: 没有 id
+        """.trimIndent()
+
+        val result = InstallerManager.parseManifestContent(content)
+        val reason = (result as PluginParseResult.Failure).reason
+        assertTrue("错误应说明解析失败, 实际: $reason", reason.startsWith("manifest.yaml 解析失败"))
+        assertTrue("错误应提到 id, 实际: $reason", reason.contains("id"))
+    }
+
+    @Test
+    fun `字段类型错误时返回可读错误`() {
+        val content = """
+            id: demo
+            type: [a, b]
+        """.trimIndent()
+
+        val result = InstallerManager.parseManifestContent(content)
+        val reason = (result as PluginParseResult.Failure).reason
+        assertTrue("错误应说明解析失败, 实际: $reason", reason.startsWith("manifest.yaml 解析失败"))
+    }
+
+    @Test
+    fun `YAML 语法错误时返回可读错误`() {
+        val content = "id: [未闭合"
+
+        val result = InstallerManager.parseManifestContent(content)
+        val reason = (result as PluginParseResult.Failure).reason
+        assertTrue("错误应说明解析失败, 实际: $reason", reason.startsWith("manifest.yaml 解析失败"))
+    }
+
+    @Test
+    fun `多余字段在非严格模式下被忽略`() {
+        val content = """
+            id: demo
+            extraField: 123
+            custom:
+              - a
+        """.trimIndent()
+
+        val config = (InstallerManager.parseManifestContent(content) as PluginParseResult.Success).config
+        assertEquals("demo", config.id)
+    }
+}


### PR DESCRIPTION
- 引入 kotlin serialization 和 kaml 依赖，替换原有的 snakeyaml
- 实现类型化的 PluginManifest、PluginConfig 等数据类
- 新增 PluginParseResult 密封类处理解析成功/失败情况
- 提供更详细的 manifest.yaml 解析错误信息
- 修复 Android 上 snakeyaml 因 java.beans 反射不可用导致的问题

fix(gradle): 更新 subproject commit 状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
