### PR TITLE
fix(keyboard): 修复键盘按键横向滑动手势时错误触发点击的问题

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -143,6 +143,8 @@ fun KeyButton(
     val swipeDownThreshold = with(density) { 50.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
+    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击
+    val horizontalClickCancelThreshold = with(density) { 30.dp.toPx() }
 
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
         if (shadowEnabled) {
@@ -189,7 +191,7 @@ fun KeyButton(
                             isSwipeDown = false
                         },
                         onDragEnd = {
-                            if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown) {
+                            if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown && abs(dragOffsetX) < horizontalClickCancelThreshold) {
                                 currentOnClick()
                             }
                             isPressed = false
@@ -205,9 +207,6 @@ fun KeyButton(
                             onSwipeStateChange?.invoke(SwipeState(false, null, false))
                         },
                         onDragCancel = {
-                            if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown) {
-                                currentOnClick()
-                            }
                             isPressed = false
                             currentOnRelease?.invoke()
                             dragOffsetX = 0f
@@ -403,6 +402,8 @@ fun SwipeableKeyButton(
     val swipeDownThreshold = with(density) { 50.dp.toPx() }
     val bubbleShowThresholdUp = swipeUpThreshold
     val bubbleShowThresholdDown = swipeDownThreshold
+    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击
+    val horizontalClickCancelThreshold = with(density) { 30.dp.toPx() }
 
     val shadowModifier = remember(shadowEnabled, shadowElevation, shadowShapeRadius, density, backgroundColor) {
         if (shadowEnabled) {
@@ -440,7 +441,7 @@ fun SwipeableKeyButton(
                         isSwipeDown = false
                     },
                     onDragEnd = {
-                        if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown) {
+                        if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown && abs(dragOffsetX) < horizontalClickCancelThreshold) {
                             currentOnClick()
                         }
                         isPressed = false
@@ -455,9 +456,6 @@ fun SwipeableKeyButton(
                         currentOnSwipeStateChange?.invoke(SwipeState(false, null, false, emptyList(), false, null), buttonBounds)
                     },
                     onDragCancel = {
-                        if (!hasTriggeredSwipeUp && !hasTriggeredSwipeDown) {
-                            currentOnClick()
-                        }
                         isPressed = false
                         currentOnRelease?.invoke()
                         dragOffsetX = 0f
@@ -963,6 +961,8 @@ fun SwipeableIconKeyButton(
     // 上滑清空/下滑撤回需要更大的滑动距离，防止误触
     val clearActionThreshold = with(density) { (-50).dp.toPx() }
     val undoActionThreshold = with(density) { 50.dp.toPx() }
+    // 水平位移超过该值视为横向手势（如键盘区滑动移动光标），不再触发点击
+    val horizontalClickCancelThreshold = with(density) { 30.dp.toPx() }
     
     LaunchedEffect(isLongPress) {
         if (isLongPress && onLongClick != null) {
@@ -1059,7 +1059,7 @@ fun SwipeableIconKeyButton(
                         } else if (dragOffsetY < swipeUpThreshold && !hasTriggeredSwipe && onSwipe != null) {
                             hasTriggeredSwipe = true
                             onSwipe()
-                        } else {
+                        } else if (!hasTriggeredSwipeLeft && abs(dragOffsetX) < horizontalClickCancelThreshold) {
                             currentOnClick()
                         }
                         dragActivated = false
@@ -1080,7 +1080,6 @@ fun SwipeableIconKeyButton(
                         onSwipeStateChange?.invoke(SwipeState(), buttonBounds)
                     },
                     onDragCancel = {
-                        currentOnClick()
                         dragActivated = false
                         isPressed = false
                         currentOnRelease?.invoke()


### PR DESCRIPTION
- 添加水平位移阈值判断，当水平滑动超过30dp时不再触发点击事件
- 防止键盘区域滑动移动光标时误触按键
- 移除拖拽取消时的点击触发逻辑，避免意外激活按键功能
- 在KeyButton、SwipeableKeyButton和SwipeableIconKeyButton中统一应用手势识别优化

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
