### PR TITLE
feat(rime): 统一部署机制并优化引擎锁策略

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
+++ b/app/src/main/java/com/kingzcheung/xime/XimeApplication.kt
@@ -102,12 +102,9 @@ class XimeApplication : Application(), ImageLoaderFactory {
                 val engine = RimeEngine.getInstance()
                 engine.initialize(userDataDir, sharedDataDir)
 
-                // 首次启动时静默编译词库，避免用户在设置中手动点「部署」
-                if (!SettingsPreferences.isDeploymentDone(this@XimeApplication)) {
-                    engine.deploy()
-                    SettingsPreferences.setDeploymentDone(this@XimeApplication, true)
-                    RimeConfigHelper.storeDeploymentHash(this@XimeApplication)
-                }
+                // 首次安装/升级后静默编译词库。ensureDeployment 内部带互斥且 hash 一致时跳过，
+                // 统一负责 deploymentDone/hash 状态，避免与输入法服务的初始化重复触发全量编译。
+                RimeConfigHelper.ensureDeployment(this@XimeApplication)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to pre-initialize Rime engine", e)
             }

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeConfigHelper.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.rime
 
 import android.content.Context
 import android.util.Log
+import com.kingzcheung.xime.BuildConfig
 import com.kingzcheung.xime.settings.PersonalDictManager
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManifestManager
@@ -17,6 +18,9 @@ import java.io.IOException
 object RimeConfigHelper {
     private const val TAG = "RimeConfigHelper"
     private const val ASSETS_RIME_DIR = "rime"
+
+    /** 部署互斥：Application 预初始化与输入法服务初始化可能并发触发部署，串行化避免重复/并发全量编译。 */
+    private val deploymentLock = Any()
     
     suspend fun initializeRimeDataAsync(context: Context): Pair<String, String> {
         val rimeDir = File(context.filesDir, "rime")
@@ -37,14 +41,40 @@ object RimeConfigHelper {
         // 为所有启用方案打个人词库补丁
         PersonalDictManager.ensureSchemaPacks(context)
         invalidateBuildIfConfigChanged(context)
-        // 配置文件有改动时重新部署，确保 build 目录最新
-        if (!File(rimeDir, "build").exists() || File(rimeDir, "build").list()?.isEmpty() == true) {
-            Log.i(TAG, "Build directory missing or empty, triggering deploy")
-            RimeEngine.getInstance().deploy()
-            storeDeploymentHash(context)
-        }
+        // 部署统一由 ensureDeployment() 在 engine 初始化后执行（本方法不持有 rimeLock）。
         
         return Pair(rimeDir.absolutePath, rimeDir.absolutePath)
+    }
+
+    /**
+     * 统一部署入口（进程内互斥）：
+     * - 部署 hash 一致 → build 已是最新，对齐 deploymentDone 标记，跳过编译；
+     * - hash 缺失/不一致 → 清空 build 全量编译，成功后统一记录 hash 与 deploymentDone。
+     *
+     * 必须由调用方保证 engine 已 initialize（deploy() 未初始化时返回 false）。
+     * 该入口被 Application 预初始化与输入法服务共享，配合 deploymentLock
+     * 避免两者并发触发两次 24 秒级别的全量编译。
+     */
+    fun ensureDeployment(context: Context): Boolean {
+        synchronized(deploymentLock) {
+            val currentHash = computeDeploymentHash(context)
+            if (currentHash.isNotEmpty() && currentHash == SettingsPreferences.getDeploymentHash(context)) {
+                SettingsPreferences.setDeploymentDone(context, true)
+                return true
+            }
+            Log.i(TAG, "Deployment hash mismatch or missing, clearing build for full deploy")
+            val buildDir = File(context.filesDir, "rime/build")
+            if (buildDir.exists()) {
+                buildDir.deleteRecursively()
+                buildDir.mkdirs()
+            }
+            if (RimeEngine.getInstance().deploy()) {
+                storeDeploymentHash(context)
+                SettingsPreferences.setDeploymentDone(context, true)
+                return true
+            }
+            return false
+        }
     }
     
     fun initializeRimeData(context: Context): Pair<String, String> {
@@ -170,12 +200,20 @@ object RimeConfigHelper {
     }
     
     private fun copyAssetsToRimeDir(context: Context, targetDir: File): Boolean {
-        try {
-            return copyAssetsRecursively(context, ASSETS_RIME_DIR, targetDir)
-        } catch (e: IOException) {
-            Log.e(TAG, "Failed to copy assets", e)
+        // assets 编译进 APK，同一 versionCode 内不会变化。记录上次同步的版本号，
+        // 一致时跳过全量拷贝：避免每次启动都覆盖 default.yaml 等文件（assets 默认压缩，
+        // openFd 抛异常导致 size 判断失效），从而保证部署 hash 稳定、不再每次启动全量重编译。
+        if (SettingsPreferences.getRimeAssetsVersion(context) == BuildConfig.VERSION_CODE) {
             return false
         }
+        val copied = try {
+            copyAssetsRecursively(context, ASSETS_RIME_DIR, targetDir)
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to copy assets", e)
+            false
+        }
+        SettingsPreferences.setRimeAssetsVersion(context, BuildConfig.VERSION_CODE)
+        return copied
     }
     
     private fun copyAssetsRecursively(context: Context, assetPath: String, targetDir: File): Boolean {

--- a/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
+++ b/app/src/main/java/com/kingzcheung/xime/rime/RimeEngine.kt
@@ -2,6 +2,7 @@ package com.kingzcheung.xime.rime
 
 import android.util.Log
 import java.io.File
+import java.util.concurrent.locks.ReentrantLock
 
 data class RimeCandidate(
     val text: String,
@@ -118,7 +119,7 @@ class RimeEngine {
         private var deploymentCallback: ((Boolean, String) -> Unit)? = null
 
         /** 全局 Rime 引擎锁 — 所有 native 调用必须通过此锁同步 */
-        val rimeLock = Any()
+        val rimeLock = ReentrantLock()
 
         init {
             System.loadLibrary("rime_jni")
@@ -150,6 +151,33 @@ class RimeEngine {
     private val initLock = Any()
     @Volatile
     private var userDataDir: String = ""
+
+    /**
+     * 管理路径（初始化/部署/会话创建/方案切换等）：阻塞等待锁。
+     * 这类调用在后台线程执行，等待部署/编译完成是预期行为。
+     */
+    private inline fun <T> locked(block: () -> T): T {
+        rimeLock.lock()
+        try {
+            return block()
+        } finally {
+            rimeLock.unlock()
+        }
+    }
+
+    /**
+     * 输入/查询路径：非阻塞获取锁。拿不到锁（如全量部署持锁中）立即返回
+     * [defaultValue] 而不等待，避免主线程 UI（updateUI → getComposition 等）
+     * 被 20+ 秒的部署阻塞导致 ANR。拿不到锁时不进入 native，并发安全。
+     */
+    private inline fun <T> tryLocked(defaultValue: T, block: () -> T): T {
+        if (!rimeLock.tryLock()) return defaultValue
+        try {
+            return block()
+        } finally {
+            rimeLock.unlock()
+        }
+    }
 
     private fun notifyDeploymentStatus(isDeploying: Boolean, message: String) {
         deploymentCallback?.invoke(isDeploying, message)
@@ -201,7 +229,7 @@ class RimeEngine {
             waited += 1000
         }
 
-        synchronized(rimeLock) {
+        locked {
             waited = 0L
             while (waited < timeoutMs) {
                 if (!nativeHasSession()) {
@@ -228,24 +256,26 @@ class RimeEngine {
 
     fun getCurrentSchema(): String {
         if (!nativeHasSession()) return ""
-        synchronized(rimeLock) {
-            return nativeGetCurrentSchema() ?: ""
+        return tryLocked("") {
+            nativeGetCurrentSchema() ?: ""
         }
     }
 
     fun processKey(keycode: Int, mask: Int): Boolean {
         if (!isInitialized) return false
-        synchronized(rimeLock) {
-            if (!nativeHasSession() && !nativeCreateSession()) return false
-            return nativeProcessKey(keycode, mask)
+        return tryLocked(false) {
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
+            nativeProcessKey(keycode, mask)
         }
     }
 
     fun processKeyAndGetResult(keycode: Int, mask: Int): RimeProcessResult {
         if (!isInitialized) return RimeProcessResult(false, "", "", "", emptyArray(), false, false, false)
-        if (!nativeHasSession() && !nativeCreateSession())
-            return RimeProcessResult(false, "", "", "", emptyArray(), false, false, false)
-        return nativeProcessKeyAndGetResult(keycode, mask)
+        return tryLocked(RimeProcessResult(false, "", "", "", emptyArray(), false, false, false)) {
+            if (!nativeHasSession() && !nativeCreateSession())
+                return@tryLocked RimeProcessResult(false, "", "", "", emptyArray(), false, false, false)
+            nativeProcessKeyAndGetResult(keycode, mask)
+        }
     }
 
     fun getProcessResult(processed: Boolean): RimeProcessResult {
@@ -253,23 +283,24 @@ class RimeEngine {
         // 必须持 rimeLock：nativeGetProcessResult 内部 RimeGetContext → Menu::Prepare
         // 会惰性生成候选页（遍历 translations），与 t9FlushRimeInput（set_input → Reset，
         // 释放旧 translations）并发会导致悬空 → ScriptTranslation::Peek 空指针崩溃。
-        synchronized(rimeLock) {
-            return nativeGetProcessResult(processed)
+        // 部署/编译持锁期间拿不到锁直接返回空结果（不进 native），避免阻塞调用线程。
+        return tryLocked(RimeProcessResult(false, "", "", "", emptyArray(), false, false, false)) {
+            nativeGetProcessResult(processed)
         }
     }
 
     fun getCandidates(): Array<String> {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return emptyArray()
-            return nativeGetCandidates() ?: emptyArray()
+        return tryLocked(emptyArray()) {
+            if (!nativeHasSession()) return@tryLocked emptyArray()
+            nativeGetCandidates() ?: emptyArray()
         }
     }
 
     fun getCandidatesWithComments(): Array<RimeCandidate> {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return emptyArray()
+        return tryLocked(emptyArray()) {
+            if (!nativeHasSession()) return@tryLocked emptyArray()
             val rawCandidates = nativeGetCandidatesWithComments() ?: emptyArray()
-            return rawCandidates.map { pair ->
+            rawCandidates.map { pair ->
                 RimeCandidate(
                     text = pair.getOrElse(0) { "" },
                     comment = pair.getOrElse(1) { "" }
@@ -279,8 +310,8 @@ class RimeEngine {
     }
 
     fun getInput(): String {
-        synchronized(rimeLock) {
-            return nativeGetInput() ?: ""
+        return tryLocked("") {
+            nativeGetInput() ?: ""
         }
     }
 
@@ -291,55 +322,55 @@ class RimeEngine {
      * 是 T9 路径 updateUI 的首选查询接口，可替代多次独立 JNI 调用。
      */
     fun getComposition(): RimeComposition {
-        synchronized(rimeLock) {
-            return nativeGetComposition()
+        return tryLocked(RimeComposition("", "", "", emptyArray(), false, false, false)) {
+            nativeGetComposition()
         }
     }
 
     fun selectCandidate(index: Int): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativeSelectCandidate(index)
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativeSelectCandidate(index)
         }
     }
 
     fun pageDown(): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativePageDown()
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativePageDown()
         }
     }
 
     fun pageUp(): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativePageUp()
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativePageUp()
         }
     }
 
     fun hasNextPage(): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativeHasNextPage()
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativeHasNextPage()
         }
     }
 
     fun hasPrevPage(): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativeHasPrevPage()
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativeHasPrevPage()
         }
     }
 
     fun commit(): String {
-        synchronized(rimeLock) {
-            return nativeCommit() ?: ""
+        return tryLocked("") {
+            nativeCommit() ?: ""
         }
     }
 
     fun clearComposition() {
         if (!nativeHasSession()) return
-        synchronized(rimeLock) {
+        tryLocked(Unit) {
             nativeClearComposition()
         }
     }
@@ -356,23 +387,23 @@ class RimeEngine {
      */
     fun setInput(input: String): Boolean {
         if (!isInitialized) return false
-        synchronized(rimeLock) {
-            if (!nativeHasSession() && !nativeCreateSession()) return false
-            return nativeSetInput(input)
+        return tryLocked(false) {
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
+            nativeSetInput(input)
         }
     }
 
     fun toggleAsciiMode(): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativeToggleAsciiMode()
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativeToggleAsciiMode()
         }
     }
 
     fun isAsciiMode(): Boolean {
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return false
-            return nativeIsAsciiMode()
+        return tryLocked(false) {
+            if (!nativeHasSession()) return@tryLocked false
+            nativeIsAsciiMode()
         }
     }
 
@@ -392,7 +423,7 @@ class RimeEngine {
     }
 
     fun switchSchema(schemaId: String): Boolean {
-        synchronized(rimeLock) {
+        locked {
             if (!nativeHasSession()) return false
             // 在切换方案前，确保 T9 方案的 schema 补丁已注入
             // 这会在 user_data_dir 中创建 {schemaId}.custom.yaml 文件，
@@ -404,14 +435,14 @@ class RimeEngine {
 
     fun startMaintenance(full: Boolean): Boolean {
         if (!isInitialized) return false
-        synchronized(rimeLock) {
+        locked {
             return nativeStartMaintenance(full)
         }
     }
 
     fun deploy(): Boolean {
         if (!isInitialized) return false
-        synchronized(rimeLock) {
+        locked {
             // 部署前确保 T9 补丁（含个人词库 packs 确定性名）已写入，
             // 部署时 librime 才会编译对应的 user_<schemaId>.table.bin。
             // 幂等：补丁已就位时 native 侧直接 skip，开销极小。
@@ -422,9 +453,9 @@ class RimeEngine {
 
     fun lookupText(text: String): String {
         if (!isInitialized || text.isEmpty()) return ""
-        synchronized(rimeLock) {
-            if (!nativeHasSession()) return ""
-            return nativeLookupText(text) ?: ""
+        return tryLocked("") {
+            if (!nativeHasSession()) return@tryLocked ""
+            nativeLookupText(text) ?: ""
         }
     }
 
@@ -492,14 +523,14 @@ class RimeEngine {
 
     /** 运行时切换 JNI verbose 日志（仅 Debug 构建生效，Release 为空操作）。 */
     fun setVerboseLogging(enabled: Boolean) {
-        synchronized(rimeLock) {
+        locked {
             nativeSetVerboseLogging(enabled)
         }
     }
 
     fun destroy() {
         if (isInitialized) {
-            synchronized(rimeLock) {
+            locked {
                 nativeDestroy()
                 isInitialized = false
             }
@@ -518,9 +549,9 @@ class RimeEngine {
      */
     fun t9SelectCandidate(pinyin: String, textLength: Int): Boolean {
         if (!isInitialized) return false
-        synchronized(rimeLock) {
-            if (!nativeHasSession() && !nativeCreateSession()) return false
-            return nativeT9SelectCandidate(pinyin, textLength)
+        return tryLocked(false) {
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
+            nativeT9SelectCandidate(pinyin, textLength)
         }
     }
 
@@ -604,9 +635,9 @@ class RimeEngine {
      */
     fun t9SelectPinyinDirect(pinyin: String, digitLength: Int): Boolean {
         if (!isInitialized) return false
-        synchronized(rimeLock) {
-            if (!nativeHasSession() && !nativeCreateSession()) return false
-            return nativeT9SelectPinyinDirect(pinyin, digitLength)
+        return tryLocked(false) {
+            if (!nativeHasSession() && !nativeCreateSession()) return@tryLocked false
+            nativeT9SelectPinyinDirect(pinyin, digitLength)
         }
     }
 
@@ -615,8 +646,8 @@ class RimeEngine {
      */
     fun t9GetRemainingDigits(): String {
         if (!isInitialized) return ""
-        synchronized(rimeLock) {
-            return nativeT9GetRemainingDigits() ?: ""
+        return tryLocked("") {
+            nativeT9GetRemainingDigits() ?: ""
         }
     }
 
@@ -626,8 +657,8 @@ class RimeEngine {
      */
     fun t9GetLeftPanelState(): String {
         if (!isInitialized) return "IDLE;;;;;0"
-        synchronized(rimeLock) {
-            return nativeT9GetLeftPanelState() ?: "IDLE;;;;;0"
+        return tryLocked("IDLE;;;;;0") {
+            nativeT9GetLeftPanelState() ?: "IDLE;;;;;0"
         }
     }
 
@@ -637,8 +668,8 @@ class RimeEngine {
      */
     fun t9GetAndConsumeUndoneRightCommitCount(): Int {
         if (!isInitialized) return 0
-        synchronized(rimeLock) {
-            return nativeT9GetAndConsumeUndoneRightCommitCount()
+        return tryLocked(0) {
+            nativeT9GetAndConsumeUndoneRightCommitCount()
         }
     }
 
@@ -648,10 +679,10 @@ class RimeEngine {
      */
     fun t9GetFirstSyllableOptions(digits: String, maxResults: Int = 20): List<Pair<String, Int>> {
         if (!isInitialized || digits.isEmpty()) return emptyList()
-        synchronized(rimeLock) {
-            val raw = nativeT9GetFirstSyllableOptions(digits, maxResults) ?: return emptyList()
-            if (raw.isEmpty()) return emptyList()
-            return raw.split(",").mapNotNull { entry ->
+        return tryLocked(emptyList()) {
+            val raw = nativeT9GetFirstSyllableOptions(digits, maxResults) ?: return@tryLocked emptyList()
+            if (raw.isEmpty()) return@tryLocked emptyList()
+            raw.split(",").mapNotNull { entry ->
                 val parts = entry.split("|")
                 if (parts.size == 2) {
                     Pair(parts[0], parts[1].toIntOrNull() ?: 1)
@@ -666,7 +697,7 @@ class RimeEngine {
      */
     fun t9ClearComposition(mode: Int) {
         if (!isInitialized) return
-        synchronized(rimeLock) {
+        tryLocked(Unit) {
             nativeT9ClearComposition(mode)
         }
     }
@@ -680,7 +711,7 @@ class RimeEngine {
      */
     fun t9FlushRimeInput() {
         if (!isInitialized) return
-        synchronized(rimeLock) {
+        tryLocked(Unit) {
             nativeT9FlushRimeInput()
         }
     }

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeSchemaController.kt
@@ -11,6 +11,7 @@ import com.kingzcheung.xime.keyboard.HANDWRITING_SCHEMA_ID
 import com.kingzcheung.xime.settings.KeysConfigHelper
 import com.kingzcheung.xime.settings.SchemaConfigHelper
 import com.kingzcheung.xime.settings.SchemaManager
+import com.kingzcheung.xime.rime.RimeConfigHelper
 import com.kingzcheung.xime.settings.SettingsPreferences
 import com.kingzcheung.xime.ui.theme.KeyboardThemes
 import java.io.File
@@ -76,6 +77,9 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
                 }
                 
                 service.rimeEngine.deploy()
+                // 部署后记录 hash 与完成标记，否则下次启动会因 hash 不一致再次全量编译
+                RimeConfigHelper.storeDeploymentHash(service)
+                SettingsPreferences.setDeploymentDone(service, true)
                 
                 // 部署完成后重新加载配置（Rime 可能在部署过程中改写文件）
                 KeysConfigHelper.loadConfig(service)
@@ -114,6 +118,9 @@ internal class ImeSchemaController(private val service: XimeInputMethodService) 
     private fun deploySchema() {
         try {
             service.rimeEngine.deploy()
+            // 部署后记录 hash 与完成标记，避免下次启动再次全量编译
+            RimeConfigHelper.storeDeploymentHash(service)
+            SettingsPreferences.setDeploymentDone(service, true)
             val savedSchema = SettingsPreferences.getCurrentSchema(service)
             applyPageSizeSetting(savedSchema)
             service.rimeEngine.switchSchema(savedSchema)

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -476,51 +476,18 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                 notifyDeploymentStatus(true, "正在加载输入法引擎...")
                 rimeEngine.initialize(userDataDir, sharedDataDir)
 
-                // 检查词库是否已部署（prism.bin 文件是否存在）
+                // 检查词库是否已部署（deploymentDone 标记 + 部署 hash 一致）
                 val deploymentDone = SettingsPreferences.isDeploymentDone(this@XimeInputMethodService)
                 val needsDeployment = !deploymentDone || !RimeConfigHelper.isDeploymentComplete(this@XimeInputMethodService)
 
                 if (needsDeployment) {
-                    // 首次部署：需要完整编译词库
+                    // 统一部署入口（进程内互斥，hash 一致时内部跳过）。
+                    // 与 XimeApplication 预初始化共享，避免两者并发触发两次全量编译。
                     notifyDeploymentStatus(true, "正在编译词库...")
-
-                    // 如果所有方案已编译完成，只是 deploymentDone 标记没设（例如从设置页部署的），
-                    // 用增量刷新即可，避免不必要的全量扫描
-                    val alreadyCompiled = RimeConfigHelper.isDeploymentComplete(this@XimeInputMethodService)
-                    val maintenanceStarted = rimeEngine.startMaintenance(!alreadyCompiled)
-                    if (!maintenanceStarted) {
-                        Log.w(TAG, "initRimeEngine: startMaintenance returned false! " +
-                                "Deployment may not have started. Trying deploy() as fallback...")
-                        val deployed = rimeEngine.deploy()
-                        if (deployed) {
-                            Log.i(TAG, "initRimeEngine: deploy() succeeded as fallback")
-                        } else {
-                            Log.e(TAG, "initRimeEngine: both startMaintenance and deploy() failed")
-                        }
-                    }
-
-                    // 诊断：检查 maintenance 是否真的进入了维护模式
-                    val maintaining = rimeEngine.isMaintaining()
-                    Log.d(TAG, "initRimeEngine: startMaintenance returned $maintenanceStarted, isMaintaining=$maintaining")
-
-                    // 等待编译完成（最多 120 秒），startMaintenance 是异步的，
-                    // 不等待的话 ensureSession 读到的是空 schema 列表
-                    if (maintaining) {
-                        var maintenanceWaited = 0L
-                        val maintenanceTimeoutMs = 300_000L
-                        while (rimeEngine.isMaintaining() && maintenanceWaited < maintenanceTimeoutMs) {
-                            Thread.sleep(100)
-                            maintenanceWaited += 100
-                            if (maintenanceWaited % 5000 == 0L) {
-                                Log.d(TAG, "initRimeEngine: waiting for maintenance... (${maintenanceWaited / 1000}s)")
-                            }
-                        }
-                        if (rimeEngine.isMaintaining()) {
-                            Log.w(TAG, "initRimeEngine: maintenance still running after timeout, continuing anyway")
-                        } else {
-                            Log.d(TAG, "initRimeEngine: maintenance completed in ${maintenanceWaited}ms")
-                            rimeEngine.updateLastBuildTime()
-                        }
+                    if (RimeConfigHelper.ensureDeployment(this@XimeInputMethodService)) {
+                        rimeEngine.updateLastBuildTime()
+                    } else {
+                        Log.e(TAG, "initRimeEngine: ensureDeployment failed, deployment may not have completed")
                     }
                 } else {
                     Log.d(TAG, "initRimeEngine: Already deployed, creating session directly")

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -9,6 +9,7 @@ object SettingsPreferences {
     private const val KEY_CURRENT_SCHEMA = "current_schema"
     private const val KEY_DEPLOYMENT_DONE = "deployment_done"
     private const val KEY_DEPLOYMENT_HASH = "deployment_hash"
+    private const val KEY_RIME_ASSETS_VERSION = "rime_assets_version"
     private const val KEY_SETUP_COMPLETED = "setup_completed"
     private const val KEY_DARK_MODE = "dark_mode"
     private const val KEY_VERBOSE_LOGGING = "verbose_logging"
@@ -167,6 +168,15 @@ object SettingsPreferences {
 
     fun setDeploymentHash(context: Context, hash: String) {
         getPrefs(context).edit().putString(KEY_DEPLOYMENT_HASH, hash).apply()
+    }
+
+    /** 上次完成 rime assets 同步的 versionCode（0 表示从未同步）。 */
+    fun getRimeAssetsVersion(context: Context): Int {
+        return getPrefs(context).getInt(KEY_RIME_ASSETS_VERSION, 0)
+    }
+
+    fun setRimeAssetsVersion(context: Context, version: Int) {
+        getPrefs(context).edit().putInt(KEY_RIME_ASSETS_VERSION, version).apply()
     }
 
     /** 调试 verbose 日志总开关（仅 Debug 构建生效，Release 恒关闭）。 */

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/SetupWizardScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/SetupWizardScreen.kt
@@ -383,6 +383,8 @@ private suspend fun doCompile(
             // 2. 部署 = 编译词库 + 创建 session（一步完成）
             onProgress("正在编译词库...")
             engine.deploy()
+            RimeConfigHelper.storeDeploymentHash(context)
+            SettingsPreferences.setDeploymentDone(context, true)
 
             onDone()
         } catch (e: Exception) {


### PR DESCRIPTION
- 实现 RimeConfigHelper.ensureDeployment() 统一部署入口，进程内互斥避免 Application 预初始化与输入法服务并发触发重复编译
- 采用 ReentrantLock 替代 synchronized，提供 tryLock 支持非阻塞调用 避免主线程 UI 被长时间部署阻塞导致 ANR
- 添加 assets 版本缓存机制，相同版本跳过全量拷贝保持部署 hash 稳定
- 更新 SetupWizardScreen 和 ImeSchemaController 部署后状态记录逻辑
- 优化 RimeEngine 中所有 JNI 调用的锁获取策略：管理路径使用阻塞锁， 输入查询路径使用非阻塞锁

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
