### PR TITLE
feat(keyboard): 调整滑动提示文本的视觉效果

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/keyboard/KeyButton.kt
@@ -693,9 +693,9 @@ fun SwipeableKeyButton(
                             val displayText = if (swipeDownHint.length <= 12) swipeDownHint else swipeDownHint.take(12)
                             Text(
                                 text = displayText,
-                                color = textColor.copy(alpha = 0.5f),
+                                color = textColor.copy(alpha = 0.7f),
                                 fontSize = adjustedFontSize,
-                                fontWeight = FontWeight.Normal,
+                                fontWeight = FontWeight.Medium,
                                 textAlign = TextAlign.Right,
                                 maxLines = 3,
                                 lineHeight = adjustedFontSize,


### PR DESCRIPTION
增加滑动提示文本的透明度从0.5到0.7，使提示更加清晰可见。
将字体粗细从Normal调整为Medium，提升文字的可读性。

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [ ] 代码编译通过
- [ ] 已运行 `./gradlew test` 并通过
- [ ] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
