### PR TITLE
fix(t9): 修复九键回退预编辑异常与右选后候选栏不刷新

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
+++ b/app/src/main/java/com/kingzcheung/xime/service/ImeKeyRouter.kt
@@ -784,9 +784,12 @@ internal class ImeKeyRouter(private val service: XimeInputMethodService) {
                     )
                     // RIME composition 未被 selectCandidate 修改（已跳过），
                     // 直接发送剩余数字到 RIME 重建 composition。
+                    // 候选栏由 forceSendToRime 异步 post 刷新；此处不可同步调 updateUI，
+                    // 否则与 refreshOnBackground 竞争 rimeLock，空数据覆盖候选栏。
                     service.keyboardCallbacks?.onT9ForceSendToRime?.invoke()
+                } else {
+                    service.updateUI()
                 }
-                service.updateUI()
             }
         }
     }

--- a/app/src/main/jni/librime-t9/src/t9_undo_model.cc
+++ b/app/src/main/jni/librime-t9/src/t9_undo_model.cc
@@ -516,14 +516,31 @@ bool T9UndoModel::UndoOp(const T9SegmentOp& op) {
             return true;
         }
         case T9SegmentOp::kTailConsume: {
-            // 恢复被消费的 tail 部分（仅该次消费的数字，放回 tail 开头）。
-            // 修复（2026-08-05，设备实证）：不能完整恢复 prev_tail——多次 tail 消费
-            // （如右选"几 ji"+"股 gu"各消费 2 位）时，后 undo 完整恢复会重复恢复
-            // 已删除的早期数字（回退次数 10 vs 设计 7）。消费的数字 = prev_tail 开头 n 位
-            // （ConsumeTail 总是从 tail 开头消费）。
+            // 恢复被消费的 tail 数字到开头。
+            // 修复（2026-08-09）：undo TC 前若存在 undo LC 残留的 unassigned 段，
+            // 其数字一并并入 tail；段数字是 prev_tail 剩余部分的后缀（原位置在被
+            // 恢复数字之后）→ 顺序 = consumed + 段数字，否则段数字 + consumed，
+            // 避免派生 unassigned 顺序错乱（'34' 而非 '43'，预编辑 "k di" 异常）。
             std::string consumed =
                 op.prev_tail.substr(0, static_cast<size_t>(op.tail_consumed));
-            tail_digits_ = consumed + tail_digits_;
+            std::string remaining =
+                op.prev_tail.substr(static_cast<size_t>(op.tail_consumed));
+            std::string seg_digits;
+            for (auto& seg : segments_) {
+                if (seg.phase == T9Segment::kUnassigned && !seg.digits.empty()) {
+                    seg_digits += seg.digits;
+                    seg.digits.clear();
+                }
+            }
+            std::string restored;
+            if (remaining.size() >= seg_digits.size() &&
+                remaining.compare(remaining.size() - seg_digits.size(),
+                                  seg_digits.size(), seg_digits) == 0) {
+                restored = consumed + seg_digits;
+            } else {
+                restored = seg_digits + consumed;
+            }
+            tail_digits_ = restored + tail_digits_;
             undone_commit_count_++;  // 撤销一个 commit 操作（供 Kotlin 同步）
             return true;
         }

--- a/app/src/main/jni/librime-t9/test/t9_undo_model_test.cc
+++ b/app/src/main/jni/librime-t9/test/t9_undo_model_test.cc
@@ -1072,6 +1072,62 @@ TEST(T9UndoModelTest, Scenario33_5143_KHe_KouHao_D_PartialConsume) {
     EXPECT_TRUE(m.IsEmpty());
 }
 
