### PR TITLE
feat(asr): 移除ASR模型线程数参数并优化会话管理

### DIFF
--- a/app/src/main/java/com/kingzcheung/xime/ui/settings/ModelLocalScreen.kt
+++ b/app/src/main/java/com/kingzcheung/xime/ui/settings/ModelLocalScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
@@ -139,6 +140,29 @@ fun ModelLocalContent(
                 ) {
                     item {
                         Spacer(Modifier.height(4.dp))
+                        Surface(
+                            shape = RoundedCornerShape(8.dp),
+                            color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f),
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    Icons.Default.Info,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    "使用本地模型是有代价的：本地推理会占用 CPU、增加耗电并可能导致手机发热，请斟酌使用。",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                )
+                            }
+                        }
+                        Spacer(Modifier.height(8.dp))
                         Text(
                             "共 ${localModels.size} 个本地模型",
                             style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/jni/asr/asr_jni.cc
+++ b/app/src/main/jni/asr/asr_jni.cc
@@ -53,7 +53,7 @@ Java_com_kingzcheung_xime_speech_AsrNative_nativeCreate(JNIEnv *env, jobject,
 
   auto *holder = new (std::nothrow) RecognizerHolder();
   if (!holder) return 0;
-  holder->rec = std::make_unique<StreamingRecognizer>(paths, tokens, 4);
+  holder->rec = std::make_unique<StreamingRecognizer>(paths, tokens);
   if (!holder->rec->LoadOk()) {
     LOGE("nativeCreate: failed to load ASR model");
     delete holder;

--- a/app/src/main/jni/asr/streaming_recognizer.cc
+++ b/app/src/main/jni/asr/streaming_recognizer.cc
@@ -40,11 +40,10 @@ std::vector<std::string> LoadSymbolTable(const std::string &path) {
 }  // namespace
 
 StreamingRecognizer::StreamingRecognizer(const AsrModelPaths &paths,
-                                         const std::string &tokens_path,
-                                         int32_t num_threads)
+                                         const std::string &tokens_path)
     : decoder_out_(nullptr) {
   try {
-    model_ = std::make_unique<Zipformer2Model>(paths, num_threads);
+    model_ = std::make_unique<Zipformer2Model>(paths);
     id2sym_ = LoadSymbolTable(tokens_path);
     chunk_size_ = model_->ChunkSize();
     chunk_shift_ = model_->ChunkShift();

--- a/app/src/main/jni/asr/streaming_recognizer.h
+++ b/app/src/main/jni/asr/streaming_recognizer.h
@@ -20,7 +20,7 @@ namespace xime_asr {
 class StreamingRecognizer {
  public:
   StreamingRecognizer(const AsrModelPaths &paths,
-                      const std::string &tokens_path, int32_t num_threads = 2);
+                      const std::string &tokens_path);
 
   bool LoadOk() const { return loaded_; }
 

--- a/app/src/main/jni/asr/zipformer2_model.cc
+++ b/app/src/main/jni/asr/zipformer2_model.cc
@@ -12,6 +12,7 @@
 #include <map>
 #include <numeric>
 #include <sstream>
+#include <stdexcept>
 
 #include "onnx_env.h"
 
@@ -122,16 +123,15 @@ Ort::Value Cat(OrtAllocator *alloc, const std::vector<Ort::Value *> &ins,
 
 }  // namespace
 
-Zipformer2Model::Zipformer2Model(const AsrModelPaths &paths,
-                                 int32_t num_threads)
-    : env_(ORT_LOGGING_LEVEL_WARNING, "xime-asr"), allocator_{} {
+Zipformer2Model::Zipformer2Model(const AsrModelPaths &paths) : allocator_{} {
   // 纯 CPU 推理。zipformer2 为 int8 + 动态 shape 的流式模型，NNAPI 支持率
   // 不足 5%（且多为 CPU reference 驱动），切图开销大于收益，故不启用硬件 EP。
   OnnxGetApi();  // 初始化 C API
 
-  auto configure = [this, num_threads](Ort::SessionOptions &opts) {
-    opts.SetIntraOpNumThreads(num_threads);
-    opts.SetInterOpNumThreads(1);
+  // 复用全局共享 env 的 intra-op 线程池（2 线程），而非每个 session 自建
+  // 线程池。此前 3 个 session × 4 线程 = 12 个常驻线程，是模型驻留期间
+  // 待机发热的主要来源（线程池空闲时仍周期性 spin-wait）。
+  auto configure = [](Ort::SessionOptions &opts) {
     OnnxTryEnableCpuFallback(opts);
   };
   configure(encoder_sess_opts_);
@@ -144,30 +144,71 @@ Zipformer2Model::Zipformer2Model(const AsrModelPaths &paths,
 }
 
 void Zipformer2Model::LoadEncoderSession(const std::string &path) {
-  encoder_sess_ = std::make_unique<Ort::Session>(env_, path.c_str(),
-                                                 encoder_sess_opts_);
-  encoder_input_names_ = GetInputNames(encoder_sess_.get());
-  encoder_output_names_ = GetOutputNames(encoder_sess_.get());
+  const OrtApi *api = OnnxGetApi();
+  OrtEnv *env = OnnxGetSharedEnv();
+  if (!api || !env) {
+    throw std::runtime_error("ONNX Runtime env not available");
+  }
+  OrtSession *raw = nullptr;
+  OrtStatus *status = api->CreateSession(env, path.c_str(), encoder_sess_opts_, &raw);
+  if (status) {
+    LOGE("Failed to create encoder session: %s", api->GetErrorMessage(status));
+    api->ReleaseStatus(status);
+    throw std::runtime_error("Create encoder session failed");
+  }
+  encoder_sess_ = Ort::UnownedSession{raw};
+  encoder_input_names_ = GetInputNames(&encoder_sess_);
+  encoder_output_names_ = GetOutputNames(&encoder_sess_);
   ReadEncoderMetadata();
 }
 
 void Zipformer2Model::LoadDecoderSession(const std::string &path) {
-  decoder_sess_ = std::make_unique<Ort::Session>(env_, path.c_str(),
-                                                 decoder_sess_opts_);
-  decoder_input_names_ = GetInputNames(decoder_sess_.get());
-  decoder_output_names_ = GetOutputNames(decoder_sess_.get());
+  const OrtApi *api = OnnxGetApi();
+  OrtEnv *env = OnnxGetSharedEnv();
+  if (!api || !env) {
+    throw std::runtime_error("ONNX Runtime env not available");
+  }
+  OrtSession *raw = nullptr;
+  OrtStatus *status = api->CreateSession(env, path.c_str(), decoder_sess_opts_, &raw);
+  if (status) {
+    LOGE("Failed to create decoder session: %s", api->GetErrorMessage(status));
+    api->ReleaseStatus(status);
+    throw std::runtime_error("Create decoder session failed");
+  }
+  decoder_sess_ = Ort::UnownedSession{raw};
+  decoder_input_names_ = GetInputNames(&decoder_sess_);
+  decoder_output_names_ = GetOutputNames(&decoder_sess_);
   ReadDecoderMetadata();
 }
 
 void Zipformer2Model::LoadJoinerSession(const std::string &path) {
-  joiner_sess_ = std::make_unique<Ort::Session>(env_, path.c_str(),
-                                                joiner_sess_opts_);
-  joiner_input_names_ = GetInputNames(joiner_sess_.get());
-  joiner_output_names_ = GetOutputNames(joiner_sess_.get());
+  const OrtApi *api = OnnxGetApi();
+  OrtEnv *env = OnnxGetSharedEnv();
+  if (!api || !env) {
+    throw std::runtime_error("ONNX Runtime env not available");
+  }
+  OrtSession *raw = nullptr;
+  OrtStatus *status = api->CreateSession(env, path.c_str(), joiner_sess_opts_, &raw);
+  if (status) {
+    LOGE("Failed to create joiner session: %s", api->GetErrorMessage(status));
+    api->ReleaseStatus(status);
+    throw std::runtime_error("Create joiner session failed");
+  }
+  joiner_sess_ = Ort::UnownedSession{raw};
+  joiner_input_names_ = GetInputNames(&joiner_sess_);
+  joiner_output_names_ = GetOutputNames(&joiner_sess_);
+}
+
+Zipformer2Model::~Zipformer2Model() {
+  const OrtApi *api = OnnxGetApi();
+  if (!api) return;
+  if (encoder_sess_) api->ReleaseSession(encoder_sess_);
+  if (decoder_sess_) api->ReleaseSession(decoder_sess_);
+  if (joiner_sess_) api->ReleaseSession(joiner_sess_);
 }
 
 std::vector<std::string> Zipformer2Model::GetInputNames(
-    const Ort::Session *sess) const {
+    const Ort::UnownedSession *sess) const {
   std::vector<std::string> names;
   size_t n = sess->GetInputCount();
   names.reserve(n);
@@ -179,7 +220,7 @@ std::vector<std::string> Zipformer2Model::GetInputNames(
 }
 
 std::vector<std::string> Zipformer2Model::GetOutputNames(
-    const Ort::Session *sess) const {
+    const Ort::UnownedSession *sess) const {
   std::vector<std::string> names;
   size_t n = sess->GetOutputCount();
   names.reserve(n);
@@ -191,7 +232,7 @@ std::vector<std::string> Zipformer2Model::GetOutputNames(
 }
 
 void Zipformer2Model::ReadEncoderMetadata() {
-  auto meta = encoder_sess_->GetModelMetadata();
+  auto meta = encoder_sess_.GetModelMetadata();
   auto lookup = [&](const char *key) -> std::string {
     auto v = meta.LookupCustomMetadataMapAllocated(key, allocator_);
     return v.get();
@@ -224,7 +265,7 @@ void Zipformer2Model::ReadEncoderMetadata() {
 }
 
 void Zipformer2Model::ReadDecoderMetadata() {
-  auto meta = decoder_sess_->GetModelMetadata();
+  auto meta = decoder_sess_.GetModelMetadata();
   auto lookup = [&](const char *key) -> std::string {
     auto v = meta.LookupCustomMetadataMapAllocated(key, allocator_);
     return v.get();
@@ -252,7 +293,7 @@ Zipformer2Model::RunEncoder(Ort::Value features, std::vector<Ort::Value> states,
   in_vals.push_back(std::move(features));
   for (auto &v : states) in_vals.push_back(std::move(v));
 
-  auto out = encoder_sess_->Run(Ort::RunOptions{nullptr}, in_names.data(),
+  auto out = encoder_sess_.Run(Ort::RunOptions{nullptr}, in_names.data(),
                                 in_vals.data(), in_vals.size(),
                                 out_names.data(), out_names.size());
 
@@ -267,7 +308,7 @@ Ort::Value Zipformer2Model::RunDecoder(Ort::Value decoder_input) {
   for (auto &s : decoder_input_names_) in_names.push_back(s.c_str());
   std::vector<const char *> out_names;
   for (auto &s : decoder_output_names_) out_names.push_back(s.c_str());
-  auto out = decoder_sess_->Run(Ort::RunOptions{nullptr}, in_names.data(),
+  auto out = decoder_sess_.Run(Ort::RunOptions{nullptr}, in_names.data(),
                                 &decoder_input, 1, out_names.data(),
                                 out_names.size());
   return std::move(out[0]);
@@ -292,7 +333,7 @@ Ort::Value Zipformer2Model::RunJoiner(Ort::Value encoder_out,
     in_vals.push_back(std::move(decoder_out));
     in_vals.push_back(std::move(encoder_out));
   }
-  auto out = joiner_sess_->Run(Ort::RunOptions{nullptr}, in_names.data(),
+  auto out = joiner_sess_.Run(Ort::RunOptions{nullptr}, in_names.data(),
                                in_vals.data(), in_vals.size(), out_names.data(),
                                out_names.size());
   return std::move(out[0]);
@@ -303,7 +344,7 @@ std::vector<Ort::Value> Zipformer2Model::GetEncoderInitStates() {
   // 第一个 encoder 输入是特征 x，其余为状态。逐个按模型声明的期望形状
   // 生成零状态（float/int64 依元素类型），避免对模型输入顺序/形状的硬编码。
   for (size_t i = 1; i < encoder_input_names_.size(); ++i) {
-    auto info = encoder_sess_->GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+    auto info = encoder_sess_.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
     auto shape = info.GetShape();
     for (auto &d : shape) {
       if (d == -1) d = 1;  // dynamic dim -> 1

--- a/app/src/main/jni/asr/zipformer2_model.h
+++ b/app/src/main/jni/asr/zipformer2_model.h
@@ -27,7 +27,8 @@ struct AsrModelPaths {
 // encoder/decoder/joiner inference plus encoder recurrent-state management.
 class Zipformer2Model {
  public:
-  explicit Zipformer2Model(const AsrModelPaths &paths, int32_t num_threads = 2);
+  explicit Zipformer2Model(const AsrModelPaths &paths);
+  ~Zipformer2Model();
 
   // ---- encoder ----
   // features: (N, T, feat_dim) float; states: encoder recurrent state.
@@ -73,17 +74,17 @@ class Zipformer2Model {
   void ReadEncoderMetadata();
   void ReadDecoderMetadata();
 
-  std::vector<std::string> GetInputNames(const Ort::Session *sess) const;
-  std::vector<std::string> GetOutputNames(const Ort::Session *sess) const;
+  std::vector<std::string> GetInputNames(const Ort::UnownedSession *sess) const;
+  std::vector<std::string> GetOutputNames(const Ort::UnownedSession *sess) const;
 
-  Ort::Env env_;
   Ort::SessionOptions encoder_sess_opts_;
   Ort::SessionOptions decoder_sess_opts_;
   Ort::SessionOptions joiner_sess_opts_;
 
-  std::unique_ptr<Ort::Session> encoder_sess_;
-  std::unique_ptr<Ort::Session> decoder_sess_;
-  std::unique_ptr<Ort::Session> joiner_sess_;
+  // 非拥有包装：session 由共享 env 创建，原始指针在此析构时显式释放。
+  Ort::UnownedSession encoder_sess_;
+  Ort::UnownedSession decoder_sess_;
+  Ort::UnownedSession joiner_sess_;
 
   std::vector<std::string> encoder_input_names_;
   std::vector<std::string> encoder_output_names_;

--- a/app/src/main/jni/onnx_env.cc
+++ b/app/src/main/jni/onnx_env.cc
@@ -8,8 +8,8 @@ static std::mutex g_env_mutex;
 static bool g_env_created = false;
 static OrtThreadingOptions* g_threading_options = nullptr;
 
-// 共享 intra-op 线程池：所有 ONNX 模型（联想/标点/手写）共用一个 env，
-// 因此共用一个线程池，避免每个 session 各自创建线程导致资源/内存浪费。
+// 共享 intra-op 线程池：所有 ONNX 模型（联想/标点/手写/离线语音 ASR）共用一个
+// env，因此共用一个线程池，避免每个 session 各自创建线程导致资源/内存浪费。
 #define ONNX_INTRA_OP_THREADS 2
 
 #define LOG_TAG "OnnxEnv"


### PR DESCRIPTION
移除了StreamingRecognizer构造函数中的num_threads参数，改用共享的
ONNX运行时环境来减少线程池开销。将Session管理从独占改为非拥有包装，
并添加了析构函数确保资源正确释放。

perf(asr): 减少ASR模型待机时的CPU占用和发热

通过复用全局共享的ONNX运行时环境的线程池，避免每个session单独创建
线程池。之前3个session每个多分配4个线程共12个常驻线程，在模型驻留
期间导致待机发热问题得到解决。

docs(ui): 在本地模型页面添加使用提示

在ModelLocalScreen中添加信息提示框，提醒用户使用本地模型会占用CPU、
增加耗电并可能导致手机发热的问题。

chore(deps): 更新rime子模块依赖版本

## 概述

简要描述此 PR 的目的和改动内容。

## 关联 Issue

Closes #（填写关联 issue 号）

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] CI / 构建
- [ ] 文档

## 自测清单

- [x] 代码编译通过
- [x] 已运行 `./gradlew test` 并通过
- [x] 已在真机/模拟器上验证

## 备注

补充说明（如有）。
