### PR TITLE
fix(input): 修复英文输入时undo_clear功能失效问题

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -16,8 +16,6 @@
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/marisa-trie" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/opencc" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/deps/yaml-cpp" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/plugins/lua" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/app/src/main/jni/librime/plugins/lua/thirdparty" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy/third_party/benchmark" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/app/src/main/jni/snappy/third_party/googletest" vcs="Git" />

--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -110,12 +110,17 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     //（composing 区），candState.inputText 与它是同一份内容，再拼接会重复
                     //（如 "ji hua"+"ji hua"="ji huaji hua"）；候选栏模式输入框只有已上屏文本，
                     // 才需补上候选栏中的编码 candState.inputText。
+                    // 英文输入时文本在 pendingEnglishText（composing 区），getTextBeforeCursor
+                    // 取不到，需显式拼接以支持 undo_clear 恢复。
                     val codeInInputBox = SettingsPreferences.getInputTextLocation(service) ==
                         SettingsPreferences.INPUT_TEXT_INPUT_BOX
                     val inputFieldText = withContext(Dispatchers.Main) {
                         service.currentInputConnection?.getTextBeforeCursor(XimeInputMethodService.SAFE_TEXT_LIMIT, 0)?.toString() ?: ""
                     }
-                    service.lastClearedText = if (codeInInputBox) inputFieldText else inputFieldText + candState.inputText
+                    service.lastClearedText = when {
+                        codeInInputBox -> inputFieldText + candState.pendingEnglishText
+                        else -> inputFieldText + candState.inputText + candState.pendingEnglishText
+                    }
                     // 清空 partial commit 累积：否则残留的已选词（如右选"几乎"）会在下一轮输入
                     // 被 buildT9DisplayState 拼进 preedit（"几乎ji hua"）。
                     service.t9PartialCommitTexts.clear()

--- a/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/XimeInputMethodService.kt
@@ -1412,9 +1412,14 @@ class XimeInputMethodService : InputMethodService(), LifecycleOwner, SavedStateR
         endComposingInputBox()
     }
 
-    /** 结束输入框中的 composing span，先清空内容再结束，避免转为 committed text。 */
+    /**
+     * 结束输入框中的 composing span，先清空内容再结束，避免转为 committed text。
+     *
+     * 无论输入位置设置（输入框/候选栏）都执行：英文输入（pendingEnglishText）始终通过
+     * setComposingText 写入编辑器，清空时若跳过会残留英文 composing 文本。
+     * 中文候选栏模式下编辑器无 composing 文本，本方法为空操作。
+     */
     internal fun endComposingInputBox() {
-        if (SettingsPreferences.getInputTextLocation(this) != SettingsPreferences.INPUT_TEXT_INPUT_BOX) return
         currentInputConnection?.let {
             it.setComposingText("", 0)
             it.finishComposingText()

--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyboardView.kt
@@ -215,7 +215,7 @@ fun KeyboardView(
             val cs = candidateState.value
             val candidateBarState = remember(
                 cs.candidates, cs.candidateComments, cs.inputText, cs.preeditText, cs.isComposing,
-                cs.associationCandidates, cs.isShowingRecentClipboard, cs.hasNextPage,
+                cs.associationCandidates, cs.pendingEnglishText, cs.isShowingRecentClipboard, cs.hasNextPage,
                 state.isCalculatorMode, handwritingCandidates, handwritingComments, showHandwritingCandidates,
             ) {
                 if (showHandwritingCandidates) {


### PR DESCRIPTION
当英文输入时，文本存储在pendingEnglishText中，getTextBeforeCursor无法获取， 需要显式拼接pendingEnglishText以支持undo_clear恢复功能。

同时调整了endComposingInputBox逻辑，使其无论输入位置设置如何都执行，
确保英文输入的composing文本能被正确清空，避免残留。

feat(candidate): 更新候选栏状态依赖以包含pendingEnglishText

chore(vcs): 移除lua插件的VCS映射配置

更新rime和librime-lua-deps子模块到dirty状态

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