+// 用户实测（2026-08-09）：5143 左选 k → 右选"客户 ke hu"（简拼 k h：commit k 段 +
+// TC 消费 tail '4'，linked）→ 左选 e（消费剩余 '3'）→ ⌫1 undo e → ⌫2 undo 客户。
+// 修复前：undo 客户 后 tail='4'、e 段 digits='3' 残留 → 派生 unassigned='34'（预编辑
+// "k di"，异常字符 'i'）；期望派生 unassigned='43'（"k he/ge"）。
+// 根因：UndoOp(kTailConsume) 恢复 tail 时假设"剩余 tail 数字都在 tail_digits_ 中"，
+// 但 undo LC 残留的 unassigned 段数字（原输入位置在被恢复数字之后）打破了该假设。
+// 修复：undo TC 恢复 tail 时把 undo LC 残留的 unassigned 段数字一并并入 tail。
+TEST(T9UndoModelTest, Scenario5143_K_KeHu_E_UndoKeHu_TailOrder) {
+    T9UndoModel m;
+    for (char d : std::string("543")) m.DigitPressed(d);
+    m.SeparatorPressed(1);  // 分词键 1（'5' 与 '4' 之间）
+    m.LeftChoice(SyllableOption("k", 1));
+    // 右选"客户 ke hu"：commit k 段 + TC 消费 tail '4'（linked）
+    m.SyncRightCommit(
+        T9Buffer("543", {SyllableOption("k", 1)}, 1, 4),
+        T9Buffer("3", {}, 0, 4));
+    ASSERT_EQ(1u, m.segments().size());
+    EXPECT_EQ(T9Segment::kCommitted, m.segments()[0].phase);
+    EXPECT_EQ("3", m.tail_digits());
+    // 左选 e → 从 tail 消费剩余 '3'
+    m.LeftChoice(SyllableOption("e", 1));
+    ASSERT_EQ(2u, m.segments().size());
+    EXPECT_EQ(T9Segment::kSelected, m.segments()[1].phase);
+    EXPECT_EQ("3", m.segments()[1].digits);
+    EXPECT_EQ("", m.tail_digits());
+    // ⌫1: undo e（数字保留在段，等待数字区删除）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ(T9Segment::kUnassigned, m.segments()[1].phase);
+    EXPECT_EQ("3", m.segments()[1].digits);
+    // ⌫2: undo 客户（RC+TC linked 整体撤销）→ tail 恢复 '43'（'4' 在 '3' 前）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ(T9Segment::kSelected, m.segments()[0].phase);
+    EXPECT_EQ("43", m.tail_digits());
+    // e 段残留空段（数字已收拢回 tail，保持原始顺序）
+    EXPECT_EQ("", m.segments()[1].digits);
+    // 派生 buffer：unassigned='43'（修复前 '34' → 预编辑 "k di"）
+    T9Buffer buf = m.ToBuffer();
+    EXPECT_EQ("543", buf.digit_sequence);
+    EXPECT_EQ(1, buf.consumed_count);
+    EXPECT_EQ("43", buf.unassigned());
+    // 后续回退：删 3,4（tail 末位）→ undo k → 删分词键 → 删 5
+    // （e 段数字已收拢回 tail 并删除 → 残留空段无操作可撤销，自然跳过）
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ("4", m.tail_digits());
+    EXPECT_TRUE(m.Backspace());
+    EXPECT_EQ("", m.tail_digits());
+    EXPECT_TRUE(m.Backspace());  // undo k → k 回 unassigned
+    EXPECT_EQ(T9Segment::kUnassigned, m.segments()[0].phase);
+    EXPECT_TRUE(m.Backspace());  // 删分词键 1
+    EXPECT_TRUE(m.separator_positions().empty());
+    EXPECT_TRUE(m.Backspace());  // 删 '5'
+    EXPECT_EQ("", m.segments()[0].digits);
+    EXPECT_FALSE(m.Backspace());
+    EXPECT_TRUE(m.IsEmpty());
+}
+
 // 场景：54482 无左选，纯右选"几"（ji 54）、"股"（gu 48）→ 回退 = 7 次。
 // 回归（2026-08-05）：undo kTailConsume 曾完整恢复 prev_tail，嵌套消费（两次
 // ConsumeTail）时 undo 几 重复恢复已删的 482 → 次数 10 vs 设计 7。


### PR DESCRIPTION
## 概述
@kingzcheung 
修复特定场景九键回退预编辑文本异常，以及右选候选词候选栏不刷新问题。

## 关联 Issue

Closes #602 、#598 、#598 、#565 

## 改动
两个独立 commit，各对应一个 issue，遵循最小修改原则：

1. fix(t9): 修复 undo TC 恢复 tail 顺序错位导致回退预编辑异常
   - librime-t9/src/t9_undo_model.cc：UndoOp(kTailConsume) 并入 undo LC
     残留的 unassigned 段数字，保持 tail 数字原始顺序
   - 新增单测 Scenario5143_K_KeHu_E_UndoKeHu_TailOrder

2. fix(t9): 恢复 partial commit 纯异步刷新，消除 rimeLock 竞争
   - ImeKeyRouter.kt：partial 分支 T9 不调同步 updateUI，非 T9 保留

## 验证
- C++ 单测：267 全通过（16 套件）
- 构建：./gradlew assembleDebug 成功
- 设备：两个场景均已复现验证通过

## 影响范围
仅 T9 九键路径（librime-t9 插件 + partial commit 分支）；
全键盘方案不注册 t9 组件，不受影响。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
