### PR TITLE
feat(theme): 添加候选选中文字颜色配置支持

### DIFF
--- a/app/src/main/assets/xime.yaml
+++ b/app/src/main/assets/xime.yaml
@@ -46,6 +46,17 @@ style:
 #    xime.custom.yaml 中添加引用它的 color_scheme，src 写相对 rime/ 的路径。
 #    内置主题的同名文件会被用户目录中的文件覆盖。
 #
+# color_schemes 每个主题可用的颜色字段（未设置的会回退到全局 keyboard.colors 默认值）：
+#   primary_color          - 主题强调色（种子色）
+#   keyboard_bg_color      - 键盘背景后备色（配置了 keyboard_background 时以 background 为准）
+#   key_bg_color / key_bg_color_dark           - 按键底色（亮/暗）
+#   special_key_bg_color / _dark               - 特殊按键底色（亮/暗）
+#   candidate_bar_bg_color                     - 候选栏底色
+#   key_text_color / key_text_color_dark       - 按键文字色（亮/暗）
+#   candidate_text_color / _dark               - 候选文字色（亮/暗）
+#   candidate_selected_text_color / _dark      - 候选选中文字色（亮/暗），未设置时回退到
+#                                                 key_text_color（图片背景看不清时建议单独配置）
+#
 color_schemes:
   lavender_purple:
     name: "薰衣草紫"
@@ -283,6 +294,8 @@ color_schemes:
     key_text_color_dark: 0xf2f2f2
     candidate_text_color: 0x232323
     candidate_text_color_dark: 0xf2f2f2
+    candidate_selected_text_color: 0x9CB2D6
+    candidate_selected_text_color_dark: 0x9CB2D6
 
   mrfawdi_nature:
     name: "暮色之桥"
@@ -296,8 +309,10 @@ color_schemes:
     key_bg_color_dark: 0x5affffff
     key_text_color: 0x3a2028
     key_text_color_dark: 0xf7eef1
-    candidate_text_color: 0x76565F
-    candidate_text_color_dark: 0xf7eef1
+    candidate_text_color: 0xA4828C
+    candidate_text_color_dark: 0xA4828C
+    candidate_selected_text_color: 0xDCA79C
+    candidate_selected_text_color_dark: 0xDCA79C
 
   olivcelso_desert:
     name: "大漠流金"

