### PR TITLE
feat(settings): 实现颜色主题配置的深度合并功能

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
+++ b/app/src/main/java/com/kingzcheung/xime/settings/KeysConfigHelper.kt
@@ -815,7 +815,34 @@ object KeysConfigHelper {
     ): Map<String, ColorSchemeEntry>? {
         if (custom == null) return default
         if (default == null) return custom
-        return default + custom
+        // 字段级深合并：custom 只覆盖显式配置的字段，同名主题其余字段保留内置值。
+        // 例如 custom 只写 primary_color 时，内置主题的 keyboard_background 不会被清掉。
+        val result = default.toMutableMap()
+        for ((id, customEntry) in custom) {
+            val base = default[id] ?: run {
+                result[id] = customEntry
+                continue
+            }
+            result[id] = base.copy(
+                name = customEntry.name.ifEmpty { base.name },
+                primaryColor = customEntry.primaryColor.takeIf { it != 0L } ?: base.primaryColor,
+                keyboardBgColor = customEntry.keyboardBgColor ?: base.keyboardBgColor,
+                keyBgColor = customEntry.keyBgColor ?: base.keyBgColor,
+                keyBgColorDark = customEntry.keyBgColorDark ?: base.keyBgColorDark,
+                specialKeyBgColor = customEntry.specialKeyBgColor ?: base.specialKeyBgColor,
+                candidateBarBgColor = customEntry.candidateBarBgColor ?: base.candidateBarBgColor,
+                keyTextColor = customEntry.keyTextColor ?: base.keyTextColor,
+                keyTextColorDark = customEntry.keyTextColorDark ?: base.keyTextColorDark,
+                candidateTextColor = customEntry.candidateTextColor ?: base.candidateTextColor,
+                candidateTextColorDark = customEntry.candidateTextColorDark ?: base.candidateTextColorDark,
+                candidateSelectedTextColor = customEntry.candidateSelectedTextColor ?: base.candidateSelectedTextColor,
+                candidateSelectedTextColorDark = customEntry.candidateSelectedTextColorDark ?: base.candidateSelectedTextColorDark,
+                keyboardBackground = customEntry.keyboardBackground ?: base.keyboardBackground,
+                keyBackground = customEntry.keyBackground ?: base.keyBackground,
+                candidateBarBackground = customEntry.candidateBarBackground ?: base.candidateBarBackground,
+            )
+        }
+        return result
     }
 
     private fun readAssetText(context: Context, fileName: String): String? {

--- a/docs/config_examples/wubi_compact/xime.custom.yaml
+++ b/docs/config_examples/wubi_compact/xime.custom.yaml
@@ -74,33 +74,7 @@ color_schemes:
 #   # 也支持字符串简写：
 #   long_press: { display: "bubble", values: ["q", "Q"] }
 keyboard:
-  # ── 键盘颜色配置（可选，不设置则使用内置默认值）──
-  # keyboard_bg_color        - 键盘背景色（亮色）
-  # keyboard_bg_color_dark   - 键盘背景色（暗色）
-  # key_bg_color             - 按键背景色（亮色）
-  # key_bg_color_dark        - 按键背景色（暗色）
-  # special_key_bg_color     - 特殊按键背景色（亮色）
-  # special_key_bg_color_dark- 特殊按键背景色（暗色）
-  # candidate_bar_bg_color   - 候选栏背景色（亮色）
-  # candidate_bar_bg_color_dark- 候选栏背景色（暗色）
-  # key_text_color           - 按键文字颜色（亮色）
-  # key_text_color_dark      - 按键文字颜色（暗色）
-  # candidate_text_color     - 候选文字颜色（亮色）
-  # candidate_text_color_dark- 候选文字颜色（暗色）
-  colors:
-    keyboard_bg_color: 0xE3E4E8
-    keyboard_bg_color_dark: 0x202020
-    key_bg_color: 0xFFFFFF
-    key_bg_color_dark: 0x4A4A4A
-    # special_key_bg_color: 0x9fef86 #不设置时默认取主题色
-    # special_key_bg_color_dark: 0x4A4A4A #不设置时默认取主题色
-    candidate_bar_bg_color: 0xE3E4E8
-    candidate_bar_bg_color_dark: 0x202020
-    key_text_color: 0x202124
-    key_text_color_dark: 0xE8EAED
-    candidate_text_color: 0x202124
-    candidate_text_color_dark: 0xE8EAED
-  
+
   # ── 按键配置（可选，不设置则使用默认值）──
   # corner_radius:      按键圆角半径（dp，默认 8）
   key:


### PR DESCRIPTION
当自定义颜色主题只配置部分字段时，其他未配置的字段将保留内置主题的默认值，
避免出现颜色丢失或重置的问题。现在可以单独修改某个颜色属性而不影响其他属性。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
