### PR TITLE
feat(workflow): 添加子模块验证工作流

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,8 +60,39 @@ jobs:
             echo "reason=New commits to build"
           fi
 
+  validate-submodules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Validate submodule gitlinks exist on remotes
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r name; do
+            path=$(git config -f .gitmodules --get "submodule.$name.path")
+            url=$(git config -f .gitmodules --get "submodule.$name.url")
+            sha=$(git ls-tree HEAD "$path" | awk '{print $3}')
+            echo "Checking $path -> $url"
+            if [ -z "$sha" ] || [ "$sha" = "040000" ]; then
+              echo "::error::$path is not a submodule gitlink"
+              fail=1
+              continue
+            fi
+            if git ls-remote "$url" "$sha" 2>/dev/null | grep -q "$sha"; then
+              echo "OK: $sha exists"
+            else
+              echo "::error::$path gitlink $sha not found on $url (force-pushed or deleted?)"
+              fail=1
+            fi
+          done < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | sed -E 's/^submodule\.(.*)\.path /\1/')
+          exit $fail
+
   nightly:
-    needs: check
+    needs: [check, validate-submodules]
     if: needs.check.outputs.should_build == 'true'
     runs-on: ubuntu-latest
 

--- a/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/SettingsPreferences.kt
@@ -83,7 +83,7 @@ object SettingsPreferences {
     private const val KEY_CANDIDATE_TEXT_SIZE = "candidate_text_size"
     const val INPUT_TEXT_INPUT_BOX = "input_box"
     const val INPUT_TEXT_CANDIDATE_BAR = "candidate_bar"
-    const val DEFAULT_PAGE_SIZE = 0 // 0 表示使用 Rime schema 默认值
+    const val DEFAULT_PAGE_SIZE = 20 // 手机候选栏每页候选词数；schema 里的 page_size 来自 PC 版（5），太短，默认用 20
 
     fun isCompactModeEnabled(context: Context): Boolean {
         return getPrefs(context).getBoolean(KEY_COMPACT_MODE, true)


### PR DESCRIPTION
添加 validate-submodules 工作流来检查子模块 gitlinks 是否存在于远程仓库， 确保子模块引用的有效性，防止因强制推送或删除导致的构建失败。

fix(settings): 调整默认候选词页面大小

将候选词页面大小从0改为20，适配手机端候选栏显示需求。
原PC版schema的页面大小为5，在移动端显示过短，调整为默认20个候选词。

chore(submodule): 更新子模块引用

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