--- a/app/src/main/java/com/kingzcheung/xime/MainActivity.kt
+++ b/app/src/main/java/com/kingzcheung/xime/MainActivity.kt
@@ -310,6 +310,8 @@ class MainActivity : ComponentActivity() {
                 key_text_color_dark: 0xf2f2f2
                 candidate_text_color: 0x232323
                 candidate_text_color_dark: 0xf2f2f2
+                candidate_selected_text_color: 0xffffff
+                candidate_selected_text_color_dark: 0xffffff
         """.trimIndent()
         val clipboard = getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
         clipboard.setPrimaryClip(android.content.ClipData.newPlainText("xime theme", template))

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -744,6 +744,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                         val candidateTextCol = com.kingzcheung.xime.ui.theme.KeyboardThemes.getCandidateTextColorOverride(state.themeId, isDark)
                             ?: if (isDark) longToColor(kbColors.candidateTextColorDark) else longToColor(kbColors.candidateTextColor)
                         val accentCol = com.kingzcheung.xime.ui.theme.KeyboardThemes.getAccentColor(state.themeId, isDark)
+                        val selectedTextCol = com.kingzcheung.xime.ui.theme.KeyboardThemes.getCandidateSelectedTextColor(state.themeId, isDark)
                         val keyboardBgColor = cardBg
                         val rootTheme = com.kingzcheung.xime.ui.theme.KeyboardThemes.getThemeById(state.themeId)
                         if (state.isCompact && (cand.candidates.isNotEmpty() || cand.isShowingRecentClipboard || cand.inputText.isNotEmpty())) {
@@ -760,6 +761,7 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
                                 cardBackgroundColor = cardBg,
                                 candidateTextColor = candidateTextCol,
                                 activeColor = accentCol,
+                                selectedTextColor = selectedTextCol,
                             )
                         } else if (state.isCompact) {
                             Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -311,6 +311,10 @@ data class ColorSchemeEntry(
     val candidateTextColor: Long? = null,
     @SerialName("candidate_text_color_dark")
     val candidateTextColorDark: Long? = null,
+    @SerialName("candidate_selected_text_color")
+    val candidateSelectedTextColor: Long? = null,
+    @SerialName("candidate_selected_text_color_dark")
+    val candidateSelectedTextColorDark: Long? = null,
     @SerialName("keyboard_background")
     val keyboardBackground: BackgroundConfig? = null,
     @SerialName("key_background")

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/CandidateBar.kt
@@ -64,6 +64,7 @@ data class CandidateBarVisuals(
     val textColor: Color,
     val dividerColor: Color,
     val accentColor: Color = Color(0xFF1A73E8),
+    val selectedTextColor: Color = Color(0xFF1A73E8),
     val isDarkTheme: Boolean = false,
 )
 
@@ -360,6 +361,7 @@ fun CandidateBar(
                         } else "",
                         isSelected = index == 0,
                         accentColor = visuals.accentColor,
+                        selectedTextColor = visuals.selectedTextColor,
                         fontSize = candidateTextSize.sp
                     )
                 }
@@ -385,6 +387,7 @@ fun CandidateBar(
                             comment = displayComments.getOrElse(index) { "" },
                             isSelected = assocState?.highlightIndex == index,
                             accentColor = visuals.accentColor,
+                            selectedTextColor = visuals.selectedTextColor,
                             fontSize = candidateTextSize.sp
                         )
                     }
@@ -552,6 +555,7 @@ fun CandidateItem(
     comment: String = "",
     isSelected: Boolean = false,
     accentColor: Color = Color(0xFF1A73E8),
+    selectedTextColor: Color = Color(0xFF1A73E8),
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier,
     fontSize: androidx.compose.ui.unit.TextUnit = 19.sp
 ) {
@@ -568,7 +572,7 @@ fun CandidateItem(
     ) {
         Text(
             text = text,
-            color = if (isSelected) accentColor else textColor,
+            color = if (isSelected) selectedTextColor else textColor,
             fontSize = fontSize,
             fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
             maxLines = 1
@@ -577,7 +581,7 @@ fun CandidateItem(
             Spacer(modifier = Modifier.width(3.dp))
             Text(
                 text = comment,
-                color = if (isSelected) accentColor.copy(alpha = 0.6f) else textColor.copy(alpha = 0.5f),
+                color = if (isSelected) selectedTextColor.copy(alpha = 0.6f) else textColor.copy(alpha = 0.5f),
                 fontSize = (fontSize.value * 11f / 19f).sp,
                 fontWeight = FontWeight.Normal,
                 maxLines = 1

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HardwareKeyboardCandidateBar.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/HardwareKeyboardCandidateBar.kt
@@ -53,6 +53,7 @@ fun HardwareKeyboardCandidateBar(
     cardBackgroundColor: Color,
     candidateTextColor: Color,
     activeColor: Color,
+    selectedTextColor: Color = activeColor,
 ) {
     if (candidates.isEmpty() && inputText.isEmpty()) return
 
@@ -146,7 +147,7 @@ fun HardwareKeyboardCandidateBar(
                                 Text(
                                     text = "$labelText $candidate",
                                     fontSize = 15.sp,
-                                    color = if (isActive) activeColor else candidateTextColor,
+                                    color = if (isActive) selectedTextColor else candidateTextColor,
                                     fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
                                     maxLines = 1,
                                 )

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -172,6 +172,8 @@ fun KeyboardView(
     val candidateTextColor = KeyboardThemes.getCandidateTextColorOverride(state.themeId, state.isDarkTheme)
         ?: if (state.isDarkTheme) longToColor(kbColors.candidateTextColorDark)
         else longToColor(kbColors.candidateTextColor)
+    val candidateSelectedTextColor = KeyboardThemes.getCandidateSelectedTextColorOverride(state.themeId, state.isDarkTheme)
+        ?: KeyboardThemes.getCandidateSelectedTextColor(state.themeId, state.isDarkTheme)
     val dividerColor = if (state.isDarkTheme) androidx.compose.ui.graphics.Color(0xFF3C4043) else androidx.compose.ui.graphics.Color(0xFFDADCE0)
 
     val clipboardTab = (page as? KeyboardPage.Overlay)?.let {
@@ -298,6 +300,7 @@ fun KeyboardView(
                     textColor = candidateTextColor,
                     dividerColor = dividerColor,
                     accentColor = accentColor,
+                    selectedTextColor = candidateSelectedTextColor,
                     isDarkTheme = state.isDarkTheme
                 ),
                 callbacks = CandidateBarCallbacks(

--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ThemePreviewSheet.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ThemePreviewSheet.kt
@@ -207,6 +207,8 @@ private fun ThemeKeyboardPreview(
     val candidateTextColor = KeyboardThemes.getCandidateTextColorOverride(theme.id, isDark)
         ?: if (isDark) longToColor(kbColors.candidateTextColorDark)
         else longToColor(kbColors.candidateTextColor)
+    val selectedTextColor = KeyboardThemes.getCandidateSelectedTextColorOverride(theme.id, isDark)
+        ?: if (isDark) theme.candidateSelectedTextColorDark else theme.candidateSelectedTextColorLight
     val context = LocalContext.current
     val candidateTextSize = SettingsPreferences.getCandidateTextSize(context)
 
@@ -225,7 +227,7 @@ private fun ThemeKeyboardPreview(
                     .fillMaxSize()
                     .padding(start = 4.dp, end = 4.dp, bottom = 8.dp),
             ) {
-                CandidateBarPreview(accent, candidateTextColor, candidateTextSize)
+                CandidateBarPreview(accent, candidateTextColor, selectedTextColor, candidateTextSize)
 
                 Column(modifier = Modifier
                     .fillMaxWidth()
@@ -329,6 +331,7 @@ private fun ThemeKeyboardPreview(
 private fun CandidateBarPreview(
     accent: Color,
     textColor: Color,
+    selectedTextColor: Color,
     textSize: Int,
 ) {
     Column(
@@ -347,6 +350,7 @@ private fun CandidateBarPreview(
                 isSelected = true,
                 accent = accent,
                 textColor = textColor,
+                selectedTextColor = selectedTextColor,
                 textSize = textSize
             )
             Spacer(modifier = Modifier.width(4.dp))
@@ -355,6 +359,7 @@ private fun CandidateBarPreview(
                 isSelected = false,
                 accent = accent,
                 textColor = textColor,
+                selectedTextColor = selectedTextColor,
                 textSize = textSize
             )
         }
@@ -367,6 +372,7 @@ private fun PreviewCandidate(
     isSelected: Boolean,
     accent: Color,
     textColor: Color,
+    selectedTextColor: Color,
     textSize: Int,
 ) {
     Box(
@@ -377,7 +383,7 @@ private fun PreviewCandidate(
     ) {
         Text(
             text = text,
-            color = if (isSelected) accent else textColor,
+            color = if (isSelected) selectedTextColor else textColor,
             fontSize = textSize.sp,
             fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
             maxLines = 1,

--- a/app/src/main/java/com/kingzcheung/xime/ui/theme/KeyboardTheme.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/theme/KeyboardTheme.kt
@@ -58,6 +58,9 @@ data class KeyboardColorScheme(
     // 候选文字颜色
     val candidateTextColorLight: Color = Color(0xFF1A73E8),
     val candidateTextColorDark: Color = Color(0xFF8AB4F8),
+    // 候选选中文字颜色（未配置时回退到按键文字色）
+    val candidateSelectedTextColorLight: Color = Color(0xFF202124),
+    val candidateSelectedTextColorDark: Color = Color(0xFFE8EAED),
     // 分隔线颜色
     val dividerColorLight: Color = Color(0xFFDADCE0),
     val dividerColorDark: Color = Color(0xFF3C4043),
@@ -139,6 +142,8 @@ object KeyboardThemes {
             ?: longToColor(global.candidateTextColor)
         val candColorDark = entry.candidateTextColorDark?.let { longToColor(it) }
             ?: longToColor(global.candidateTextColorDark)
+        val candSelectedLight = entry.candidateSelectedTextColor?.let { longToColor(it) } ?: txtColor
+        val candSelectedDark = entry.candidateSelectedTextColorDark?.let { longToColor(it) } ?: txtColorDark
 
         return KeyboardColorScheme(
             id = id,
@@ -163,6 +168,8 @@ object KeyboardThemes {
             keyTextColorDark = txtColorDark,
             candidateTextColorLight = candColorLight,
             candidateTextColorDark = candColorDark,
+            candidateSelectedTextColorLight = candSelectedLight,
+            candidateSelectedTextColorDark = candSelectedDark,
             keyboardBackground = entry.keyboardBackground,
             keyBackground = entry.keyBackground,
             candidateBarBackground = entry.candidateBarBackground,
@@ -354,6 +361,12 @@ object KeyboardThemes {
                 ?: longToColor(global.candidateTextColor),
             candidateTextColorDark = entry.candidateTextColorDark?.let { longToColor(it) }
                 ?: longToColor(global.candidateTextColorDark),
+            candidateSelectedTextColorLight = entry.candidateSelectedTextColor?.let { longToColor(it) }
+                ?: (entry.keyTextColor?.let { longToColor(it) }
+                    ?: scheme.candidateSelectedTextColorLight),
+            candidateSelectedTextColorDark = entry.candidateSelectedTextColorDark?.let { longToColor(it) }
+                ?: (entry.keyTextColorDark?.let { longToColor(it) }
+                    ?: scheme.candidateSelectedTextColorDark),
             keyboardBackground = entry.keyboardBackground ?: scheme.keyboardBackground,
             keyBackground = entry.keyBackground ?: scheme.keyBackground,
             candidateBarBackground = entry.candidateBarBackground ?: scheme.candidateBarBackground,
@@ -426,6 +439,12 @@ object KeyboardThemes {
         return if (isDark) theme.candidateTextColorDark else theme.candidateTextColorLight
     }
 
+    /** 候选选中文字色，未显式配置时回退到按键文字色。 */
+    fun getCandidateSelectedTextColor(themeId: String, isDark: Boolean): Color {
+        val theme = getThemeById(themeId)
+        return if (isDark) theme.candidateSelectedTextColorDark else theme.candidateSelectedTextColorLight
+    }
+
     fun getDividerColor(themeId: String, isDark: Boolean): Color {
         val theme = getThemeById(themeId)
         return if (isDark) theme.dividerColorDark else theme.dividerColorLight
@@ -454,6 +473,16 @@ object KeyboardThemes {
             entry.candidateTextColorDark?.let { longToColor(it) }
         } else {
             entry.candidateTextColor?.let { longToColor(it) }
+        }
+    }
+
+    /** 返回 color_schemes 中显式定义的候选选中文字色，未定义返回 null。 */
+    fun getCandidateSelectedTextColorOverride(themeId: String, isDark: Boolean): Color? {
+        val entry = configOverrides[themeId] ?: return null
+        return if (isDark) {
+            entry.candidateSelectedTextColorDark?.let { longToColor(it) }
+        } else {
+            entry.candidateSelectedTextColor?.let { longToColor(it) }
         }
     }
 }


### PR DESCRIPTION
为键盘主题系统添加了候选选中文字颜色的独立配置选项，
允许用户自定义选中状态下的候选文字颜色。

- 在 color_schemes 中新增 candidate_selected_text_color 和 candidate_selected_text_color_dark 配置项
- 更新主题预览组件以显示新的颜色配置
- 修正选中状态文字颜色应用逻辑
- 添加相关注释说明颜色字段用途

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
